### PR TITLE
Match pom.xml to build.gradle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
We use gradle (`build.gradle`) for local builds and maven (`pom.xml`) for the distributed builds. The versions in the backing libraries must match.