### PR TITLE
Fix ser/deserialization of forms with external data instances

### DIFF
--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -48,6 +48,7 @@ import org.javarosa.core.util.externalizable.ExtWrapList;
 import org.javarosa.core.util.externalizable.ExtWrapListPoly;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.debug.EvaluationResult;
 import org.javarosa.debug.Event;
@@ -1189,7 +1190,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 String.class, SubmissionProfile.class));
 
         formInstances = (HashMap<String, DataInstance>) ExtUtil.read(dis, new ExtWrapMap(
-                String.class, FormInstance.class));
+                String.class, new ExtWrapTagged()), pf);
 
         eventListeners = (HashMap<String, List<Action>>) ExtUtil.read(dis, new ExtWrapMap(
                 String.class, new ExtWrapListPoly()), pf);
@@ -1256,7 +1257,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         // for support of multi-instance forms
 
-        ExtUtil.write(dos, new ExtWrapMap(formInstances));
+        ExtUtil.write(dos, new ExtWrapMap(formInstances, new ExtWrapTagged()));
         ExtUtil.write(dos, new ExtWrapMap(eventListeners, new ExtWrapListPoly()));
         ExtUtil.write(dos, new ExtWrapListPoly(extensions));
     }

--- a/src/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -1,5 +1,8 @@
 package org.javarosa.core.model.instance;
 
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xml.ElementParser;
 import org.javarosa.xml.TreeElementParser;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -7,6 +10,8 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -15,19 +20,33 @@ import java.net.URISyntaxException;
 // This is still a work in progress.
 
 public class ExternalDataInstance extends DataInstance {
+    private String path;
     private TreeElement root;
 
     // todo Make @mdudzinski’s recommended changes from https://github.com/opendatakit/javarosa/pull/154#pullrequestreview-51806826
 
-    public ExternalDataInstance(String path, String instanceId)
-        /* todo implement error handling */ throws IOException, UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException {
+    /** No-args constructor for deserialization */
+    public ExternalDataInstance() {
+    }
+
+    public ExternalDataInstance(String path, String instanceId, TreeElement root) {
         super(instanceId);
+        this.path = path;
         setName(instanceId);
-        String absolutePath = /* ToDo: find out how to get the actual location */
-                System.getProperty("user.dir") + "/resources" + path;
+        this.root = root;
+    }
+
+    public static ExternalDataInstance buildFromPath(String path, String instanceId)
+            throws IOException, UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException {
+        String absolutePath = getPathPrefix() + path;
         KXmlParser xmlParser = ElementParser.instantiateParser(new FileInputStream(absolutePath));
         TreeElementParser treeElementParser = new TreeElementParser(xmlParser, 0, instanceId);
-        root = treeElementParser.parse();
+        TreeElement root = treeElementParser.parse();
+        return new ExternalDataInstance(path, instanceId, root);
+    }
+
+    private static String getPathPrefix() {
+        return System.getProperty("user.dir") + "/resources"; // ToDo find out how to get the actual location
     }
 
     @Override
@@ -44,6 +63,19 @@ public class ExternalDataInstance extends DataInstance {
     public void initialize(InstanceInitializationFactory initializer, String instanceId) {
         throw new RuntimeException("Not implemented");
     }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        super.readExternal(in, pf);
+        path = ExtUtil.readString(in);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+   		super.writeExternal(out);
+   		ExtUtil.write(out, path);
+   	}
 
     /**
      * Returns the path of the URI at srcLocation if the scheme is <code>jr</code> and the host is

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -464,7 +464,7 @@ public class XFormParser implements IXFormParserFunctions {
 
                 if (ediPath != null) {
                     try { /* todo implement better error handling */
-                        _f.addNonMainInstance(new ExternalDataInstance(ediPath, instanceId));
+                        _f.addNonMainInstance(ExternalDataInstance.buildFromPath(ediPath, instanceId));
                     } catch (IOException | UnfullfilledRequirementsException | InvalidStructureException | XmlPullParserException e) {
                         e.printStackTrace();
                     }

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -97,23 +97,27 @@ public class XFormParserTest {
         assertEquals("us_east", dataSetChild.getValue().getDisplayText());
     }
 
-    @Test public void serAndDeserializeMultipleInstancesForm() throws IOException, DeserializationException {
+    @Test public void multipleInstancesFormSavesAndRestores() throws IOException, DeserializationException {
         serAndDeserializeForm("Simpler_Cascading_Select_Form.xml");
     }
 
-    @Test public void serAndDeserializeExternalSecondaryInstanceForm() throws IOException, DeserializationException {
-        // todo test when working
-        if (false) {
-            serAndDeserializeForm(EXTERNAL_SECONDARY_INSTANCE_XML);
-        }
+    @Test public void externalSecondaryInstanceFormSavesAndRestores() throws IOException, DeserializationException {
+        serAndDeserializeForm(EXTERNAL_SECONDARY_INSTANCE_XML);
     }
 
     private void serAndDeserializeForm(String formName) throws IOException, DeserializationException {
         initSerialization();
         FormDef formDef = parse(formName).formDef;
         Path p = Files.createTempFile("serialized-form", null);
-        formDef.writeExternal(new DataOutputStream(Files.newOutputStream(p)));
-        formDef.readExternal(new DataInputStream(Files.newInputStream(p)), defaultPrototypes());
+
+        final DataOutputStream dos = new DataOutputStream(Files.newOutputStream(p));
+        formDef.writeExternal(dos);
+        dos.close();
+
+        final DataInputStream dis = new DataInputStream(Files.newInputStream(p));
+        formDef.readExternal(dis, defaultPrototypes());
+        dis.close();
+
         Files.delete(p);
     }
 
@@ -126,6 +130,7 @@ public class XFormParserTest {
                 "org.javarosa.core.model.QuestionDef",
                 "org.javarosa.core.model.GroupDef",
                 "org.javarosa.core.model.instance.FormInstance",
+                "org.javarosa.core.model.instance.ExternalDataInstance", // Todo export this structure to Collect and remove from there.
                 "org.javarosa.core.model.data.MultiPointerAnswerData",
                 "org.javarosa.core.model.data.PointerAnswerData",
                 "org.javarosa.core.model.data.SelectMultiData",


### PR DESCRIPTION
Fix ser/deserialization of forms with external data instances. Make some of @mdudzinski’s recommended changes from https://github.com/opendatakit/javarosa/pull/154#pullrequestreview-51806826.

#### What has been done to verify that this works as intended?
I have tests for (de)serializing two types of forms with secondary instances.

#### Why is this the best possible solution? Were any other approaches considered?
It’s working more like commcare-core

#### Are there any risks to merging this code? If so, what are they?
Since there are no users of the feature yet, and we aren’t done, I would say no.