### PR TITLE
CircleCI support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+compile:
+  override:
+    - gradle jar javadoc
+
+test:
+  override:
+    - gradle test
+  post:
+    - cp -r build/libs $CIRCLE_ARTIFACTS


### PR DESCRIPTION
This commit is dependent on https://github.com/opendatakit/javarosa/pull/7, so please review that first. 

CircleCI has a bootstrapping problem. It can't test branches until a circle.yml file is in master so I can't test this on a branch until this is checked in. I've given it a good first effort and once it's in master, we can iterate on a branch to fix any mistakes.