### PR TITLE
#64 The `round(num, decimalPlaces)` function doesn't work on locales that use comma as the decimal separator.

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
@@ -1045,7 +1046,10 @@ public class XPathFuncExpr extends XPathExpression {
         }
 
         if (numDecimals >= 0) {
-            final NumberFormat nf = NumberFormat.getNumberInstance();
+            // Some locales use ',' instead of '.' as a decimal separator. Since Double.valueOf
+            // doesn't handle comma as the decimal separator, we must ensure a dot will be used by
+            // forcing the US format locale.
+            final NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
             nf.setMaximumFractionDigits(numDecimals);
             nf.setGroupingUsed(false);
             return Double.valueOf(nf.format(number));

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -19,6 +19,7 @@ package org.javarosa.xpath.test;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -55,6 +56,7 @@ public class XPathEvalTest extends TestCase {
         TestSuite aSuite = new TestSuite();
 
         aSuite.addTest(new XPathEvalTest("doTests"));
+        aSuite.addTest(new XPathEvalTest("doTestsInPolishLocale"));
 
         return aSuite;
     }
@@ -101,6 +103,17 @@ public class XPathEvalTest extends TestCase {
                 fail("Did not get expected exception type");
             }
         }
+    }
+
+    private void doTestsInSpecificLocale(Locale targetLocale) {
+        Locale previous = Locale.getDefault();
+        Locale.setDefault(targetLocale);
+        doTests();
+        Locale.setDefault(previous);
+    }
+
+    public void doTestsInPolishLocale() {
+        doTestsInSpecificLocale(Locale.forLanguageTag("pl"));
     }
 
     public void doTests () {


### PR DESCRIPTION
Fixes #64.