### PR TITLE
Revert "Use StringBuilder instead of StringBuffer"

### DIFF
--- a/src/org/javarosa/core/util/PrefixTreeNode.java
+++ b/src/org/javarosa/core/util/PrefixTreeNode.java
@@ -73,19 +73,10 @@ public class PrefixTreeNode {
     }
 
     public String render() {
-        StringBuilder temp = new StringBuilder();
+        StringBuffer temp = new StringBuffer();
         return render(temp);
     }
 
-    public String render(StringBuilder sb) {
-        if (parent != null) {
-            parent.render(sb);
-        }
-        sb.append(this.prefix);
-        return sb.toString();
-    }
-
-    @Deprecated
     public String render(StringBuffer buffer) {
         if(parent != null){
             parent.render(buffer);


### PR DESCRIPTION
Reverts opendatakit/javarosa#194 following [this discussion](https://opendatakit.slack.com/archives/C389J6X0W/p1507085720000248).

The commits don't look right but that's ok because they'll be squashed. The diff does look right.