### PR TITLE
Expose serializable class names for Collect, so it doesn’t have to copy JavaRosa source

### DIFF
--- a/src/org/javarosa/core/model/CoreModelModule.java
+++ b/src/org/javarosa/core/model/CoreModelModule.java
@@ -23,36 +23,39 @@ import org.javarosa.core.services.storage.StorageManager;
 
 public class CoreModelModule implements IModule {
 
+    public static final String[] classNames = new String[]{
+            "org.javarosa.core.model.SubmissionProfile",
+            "org.javarosa.core.model.FormDef",
+            "org.javarosa.core.model.QuestionDef",
+            "org.javarosa.core.model.GroupDef",
+            "org.javarosa.core.model.instance.FormInstance",
+            "org.javarosa.core.model.instance.ExternalDataInstance",
+            "org.javarosa.core.model.data.BooleanData",
+            "org.javarosa.core.model.data.DateData",
+            "org.javarosa.core.model.data.DateTimeData",
+            "org.javarosa.core.model.data.DecimalData",
+            "org.javarosa.core.model.data.GeoPointData",
+            "org.javarosa.core.model.data.GeoShapeData",
+            "org.javarosa.core.model.data.GeoTraceData",
+            "org.javarosa.core.model.data.IntegerData",
+            "org.javarosa.core.model.data.LongData",
+            "org.javarosa.core.model.data.MultiPointerAnswerData",
+            "org.javarosa.core.model.data.PointerAnswerData",
+            "org.javarosa.core.model.data.SelectMultiData",
+            "org.javarosa.core.model.data.SelectOneData",
+            "org.javarosa.core.model.data.StringData",
+            "org.javarosa.core.model.data.TimeData",
+            "org.javarosa.core.model.data.UncastData",
+            "org.javarosa.core.model.data.helper.BasicDataPointer",
+            "org.javarosa.core.model.Action",
+            "org.javarosa.core.model.actions.SetValueAction"
+    };
+
+    @Override
     public void registerModule() {
         StorageManager.registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         StorageManager.registerStorage(FormInstance.STORAGE_KEY, FormInstance.class);
 
-        String[] classes = {
-                "org.javarosa.core.model.SubmissionProfile",
-                "org.javarosa.core.model.QuestionDef",
-                "org.javarosa.core.model.GroupDef",
-                "org.javarosa.core.model.instance.FormInstance",
-                "org.javarosa.core.model.data.BooleanData",
-                "org.javarosa.core.model.data.DateData",
-                "org.javarosa.core.model.data.DateTimeData",
-                "org.javarosa.core.model.data.DecimalData",
-                "org.javarosa.core.model.data.GeoLineData",
-                "org.javarosa.core.model.data.GeoPointData",
-                "org.javarosa.core.model.data.GeoShapeData",
-                "org.javarosa.core.model.data.IntegerData",
-                "org.javarosa.core.model.data.LongData",
-                "org.javarosa.core.model.data.MultiPointerAnswerData",
-                "org.javarosa.core.model.data.PointerAnswerData",
-                "org.javarosa.core.model.data.SelectMultiData",
-                "org.javarosa.core.model.data.SelectOneData",
-                "org.javarosa.core.model.data.StringData",
-                "org.javarosa.core.model.data.TimeData",
-                "org.javarosa.core.model.data.UncastData",
-                "org.javarosa.core.model.data.helper.BasicDataPointer",
-                "org.javarosa.core.model.Action",
-                "org.javarosa.core.model.actions.SetValueAction"
-        };
-        PrototypeManager.registerPrototypes(classes);
+        PrototypeManager.registerPrototypes(classNames);
     }
-
 }

--- a/src/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -46,7 +46,12 @@ public class ExternalDataInstance extends DataInstance {
     }
 
     private static String getPathPrefix() {
-        return System.getProperty("user.dir") + "/resources"; // ToDo find out how to get the actual location
+        return System.getProperty("user.dir") + "/resources";
+        /* ToDo find out how to get the actual location. Hélène says:
+        Other "stuff outside the form" uses `<odk-form-folder>/<form-name>-media/` as the root dir but
+        in this case all external secondary instances will go in the same folder. It would be good for
+        that folder to reside in the odk root folder. We can come back to it.
+        */
     }
 
     @Override

--- a/src/org/javarosa/core/util/JavaRosaCoreModule.java
+++ b/src/org/javarosa/core/util/JavaRosaCoreModule.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * 
+ *
  */
 package org.javarosa.core.util;
 
@@ -26,20 +26,18 @@ import org.javarosa.core.services.PrototypeManager;
 
 /**
  * @author Clayton Sims
- * @date Jun 1, 2009 
- *
+ * @date Jun 1, 2009
  */
 public class JavaRosaCoreModule implements IModule {
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.IModule#registerModule(org.javarosa.core.Context)
-     */
+    public static final String[] classNames = {
+            "org.javarosa.core.services.locale.ResourceFileDataSource",
+            "org.javarosa.core.services.locale.TableLocaleSource"
+    };
+
+    @Override
     public void registerModule() {
-        String[] classes = {
-                "org.javarosa.core.services.locale.ResourceFileDataSource",
-                "org.javarosa.core.services.locale.TableLocaleSource"
-        };
-        PrototypeManager.registerPrototypes(classes);
+        PrototypeManager.registerPrototypes(classNames);
         ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
     }
 }

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -1,5 +1,6 @@
 package org.javarosa.xform.parse;
 
+import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.RangeQuestion;
 import org.javarosa.core.model.data.StringData;
@@ -7,6 +8,7 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
+import org.javarosa.core.util.JavaRosaCoreModule;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -176,27 +178,8 @@ public class XFormParserTest {
     }
 
     private void initSerialization() {
-        final String[] SERIALIZABLE_CLASSES = { // Copied from Collect application
-                "org.javarosa.core.services.locale.ResourceFileDataSource",
-                "org.javarosa.core.services.locale.TableLocaleSource",
-                "org.javarosa.core.model.FormDef",
-                "org.javarosa.core.model.SubmissionProfile",
-                "org.javarosa.core.model.QuestionDef",
-                "org.javarosa.core.model.GroupDef",
-                "org.javarosa.core.model.instance.FormInstance",
-                "org.javarosa.core.model.instance.ExternalDataInstance", // Todo export this structure to Collect and remove from there.
-                "org.javarosa.core.model.data.MultiPointerAnswerData",
-                "org.javarosa.core.model.data.PointerAnswerData",
-                "org.javarosa.core.model.data.SelectMultiData",
-                "org.javarosa.core.model.data.SelectOneData",
-                "org.javarosa.core.model.data.StringData",
-                "org.javarosa.core.model.data.TimeData",
-                "org.javarosa.core.model.data.UncastData",
-                "org.javarosa.core.model.data.helper.BasicDataPointer",
-                "org.javarosa.core.model.Action",
-                "org.javarosa.core.model.actions.SetValueAction"
-        };
-        PrototypeManager.registerPrototypes(SERIALIZABLE_CLASSES);
+        PrototypeManager.registerPrototypes(JavaRosaCoreModule.classNames);
+        PrototypeManager.registerPrototypes(CoreModelModule.classNames);
         new XFormsModule().registerModule();
     }
 


### PR DESCRIPTION
See https://github.com/opendatakit/collect/issues/1466

#### What has been done to verify that this works as intended?
JavaRosa tests pass. (There are tests that use these now-exposed classnames.)

#### Why is this the best possible solution? Were any other approaches considered?
It’s the best for now. Later we can learn about the side effects in the registration methods that a Collect developer wanted to avoid, years ago.

#### Are there any risks to merging this code? If so, what are they?
Not for JavaRosa.