### PR TITLE
TreeElement#populate now handles leafs attributes.

### DIFF
--- a/resources/populate-nodes-attributes-instance.xml
+++ b/resources/populate-nodes-attributes-instance.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' ?>
+<data id="populate-nodes-attributes" xmlns:cns="custom_name_space">
+    <free_text_1 custom_attr_1="xyz1">Abc</free_text_1>
+    <regular_group cns:custom_attr_1="xyz2">
+        <free_text_2 custom_attr_2="xyz3">Abc2</free_text_2>
+    </regular_group>
+</data>

--- a/resources/populate-nodes-attributes.xml
+++ b/resources/populate-nodes-attributes.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>populate nodes attributes test</h:title>
+        <model>
+            <instance>
+                <data id="populate-nodes-attributes">
+                    <free_text_1/>
+                    <regular_group>
+                        <free_text_2/>
+                    </regular_group>
+                </data>
+            </instance>
+            <bind nodeset="/data/free_text_1" type="string"/>
+            <bind nodeset="/data/regular_group"/>
+            <bind nodeset="/data/regular_group/free_text_2" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/free_text_1">
+            <label>free text 1</label>
+        </input>
+        <group nodeset="/data/regular_group">
+            <label>regular group</label>
+            <input ref="/data/regular_group/free_text_2">
+                <label>free text 2</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -1036,13 +1036,14 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 					}
 				}
 			}
-			for (int i = 0; i < incoming.getAttributeCount(); i++) {
-				String name = incoming.getAttributeName(i);
-				String ns = incoming.getAttributeNamespace(i);
-				String value = incoming.getAttributeValue(i);
+		}
 
-				this.setAttribute(ns, name, value);
-			}
+		for (int i = 0; i < incoming.getAttributeCount(); i++) {
+			String name = incoming.getAttributeName(i);
+			String ns = incoming.getAttributeNamespace(i);
+			String value = incoming.getAttributeValue(i);
+
+			this.setAttribute(ns, name, value);
 		}
 	}
 

--- a/test/org/javarosa/core/model/instance/test/TreeElementTests.java
+++ b/test/org/javarosa/core/model/instance/test/TreeElementTests.java
@@ -1,0 +1,79 @@
+package org.javarosa.core.model.instance.test;
+
+
+import org.javarosa.core.PathConst;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TreeElementTests {
+
+    @Test
+    public void testPopulate_withNodesAttributes() {
+        // Given
+        FormParseInit formParseInit = new FormParseInit();
+        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(),
+                "populate-nodes-attributes.xml").toString());
+
+        FormEntryController formEntryController = formParseInit.getFormEntryController();
+
+        byte[] formInstanceAsBytes = null;
+        try {
+            formInstanceAsBytes =
+                    Files.readAllBytes(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(),
+                            "populate-nodes-attributes-instance.xml"));
+        } catch (IOException e) {
+            fail("There was a problem with reading the test data.\n" + e.getMessage());
+        }
+        TreeElement savedRoot = XFormParser.restoreDataModel(formInstanceAsBytes, null).getRoot();
+        FormDef formDef = formEntryController.getModel().getForm();
+        TreeElement dataRootNode = formDef.getInstance().getRoot().deepCopy(true);
+
+        // When
+        dataRootNode.populate(savedRoot, formDef);
+
+        // Then
+        assertEquals(2, dataRootNode.getNumChildren());
+        TreeElement freeText1Question = dataRootNode.getChildAt(0);
+        TreeElement regularGroup = dataRootNode.getChildAt(1);
+
+        assertEquals(1, regularGroup.getNumChildren());
+        TreeElement freeText2Question = regularGroup.getChildAt(0);
+
+        assertEquals("free_text_1", freeText1Question.getName());
+        assertEquals(1, freeText1Question.getAttributeCount());
+        TreeElement customAttr1 = freeText1Question.getAttribute(null, "custom_attr_1");
+        assertNotNull(customAttr1);
+        assertEquals("custom_attr_1", customAttr1.getName());
+        assertEquals("", customAttr1.getNamespace());
+        assertEquals("xyz1", customAttr1.getAttributeValue());
+
+        assertEquals("regular_group", regularGroup.getName());
+        assertEquals(1, regularGroup.getAttributeCount());
+        customAttr1 = regularGroup.getAttribute(null, "custom_attr_1");
+        assertNotNull(customAttr1);
+        assertEquals("custom_attr_1", customAttr1.getName());
+        assertEquals("custom_name_space", customAttr1.getNamespace());
+        assertEquals("xyz2", customAttr1.getAttributeValue());
+
+        assertEquals("free_text_2", freeText2Question.getName());
+        assertEquals(1, freeText1Question.getAttributeCount());
+        TreeElement customAttr2 = freeText2Question.getAttribute(null, "custom_attr_2");
+        assertNotNull(customAttr2);
+        assertEquals("custom_attr_2", customAttr2.getName());
+        assertEquals("", customAttr2.getNamespace());
+        assertEquals("xyz3", customAttr2.getAttributeValue());
+    }
+
+}


### PR DESCRIPTION
TreeElement#populate method was completely ignoring leafs attributes. This fix just takes the code responsible for populating attributes out from the if-else block so it runs for all kind of nodes.

XML attributes come in handy when there is a need to maintain a metadata in form instances.

Added a simple unit test that covers this changes.