### PR TITLE
Cleaner syntax, upgrade buildconfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,26 @@
-apply plugin: 'java'
+plugins {
+    id 'java'
+}
 
 repositories {
     mavenCentral()
 }
 
-sourceSets.main.java.srcDirs = ['src']
-sourceSets.test.java.srcDirs = ['test']
-sourceSets.test.resources.srcDirs = ['resources']
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src']
+        }
+    }
+    test {
+        java {
+            srcDirs = ['src']
+        }
+        resources {
+            srcDirs = ['resources']
+        }
+    }
+}
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
@@ -29,7 +43,14 @@ jar {
     }
 }
 
+// Useful for testing
+task explodedJar(type: Copy) {
+    into "$buildDir/libs/$jar.baseName $jar.version"
+    with jar
+}
+
 // TODO: does not build UML diagrams
 javadoc {
     failOnError = false
 }
+

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,6 @@ test:
   override:
     - ./gradlew test javadoc jar
   post:
-    - cp -r build/libs/. $CIRCLE_ARTIFACTS
-
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit
-    - cp -r build/reports/tests/test/. $CIRCLE_TEST_REPORTS/junit
-
-    - mkdir -p $CIRCLE_TEST_REPORTS/javadoc
-    - cp -r build/docs/javadoc/. $CIRCLE_TEST_REPORTS/javadoc
+    - cp -r build/libs $CIRCLE_ARTIFACTS
+    - cp -r build/reports/tests/test $CIRCLE_TEST_REPORTS/junit
+    - cp -r build/docs/javadoc $CIRCLE_TEST_REPORTS

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip


### PR DESCRIPTION
* More consistent syntax
* Include gradle sources for smarter IntelliJ parsing
* Add exploded jar to testing jar composition