### PR TITLE
Time parsing of forms with external secondary instances

### DIFF
--- a/resources/external-secondary-instance-large.xml
+++ b/resources/external-secondary-instance-large.xml
@@ -1,0 +1,20 @@
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml">
+
+    <h:head>
+        <h:title>Form with external secondary instance</h:title>
+        <model>
+            <instance>
+                <data id="a">
+                    <data_set_used/>
+                </data>
+            </instance>
+            <instance id="towns" src="jr://file/towns-large.xml"/>
+            <bind nodeset="/data/data_set_used" calculate="instance('towns')/towndata/data_set"/>
+        </model>
+    </h:head>
+
+    <h:body>
+    </h:body>
+
+</h:html>

--- a/src/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -73,9 +73,9 @@ public class ExternalDataInstance extends DataInstance {
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
-   		super.writeExternal(out);
-   		ExtUtil.write(out, path);
-   	}
+        super.writeExternal(out);
+        ExtUtil.write(out, path);
+    }
 
     /**
      * Returns the path of the URI at srcLocation if the scheme is <code>jr</code> and the host is


### PR DESCRIPTION
Part of https://github.com/opendatakit/javarosa/issues/170

Write a “test” that times parsing of forms with increasingly larger external secondary instance files.

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
