### PR TITLE
Issue 60: Allow http://openrosa.org/xforms namespace for meta

### DIFF
--- a/resources/meta-namespace-form.xml
+++ b/resources/meta-namespace-form.xml
@@ -1,0 +1,17 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms">
+  <h:head>
+    <h:title>Audit test ORX</h:title>
+    <model>
+      <instance>
+        <data id="audit-test-orx">
+          <orx:meta>
+            <orx:audit/>
+          </orx:meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/orx:meta/orx:audit" type="binary"/>
+    </model>
+  </h:head>
+  <h:body>
+  </h:body>
+</h:html>

--- a/resources/meta-namespace-form.xml
+++ b/resources/meta-namespace-form.xml
@@ -1,17 +1,20 @@
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
-        xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms">
+        xmlns:orx2="http://openrosa.org/xforms">
     <h:head>
         <h:title>Namespace for Metadata</h:title>
         <model>
             <instance>
-                <data id="audit-test-orx">
-                    <orx:meta>
-                        <orx:audit/>
-                    </orx:meta>
+                <data id="test">
+                    <orx2:meta>
+                        <orx2:audit/>
+                        <orx2:audit2/>
+                        <audit3/>
+                    </orx2:meta>
                 </data>
             </instance>
-            <bind nodeset="/data/orx:meta/orx:audit" type="binary"/>
+            <bind nodeset="/data/orx2:meta/orx2:audit"/>
+            <bind nodeset="/data/meta/audit2"/>
+            <bind nodeset="/data/orx2:meta/audit3"/>
         </model>
     </h:head>
     <h:body>

--- a/resources/meta-namespace-form.xml
+++ b/resources/meta-namespace-form.xml
@@ -1,17 +1,19 @@
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms">
-  <h:head>
-    <h:title>Audit test ORX</h:title>
-    <model>
-      <instance>
-        <data id="audit-test-orx">
-          <orx:meta>
-            <orx:audit/>
-          </orx:meta>
-        </data>
-      </instance>
-      <bind nodeset="/data/orx:meta/orx:audit" type="binary"/>
-    </model>
-  </h:head>
-  <h:body>
-  </h:body>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms">
+    <h:head>
+        <h:title>Namespace for Metadata</h:title>
+        <model>
+            <instance>
+                <data id="audit-test-orx">
+                    <orx:meta>
+                        <orx:audit/>
+                    </orx:meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/orx:meta/orx:audit" type="binary"/>
+        </model>
+    </h:head>
+    <h:body>
+    </h:body>
 </h:html>

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
@@ -108,10 +107,9 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 	private int flags = MASK_RELEVANT | MASK_ENABLED | MASK_RELEVANT_INH | MASK_ENABLED_INH;
 
 	private String namespace;
+	private String namespacePrefix;
 
 	private String instanceName = null;
-
-    private Map<String, String> namespacePrefixesByUri;
 
 	/**
 	 * TreeElement with null name and 0 multiplicity? (a "hidden root" node?)
@@ -1407,16 +1405,11 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 		return selectedChildren;
 	}
 
-    /**
-     * Returns a map of namespace prefixes, keyed by namespace URI, pulled from the html element.
-     * These are needed because JavaRosa doesn’t otherwise preserve prefixes (such as in orx:meta).
-     * Will be null except for the root of the instance.
-     */
-    public Map<String, String> getNamespacePrefixesByUri() {
-        return namespacePrefixesByUri;
-    }
+	public String getNamespacePrefix() {
+		return namespacePrefix;
+	}
 
-    public void setNamespacePrefixesByUri(Map<String, String> namespacePrefixesByURI) {
-        this.namespacePrefixesByUri = namespacePrefixesByURI;
-    }
+	public void setNamespacePrefix(String namespacePrefix) {
+		this.namespacePrefix = namespacePrefix;
+	}
 }

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -19,8 +19,10 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
@@ -35,6 +37,7 @@ import org.javarosa.core.model.instance.utils.CompactInstanceWrapper;
 import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
 import org.javarosa.core.model.instance.utils.IAnswerResolver;
 import org.javarosa.core.model.instance.utils.ITreeVisitor;
+import org.javarosa.core.model.instance.utils.TreeElementNameComparator;
 import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -107,6 +110,8 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 	private String namespace;
 
 	private String instanceName = null;
+
+    private Map<String, String> namespacePrefixesByUri;
 
 	/**
 	 * TreeElement with null name and 0 multiplicity? (a "hidden root" node?)
@@ -274,12 +279,12 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 
     private List<TreeElement> getChildrenWithName(String name, boolean includeTemplate) {
         if (children == null) {
-            return new ArrayList<>(0);
+            return Collections.emptyList();
         }
 
         List<TreeElement> v = new ArrayList<>();
-        for (TreeElement child : this.children) {
-            if ((child.getName().equals(name) || name.equals(TreeReference.NAME_WILDCARD))
+        for (TreeElement child : children) {
+            if (TreeElementNameComparator.elementMatchesName(child, name)
                     && (includeTemplate || child.multiplicity != TreeReference.INDEX_TEMPLATE))
                 v.add(child);
         }
@@ -1402,4 +1407,16 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 		return selectedChildren;
 	}
 
+    /**
+     * Returns a map of namespace prefixes, keyed by namespace URI, pulled from the html element.
+     * These are needed because JavaRosa doesn’t otherwise preserve prefixes (such as in orx:meta).
+     * Will be null except for the root of the instance.
+     */
+    public Map<String, String> getNamespacePrefixesByUri() {
+        return namespacePrefixesByUri;
+    }
+
+    public void setNamespacePrefixesByUri(Map<String, String> namespacePrefixesByURI) {
+        this.namespacePrefixesByUri = namespacePrefixesByURI;
+    }
 }

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -272,19 +272,20 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 		return getChildrenWithName(name, false);
 	}
 
-	private List<TreeElement> getChildrenWithName(String name, boolean includeTemplate) {
-		if(children == null) { return new ArrayList<TreeElement>(0);}
+    private List<TreeElement> getChildrenWithName(String name, boolean includeTemplate) {
+        if (children == null) {
+            return new ArrayList<>(0);
+        }
 
-      List<TreeElement> v = new ArrayList<TreeElement>();
-		for (int i = 0; i < this.children.size(); i++) {
-			TreeElement child = this.children.get(i);
-			if ((child.getName().equals(name) || name.equals(TreeReference.NAME_WILDCARD))
-					&& (includeTemplate || child.multiplicity != TreeReference.INDEX_TEMPLATE))
-				v.add(child);
-		}
+        List<TreeElement> v = new ArrayList<>();
+        for (TreeElement child : this.children) {
+            if ((child.getName().equals(name) || name.equals(TreeReference.NAME_WILDCARD))
+                    && (includeTemplate || child.multiplicity != TreeReference.INDEX_TEMPLATE))
+                v.add(child);
+        }
 
-		return v;
-	}
+        return v;
+    }
 
 	/* (non-Javadoc)
 	 * @see org.javarosa.core.model.instance.AbstractTreeElement#getNumChildren()

--- a/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
+++ b/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
@@ -6,6 +6,8 @@ import org.javarosa.core.model.instance.TreeReference;
 
 import java.util.Map;
 
+import static java.lang.System.out;
+
 /** Supports locating {@link TreeElement}s by name. */
 public class TreeElementNameComparator {
 
@@ -20,26 +22,37 @@ public class TreeElementNameComparator {
      * @return whether treeElement matches name
      */
     public static boolean elementMatchesName(TreeElement treeElement, String name) {
+        final String namespace = treeElement.getNamespace();
+        final Map<String, String> namespacesMap = findNamespacesMap(treeElement);
+        final String prefix =
+            (namespacesMap != null && namespacesMap.containsKey(namespace)) ?
+            " " + namespacesMap.get(namespace) : "";
+        final String nsMsg = namespace == null ? "" : " in " + namespace + prefix;
+        // Todo remove the logging after development is finished
+        out.println("comparing " + treeElement.getName() + nsMsg + " with " + name);
+
         if (name.equals(TreeReference.NAME_WILDCARD)) {
+            out.println("Match");
             return true;
         }
 
         final String elementName = treeElement.getName();
 
         if (elementName.equals(name)) {
+            out.println("Match");
             return true;
         }
 
-        final String namespace = treeElement.getNamespace();
-        final Map<String, String> namespacesMap = findNamespacesMap(treeElement);
 
         if (namespace != null && namespacesMap != null) {
             String namespacePrefix = namespacesMap.get(namespace);
             if (namespacePrefix != null && (namespacePrefix + ":" + elementName).equals(name)) {
+                out.println("Match");
                 return true;
             }
         }
 
+        out.println("No match");
         return false;
     }
 

--- a/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
+++ b/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
@@ -1,10 +1,7 @@
 package org.javarosa.core.model.instance.utils;
 
-import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-
-import java.util.Map;
 
 import static java.lang.System.out;
 
@@ -23,11 +20,8 @@ public class TreeElementNameComparator {
      */
     public static boolean elementMatchesName(TreeElement treeElement, String name) {
         final String namespace = treeElement.getNamespace();
-        final Map<String, String> namespacesMap = findNamespacesMap(treeElement);
-        final String prefix =
-            (namespacesMap != null && namespacesMap.containsKey(namespace)) ?
-            " " + namespacesMap.get(namespace) : "";
-        final String nsMsg = namespace == null ? "" : " in " + namespace + prefix;
+        final String namespacePrefix = treeElement.getNamespacePrefix();
+        final String nsMsg = namespace != null && namespacePrefix !=  null ? " in " + namespace + namespacePrefix : "";
         // Todo remove the logging after development is finished
         out.println("comparing " + treeElement.getName() + nsMsg + " with " + name);
 
@@ -44,34 +38,13 @@ public class TreeElementNameComparator {
         }
 
 
-        if (namespace != null && namespacesMap != null) {
-            String namespacePrefix = namespacesMap.get(namespace);
-            if (namespacePrefix != null && (namespacePrefix + ":" + elementName).equals(name)) {
-                out.println("Match");
-                return true;
-            }
+        if (namespace != null && namespacePrefix != null && (namespacePrefix + ":" + elementName).equals(name)) {
+            out.println("Match");
+            return true;
         }
 
         out.println("No match");
         return false;
     }
 
-    /**
-     * Searches treeElement (and its parents if necessary) to find the namespaces map. The map is
-     * stored in the root element of the instance.
-     *
-     * @param treeElement the element at which to start looking for the namespaces map.
-     * @return the map, if found, else null
-     */
-    private static Map<String, String> findNamespacesMap(TreeElement treeElement) {
-        final Map<String, String> map = treeElement.getNamespacePrefixesByUri();
-        if (map != null) {
-            return map;
-        }
-        final AbstractTreeElement parent = treeElement.getParent();
-        if (parent instanceof TreeElement) {
-            return findNamespacesMap((TreeElement) parent);
-        }
-        return null;
-    }
 }

--- a/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
+++ b/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
@@ -1,0 +1,64 @@
+package org.javarosa.core.model.instance.utils;
+
+import org.javarosa.core.model.instance.AbstractTreeElement;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+
+import java.util.Map;
+
+/** Supports locating {@link TreeElement}s by name. */
+public class TreeElementNameComparator {
+
+    /**
+     * Determines whether treeElement matches name. If name is a wildcard, it does. If the element’s
+     * name matches name (using equals), it does. If neither of those cases are true, a namespace
+     * prefix for treeElement, if one can be located, is prepended to treeElement’s name, and that is
+     * compared to name with equals.
+     *
+     * @param treeElement the TreeElement under examination
+     * @param name        the name to be compared with treeElement’s name
+     * @return whether treeElement matches name
+     */
+    public static boolean elementMatchesName(TreeElement treeElement, String name) {
+	    if (name.equals(TreeReference.NAME_WILDCARD)) {
+	        return true;
+        }
+
+        final String elementName = treeElement.getName();
+
+	    if (elementName.equals(name)) {
+	        return true;
+        }
+
+        final String namespace = treeElement.getNamespace();
+        final Map<String, String> namespacesMap = findNamespacesMap(treeElement);
+
+        if (namespace != null && namespacesMap != null) {
+            String namespacePrefix = namespacesMap.get(namespace);
+            if (namespacePrefix != null && (namespacePrefix + ":" + elementName).equals(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Searches treeElement (and its parents if necessary) to find the namespaces map. The map is
+     * stored in the root element of the instance.
+     *
+     * @param treeElement the element at which to start looking for the namespaces map.
+     * @return the map, if found, else null
+     */
+    private static Map<String, String> findNamespacesMap(TreeElement treeElement) {
+        final Map<String, String> map = treeElement.getNamespacePrefixesByUri();
+        if (map != null) {
+            return map;
+        }
+        final AbstractTreeElement parent = treeElement.getParent();
+        if (parent instanceof TreeElement) {
+            return findNamespacesMap((TreeElement) parent);
+        }
+        return null;
+    }
+}

--- a/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
+++ b/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
@@ -20,14 +20,14 @@ public class TreeElementNameComparator {
      * @return whether treeElement matches name
      */
     public static boolean elementMatchesName(TreeElement treeElement, String name) {
-	    if (name.equals(TreeReference.NAME_WILDCARD)) {
-	        return true;
+        if (name.equals(TreeReference.NAME_WILDCARD)) {
+            return true;
         }
 
         final String elementName = treeElement.getName();
 
-	    if (elementName.equals(name)) {
-	        return true;
+        if (elementName.equals(name)) {
+            return true;
         }
 
         final String namespace = treeElement.getNamespace();

--- a/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
+++ b/src/org/javarosa/core/model/instance/utils/TreeElementNameComparator.java
@@ -3,7 +3,6 @@ package org.javarosa.core.model.instance.utils;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 
-import static java.lang.System.out;
 
 /** Supports locating {@link TreeElement}s by name. */
 public class TreeElementNameComparator {
@@ -19,32 +18,16 @@ public class TreeElementNameComparator {
      * @return whether treeElement matches name
      */
     public static boolean elementMatchesName(TreeElement treeElement, String name) {
-        final String namespace = treeElement.getNamespace();
         final String namespacePrefix = treeElement.getNamespacePrefix();
-        final String nsMsg = namespace != null && namespacePrefix !=  null ? " in " + namespace + namespacePrefix : "";
-        // Todo remove the logging after development is finished
-        out.println("comparing " + treeElement.getName() + nsMsg + " with " + name);
 
         if (name.equals(TreeReference.NAME_WILDCARD)) {
-            out.println("Match");
             return true;
         }
 
         final String elementName = treeElement.getName();
 
-        if (elementName.equals(name)) {
-            out.println("Match");
-            return true;
-        }
-
-
-        if (namespace != null && namespacePrefix != null && (namespacePrefix + ":" + elementName).equals(name)) {
-            out.println("Match");
-            return true;
-        }
-
-        out.println("No match");
-        return false;
+        return elementName.equals(name) ||
+                (namespacePrefix != null && (namespacePrefix + ":" + elementName).equals(name));
     }
 
 }

--- a/src/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/org/javarosa/xform/parse/FormInstanceParser.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.javarosa.xform.parse.XFormParser.buildInstanceStructure;
 import static org.javarosa.xform.parse.XFormParser.getVagueLocation;
@@ -53,8 +54,9 @@ class FormInstanceParser {
         this.actionTargets = actionTargets;
     }
 
-    FormInstance parseInstance(Element e, boolean isMainInstance, String name) {
+    FormInstance parseInstance(Element e, boolean isMainInstance, String name, Map<String, String> namespacePrefixesByUri) {
         TreeElement root = buildInstanceStructure(e, null, !isMainInstance ? name : null, e.getNamespace());
+        root.setNamespacePrefixesByUri(namespacePrefixesByUri);
         FormInstance instanceModel = new FormInstance(root);
         instanceModel.setName(isMainInstance ? formDef.getTitle() : name);
 

--- a/src/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/org/javarosa/xform/parse/FormInstanceParser.java
@@ -55,8 +55,7 @@ class FormInstanceParser {
     }
 
     FormInstance parseInstance(Element e, boolean isMainInstance, String name, Map<String, String> namespacePrefixesByUri) {
-        TreeElement root = buildInstanceStructure(e, null, !isMainInstance ? name : null, e.getNamespace());
-        root.setNamespacePrefixesByUri(namespacePrefixesByUri);
+        TreeElement root = buildInstanceStructure(e, null, !isMainInstance ? name : null, e.getNamespace(), namespacePrefixesByUri);
         FormInstance instanceModel = new FormInstance(root);
         instanceModel.setName(isMainInstance ? formDef.getTitle() : name);
 

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -334,15 +334,10 @@ public class XFormParser implements IXFormParserFunctions {
     private Map<String, String> buildNamespacesMap() {
         final Map<String, String> namespacePrefixesByURI = new HashMap<>();
 
-        for (int i = 0; i < _xmldoc.getChildCount(); i++) {
-            Object firstChild = _xmldoc.getChild(0);
-            if (firstChild instanceof Element) {
-                Element el = (Element) firstChild;
-                if (el.getName().equals("html")) {
-                    for (int j = 0; j < el.getNamespaceCount(); j++) {
-                        namespacePrefixesByURI.put(el.getNamespaceUri(j), el.getNamespacePrefix(j));
-                    }
-                }
+        Element el = _xmldoc.getRootElement();
+        if (el.getName().equals("html")) {
+            for (int i = 0; i < el.getNamespaceCount(); i++) {
+                namespacePrefixesByURI.put(el.getNamespaceUri(i), el.getNamespacePrefix(i));
             }
         }
 

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -328,7 +328,7 @@ public class XFormParser implements IXFormParserFunctions {
         return _f;
     }
 
-    /** Extracts the namespaces from the element, if present, and creates a map of URI to prefix */
+    /** Extracts the namespaces from the given element and creates a map of URI to prefix */
     private static Map<String, String> buildNamespacesMap(Element el) {
         final Map<String, String> namespacePrefixesByURI = new HashMap<>();
 

--- a/test/org/javarosa/xform/parse/TreeElementNameComparatorTest.java
+++ b/test/org/javarosa/xform/parse/TreeElementNameComparatorTest.java
@@ -3,8 +3,6 @@ package org.javarosa.xform.parse;
 import org.javarosa.core.model.instance.TreeElement;
 import org.junit.Test;
 
-import java.util.HashMap;
-
 import static org.javarosa.core.model.instance.utils.TreeElementNameComparator.elementMatchesName;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +55,7 @@ public class TreeElementNameComparatorTest {
         TreeElement te = new TreeElement(name);
         if (namespace != null && prefix != null) {
             te.setNamespace(namespace);
-            te.setNamespacePrefixesByUri(new HashMap<String, String>() {{ put(namespace, prefix); }});
+            te.setNamespacePrefix(prefix);
         }
         return te;
     }

--- a/test/org/javarosa/xform/parse/TreeElementNameComparatorTest.java
+++ b/test/org/javarosa/xform/parse/TreeElementNameComparatorTest.java
@@ -1,0 +1,64 @@
+package org.javarosa.xform.parse;
+
+import org.javarosa.core.model.instance.TreeElement;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.javarosa.core.model.instance.utils.TreeElementNameComparator.elementMatchesName;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TreeElementNameComparatorTest {
+
+    private static final String NS_ORX = "http://openrosa.org/xforms";
+    private static final String PREFIX_ORX = "orx";
+
+    @Test public void wildcardMatches() {
+        assertTrue(elementMatchesName(new TreeElement("a"), "*"));
+    }
+
+    @Test public void simpleMatches() {
+        assertTrue(elementMatchesName(new TreeElement("a"), "a"));
+    }
+
+    @Test public void simpleMisMatches() {
+        assertFalse(elementMatchesName(new TreeElement("a"), "b"));
+    }
+
+    @Test public void explicitMatches() {
+        assertTrue(elementMatchesName(createTreeElement("a", NS_ORX, PREFIX_ORX), "orx:a"));
+    }
+
+    @Test public void explicitMismatchesName() {
+        assertFalse(elementMatchesName(createTreeElement("a", NS_ORX, PREFIX_ORX), "orx:b"));
+    }
+
+    @Test public void explicitMismatchesPrefix() {
+        assertFalse(elementMatchesName(createTreeElement("a", NS_ORX, PREFIX_ORX), "orx2:b"));
+    }
+
+    @Test public void explicitMismatchesNoNsElement() {
+        assertFalse(elementMatchesName(new TreeElement("a"), "orx:a"));
+    }
+
+    /**
+     * Creates a TreeElement for testing.
+     * <p>
+     * JavaRosa creates TreeElements that don’t contain prefixes. Rather, they have the namespace
+     * associated with the prefix.
+     *
+     * @param name the name of the element, without any prefix
+     * @param namespace the namespace, e.g., http://openrosa.org/xforms, or null
+     * @param prefix the prefix we are pretending has been associated with namespace, or null
+     * @return a TreeElement
+     */
+    private TreeElement createTreeElement(String name, final String namespace, final String prefix) {
+        TreeElement te = new TreeElement(name);
+        if (namespace != null && prefix != null) {
+            te.setNamespace(namespace);
+            te.setNamespacePrefixesByUri(new HashMap<String, String>() {{ put(namespace, prefix); }});
+        }
+        return te;
+    }
+}

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -43,7 +43,7 @@ public class XFormParserTest {
     @Test
     public void parsesMetaNamespaceForm() throws IOException {
         FormDef formDef = parse("meta-namespace-form.xml");
-        assertEquals(formDef.getTitle(), "Simple Form");
+        assertEquals(formDef.getTitle(), "Namespace for Metadata");
     }
 
     private FormDef parse(String formName) throws IOException {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -40,6 +40,12 @@ public class XFormParserTest {
         parse("bad-range-form.xml");
     }
 
+    @Test
+    public void parsesMetaNamespaceForm() throws IOException {
+        FormDef formDef = parse("meta-namespace-form.xml");
+        assertEquals(formDef.getTitle(), "Simple Form");
+    }
+
     private FormDef parse(String formName) throws IOException {
         XFormParser parser = new XFormParser(new FileReader("resources/" + formName));
         return parser.parse();

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.javarosa.core.model.Constants.CONTROL_RANGE;
 import static org.junit.Assert.assertEquals;
@@ -13,13 +15,13 @@ import static org.junit.Assert.assertEquals;
 public class XFormParserTest {
     @Test
     public void parsesSimpleForm() throws IOException {
-        FormDef formDef = parse("simple-form.xml");
+        FormDef formDef = parse("simple-form.xml").formDef;
         assertEquals(formDef.getTitle(), "Simple Form");
     }
 
     @Test
     public void parsesForm2() throws IOException {
-        FormDef formDef = parse("form2.xml");
+        FormDef formDef = parse("form2.xml").formDef;
         assertEquals("My Survey", formDef.getTitle());
         assertEquals(3, formDef.getChildren().size());
         assertEquals("What is your first name?", formDef.getChild(0).getLabelInnerText());
@@ -27,7 +29,7 @@ public class XFormParserTest {
 
     @Test
     public void parsesRangeForm() throws IOException {
-        FormDef formDef = parse("range-form.xml");
+        FormDef formDef = parse("range-form.xml").formDef;
         RangeQuestion question = (RangeQuestion) formDef.getChild(0);
         assertEquals(CONTROL_RANGE, question.getControlType());
         assertEquals(-2.0d, question.getRangeStart().doubleValue(), 0);
@@ -42,12 +44,37 @@ public class XFormParserTest {
 
     @Test
     public void parsesMetaNamespaceForm() throws IOException {
-        FormDef formDef = parse("meta-namespace-form.xml");
-        assertEquals(formDef.getTitle(), "Namespace for Metadata");
+        ParseResult parseResult = parse("meta-namespace-form.xml");
+        assertEquals(parseResult.formDef.getTitle(), "Namespace for Metadata");
+        assertEquals("Number of error messages", 0, parseResult.errorMessages.size());
     }
 
-    private FormDef parse(String formName) throws IOException {
+    private ParseResult parse(String formName) throws IOException {
         XFormParser parser = new XFormParser(new FileReader("resources/" + formName));
-        return parser.parse();
+        final List<String> errorMessages = new ArrayList<>();
+        parser.reporter = new XFormParserReporter() {
+            @Override
+            public void warning(String type, String message, String xmlLocation) {
+                errorMessages.add(message);
+                super.warning(type, message, xmlLocation);
+            }
+
+            @Override
+            public void error(String message) {
+                errorMessages.add(message);
+                super.error(message);
+            }
+        };
+        return new ParseResult(parser.parse(), errorMessages);
+    }
+
+    class ParseResult {
+        final FormDef formDef;
+        final List<String> errorMessages;
+
+        ParseResult(FormDef formDef, List<String> errorMessages) {
+            this.formDef = formDef;
+            this.errorMessages = errorMessages;
+        }
     }
 }

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -2,17 +2,45 @@ package org.javarosa.xform.parse;
 
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.RangeQuestion;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.services.transport.payload.ByteArrayPayload;
+import org.javarosa.model.xform.XFormSerializingVisitor;
+import org.junit.After;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.nio.file.Files.copy;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.javarosa.core.model.Constants.CONTROL_RANGE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class XFormParserTest {
+
+    private static final String FORM_INSTANCE_XML_FILE_NAME = "instance.xml";
+    private static final String AUDIT_NODE = "audit";
+    private static final String AUDIT_ANSWER = "audit111.csv";
+
+    private static final String AUDIT_2_NODE = "audit2";
+    private static final String AUDIT_2_ANSWER = "audit222.csv";
+
+    private static final String AUDIT_3_NODE = "audit3";
+    private static final String AUDIT_3_ANSWER = "audit333.csv";
+
+    @After
+    public void tearDown() throws Exception {
+        new File(FORM_INSTANCE_XML_FILE_NAME).delete();
+    }
+
     @Test
     public void parsesSimpleForm() throws IOException {
         FormDef formDef = parse("simple-form.xml").formDef;
@@ -49,6 +77,50 @@ public class XFormParserTest {
         assertEquals("Number of error messages", 0, parseResult.errorMessages.size());
     }
 
+    @Test
+    public void serializeAndRestoreMetaNamespaceFormInstance() throws IOException {
+        // Given
+        ParseResult parseResult = parse("meta-namespace-form.xml");
+        assertEquals(parseResult.formDef.getTitle(), "Namespace for Metadata");
+        assertEquals("Number of error messages", 0, parseResult.errorMessages.size());
+
+        FormDef formDef = parseResult.formDef;
+        TreeElement audit = findDepthFirst(formDef.getInstance().getRoot(), AUDIT_NODE);
+        TreeElement audit2 = findDepthFirst(formDef.getInstance().getRoot(), AUDIT_2_NODE);
+        TreeElement audit3 = findDepthFirst(formDef.getInstance().getRoot(), AUDIT_3_NODE);
+        assertNotNull(audit);
+        assertNotNull(audit2);
+        assertNotNull(audit3);
+        audit.setAnswer(new StringData(AUDIT_ANSWER));
+        audit2.setAnswer(new StringData(AUDIT_2_ANSWER));
+        audit3.setAnswer(new StringData(AUDIT_3_ANSWER));
+
+        // When
+
+        // serialize the form instance
+        XFormSerializingVisitor serializer = new XFormSerializingVisitor();
+        ByteArrayPayload xml = (ByteArrayPayload) serializer.createSerializedPayload(formDef.getInstance());
+        copy(xml.getPayloadStream(), new File(FORM_INSTANCE_XML_FILE_NAME).toPath(), REPLACE_EXISTING);
+
+        // restore (deserialize) the form instance
+        byte[] formInstanceBytes = readAllBytes(Paths.get(FORM_INSTANCE_XML_FILE_NAME));
+        FormInstance formInstance = XFormParser.restoreDataModel(formInstanceBytes, null);
+
+        // Then
+        audit = findDepthFirst(formInstance.getRoot(), AUDIT_NODE);
+        audit2 = findDepthFirst(formInstance.getRoot(), AUDIT_2_NODE);
+        audit3 = findDepthFirst(formInstance.getRoot(), AUDIT_3_NODE);
+
+        assertNotNull(audit);
+        assertEquals(AUDIT_ANSWER, audit.getValue().getValue());
+
+        assertNotNull(audit2);
+        assertEquals(AUDIT_2_ANSWER, audit2.getValue().getValue());
+
+        assertNotNull(audit3);
+        assertEquals(AUDIT_3_ANSWER, audit3.getValue().getValue());
+    }
+
     private ParseResult parse(String formName) throws IOException {
         XFormParser parser = new XFormParser(new FileReader("resources/" + formName));
         final List<String> errorMessages = new ArrayList<>();
@@ -76,5 +148,21 @@ public class XFormParserTest {
             this.formDef = formDef;
             this.errorMessages = errorMessages;
         }
+    }
+
+    private TreeElement findDepthFirst(TreeElement parent, String name) {
+        int len = parent.getNumChildren();
+        for (int i = 0; i < len; ++i) {
+            TreeElement e = parent.getChildAt(i);
+            if (name.equals(e.getName())) {
+                return e;
+            } else if (e.getNumChildren() != 0) {
+                TreeElement v = findDepthFirst(e, name);
+                if (v != null) {
+                    return v;
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This work is based on #68 but it uses `namespacePrefix` field instead of `namespacePrefixesByURI`. 