### PR TITLE
Serialize FormIndex

### DIFF
--- a/resources/formindex-serialization.xml
+++ b/resources/formindex-serialization.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+   <h:head>
+      <h:title>FormIndex Serialization</h:title>
+      <model>
+         <instance>
+            <data id="formindex-serialization">
+               <section_1>
+                  <question_1/>
+               </section_1>
+            </data>
+         </instance>
+         <bind nodeset="/data/section_1"/>
+         <bind nodeset="/data/section_1/question_1" type="string"/>
+      </model>
+   </h:head>
+   <h:body>
+      <group nodeset="/data/section_1">
+         <label>Section 1</label>
+         <input ref="/data/section_1/question_1">
+            <label>Question 1</label>
+         </input>
+      </group>
+   </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/FormIndex.java
+++ b/src/org/javarosa/core/model/FormIndex.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.core.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +40,7 @@ import org.javarosa.core.model.instance.TreeReference;
  * @author Clayton Sims
  *
  */
-public class FormIndex {
+public class FormIndex implements Serializable {
 
 	private boolean beginningOfForm = false;
 

--- a/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/org/javarosa/core/model/instance/TreeReference.java
@@ -19,6 +19,7 @@ package org.javarosa.core.model.instance;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +32,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.expr.XPathExpression;
 
-public class TreeReference implements Externalizable {
+public class TreeReference implements Externalizable, Serializable {
 	public static final int DEFAULT_MUTLIPLICITY = 0;//multiplicity
 	public static final int INDEX_UNBOUND = -1;//multiplicity
 	public static final int INDEX_TEMPLATE = -2;//multiplicity

--- a/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -6,6 +6,7 @@ package org.javarosa.core.model.instance;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 
 import org.javarosa.core.util.ArrayUtilities;
@@ -21,7 +22,7 @@ import org.javarosa.xpath.expr.XPathExpression;
  * @author ctsims
  *
  */
-public class TreeReferenceLevel implements Externalizable {
+public class TreeReferenceLevel implements Externalizable, Serializable {
 	public static final int MULT_UNINIT = -16;
 	
 	private String name;

--- a/src/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/org/javarosa/xpath/expr/XPathExpression.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.xpath.expr;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.util.externalizable.Externalizable;
 
-public abstract class XPathExpression implements Externalizable {
+public abstract class XPathExpression implements Externalizable, Serializable {
 
 	public Object eval (EvaluationContext evalContext) {
 		return this.eval(evalContext.getMainInstance(), evalContext);

--- a/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
+++ b/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
@@ -1,0 +1,94 @@
+package org.javarosa.core.model.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.file.Paths;
+
+import org.javarosa.core.PathConst;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FormIndexSerializationTest {	
+
+	@Test
+	public void testBeginningOfForm() throws IOException, ClassNotFoundException {
+		FormIndex formIndexToSerialize = FormIndex.createBeginningOfFormIndex();
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+
+	@Test
+	public void testEndOfForm() throws IOException, ClassNotFoundException {
+		FormIndex formIndexToSerialize = FormIndex.createEndOfFormIndex();
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+	
+	@Test
+	public void testLocalAndInstanceNullReference() throws IOException, ClassNotFoundException {
+		FormIndex formIndexToSerialize = new FormIndex(1, 2, null);
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+
+	@Test
+	public void testLocalAndInstanceNonNullReference() throws IOException, ClassNotFoundException {
+		TreeReference treeReference = TreeReference.rootRef();
+		FormIndex formIndexToSerialize = new FormIndex(1, 2, treeReference);
+		byte[] serializedObject = serializeObject(formIndexToSerialize);
+		FormIndex formIndexDeserialized = deserializeFormIndex(serializedObject);
+		assertFormIndex(formIndexToSerialize, formIndexDeserialized);
+	}
+
+	@Test
+	public void testOnFormController() throws IOException, ClassNotFoundException {
+		FormParseInit formParseInit = new FormParseInit();
+		formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "formindex-serialization.xml").toString());
+		FormEntryController formEntryController = formParseInit.getFormEntryController();
+		
+		FormIndex formIndex = formEntryController.getModel().getFormIndex();
+		assertFormIndex(formIndex, deserializeFormIndex(serializeObject(formIndex)));
+		
+		do {
+			formIndex = formEntryController.getModel().incrementIndex(formIndex);
+			assertFormIndex(formIndex, deserializeFormIndex(serializeObject(formIndex)));		
+		} while (!formIndex.isEndOfFormIndex());
+	}
+
+	// helper methods -->
+
+	private static byte[] serializeObject(Serializable serializable)
+			throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(serializable);
+		oos.close();
+		return baos.toByteArray();
+	}
+
+	private static FormIndex deserializeFormIndex(byte[] serializedFormIndex) 
+			throws IOException, ClassNotFoundException {
+		ByteArrayInputStream bais = new ByteArrayInputStream(serializedFormIndex);
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Object o = ois.readObject();
+		return (FormIndex) o;
+	}
+
+	// Fails if expected FormIndex is not equal to actual FormIndex.
+	private static void assertFormIndex(FormIndex expected, FormIndex actual) {
+		assertEquals(expected, actual);
+		assertEquals(expected.getReference(), actual.getReference());
+	}
+}


### PR DESCRIPTION
These changes makes FormIndex serializable.

It is useful for example in case when there is need to store it in Android's Bundle object.

I've also includued tests to cover FormIndex serialization. 