### PR TITLE
Auto-release to central after deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <configuration>
            <serverId>ossrh</serverId>
            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-           <autoReleaseAfterClose>false</autoReleaseAfterClose>
+           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This can only be triggered by the person doing the release, so it's not really unsafe.