### PR TITLE
Use StringBuilder instead of StringBuffer

### DIFF
--- a/src/org/javarosa/core/util/PrefixTreeNode.java
+++ b/src/org/javarosa/core/util/PrefixTreeNode.java
@@ -73,10 +73,19 @@ public class PrefixTreeNode {
     }
 
     public String render() {
-        StringBuffer temp = new StringBuffer();
+        StringBuilder temp = new StringBuilder();
         return render(temp);
     }
 
+    public String render(StringBuilder sb) {
+        if (parent != null) {
+            parent.render(sb);
+        }
+        sb.append(this.prefix);
+        return sb.toString();
+    }
+
+    @Deprecated
     public String render(StringBuffer buffer) {
         if(parent != null){
             parent.render(buffer);


### PR DESCRIPTION
Foloow-up to https://github.com/opendatakit/javarosa/pull/193.

`StringBuffer` is synchronized, so for performance reasons `StringBuilder` should be
used in preference unless thread safety is required.
See https://docs.oracle.com/javase/7/docs/api/java/lang/StringBuffer.html

Any external code previously using `PrefixTreeNode.render(StringBuffer)` will
need updating to use `PrefixTreeNode.render(StringBuilder)`.

# Risks

If any external code exists using `PrefixTreeNode.render(StringBuffer)`, and it actually depends on the thread-safety of the `StringBuffer`, this cannot be merged.  That seems unlikely.