### PR TITLE
Specify the gpg binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Deviations from OSSRH's documentation are that maintainers use `gpg2` (and not `
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
-				<gpg.executable>gpg2</gpg.executable>
+				<gpg.executable>/path/to/gpg2</gpg.executable>
 				<gpg.homedir>/path/to/javarosa/gpg/folder</gpg.homedir>
 				<gpg.keyname>1234ABCD</gpg.keyname>
 				<gpg.passphrase>very-secure-passphrase</gpg.passphrase>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I used the command to generate a snapshot on macOS

#### Why is this the best possible solution? Were any other approaches considered?
On macOS, gpg and gpg2 are often aliases and so users should specify the gpg binary they want to use. This subtle change makes that clearer. If you put just gpg or just gpg2, you could be in for a bad time.

#### Are there any risks to merging this code? If so, what are they?
Nope. 