### PR TITLE
Deprecate getXMLDocument(Reader reader, CacheTable<String> stringCache).

### DIFF
--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -350,7 +350,18 @@ public class XFormParser implements IXFormParserFunctions {
         return getXMLDocument(reader, null);
     }
 
-    public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache) throws IOException  {
+    /**
+     * Uses xkml to parse the provided XML content, and then consolidates text elements.
+     *
+     * @param reader      the XML content provider
+     * @param stringCache an optional string cache, whose presence will cause the use of
+     *                    {@link InterningKXmlParser} rather than {@link KXmlParser}.
+     * @return the parsed document
+     * @throws IOException
+     * @deprecated The InterningKXmlParser is not used.
+     */
+    @Deprecated public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache)
+            throws IOException {
         Document doc = new Document();
 
         try{


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?
All tests still pass.

#### Why is this the best possible solution? Were any other approaches considered?
This is safe. We considered completely removing the code.

#### Are there any risks to merging this code? If so, what are they?
No