### PR TITLE
Use StringBuilder instead of StringBuffer

### DIFF
--- a/src/org/javarosa/core/util/PrefixTreeNode.java
+++ b/src/org/javarosa/core/util/PrefixTreeNode.java
@@ -58,7 +58,7 @@ public class PrefixTreeNode {
     }
 
     public String toString () {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("{");
         sb.append(prefix);
         if (terminal)


### PR DESCRIPTION
`StringBuffer` is synchronized, so for performance reasons `StringBuilder` should be
used in preference unless thread safety is required.
See https://docs.oracle.com/javase/7/docs/api/java/lang/StringBuffer.html
