### PR TITLE
Issue #173 - Make second parameter for round optional.

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -44,13 +44,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 import static java.lang.Double.NaN;

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -194,9 +194,16 @@ public class XPathFuncExpr extends XPathExpression {
         } else if (name.equals("int")) { //non-standard
             assertArgsCount(name, args, 1);
             return toInt(argVals[0]);
-        } else if (name.equals("round")) { // non-standard Excel-style round(value,decimal place)
-            assertArgsCount(name, args, 2);
-            return round(toNumeric(argVals[0]), toNumeric(argVals[1]).intValue());
+        } else if (name.equals("round")) { // Proximate XPath 3.0 and Excel-style round(value,decimal place)
+            final int places;
+            if (args.length == 1) {
+                places = 0;
+             } else {
+                assertArgsCount(name, args, 2);
+                places = toNumeric(argVals[1]).intValue();
+            }
+            // Some locales use ',' instead of '.' as a decimal separator, but not supported by Decimal class.
+            return round(toNumeric(argVals[0].toString().replace(',','.')), places);
         } else if (name.equals("string")) {
             assertArgsCount(name, args, 1);
             return toString(argVals[0]);
@@ -1045,14 +1052,22 @@ public class XPathFuncExpr extends XPathExpression {
             return NaN;
         }
 
+        // Rounding with positive decimals
         if (numDecimals >= 0) {
-            // Some locales use ',' instead of '.' as a decimal separator. Since Double.valueOf
-            // doesn't handle comma as the decimal separator, we must ensure a dot will be used by
-            // forcing the US format locale.
-            final NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
-            nf.setMaximumFractionDigits(numDecimals);
-            nf.setGroupingUsed(false);
-            return Double.valueOf(nf.format(number));
+            try {
+                // Per XPath specification, round up or towards zero
+                int method = (number < 0) ? BigDecimal.ROUND_HALF_DOWN : BigDecimal.ROUND_HALF_UP;
+                return (new BigDecimal(
+                        Double.toString(number)))
+                        .setScale(numDecimals, method)
+                        .doubleValue();
+            } catch (NumberFormatException ex) {
+                if (Double.isInfinite(number)) {
+                    return number;
+                } else {
+                    return Double.NaN;
+                }
+             }
         }
 
         // we want to retain 100's or higher value

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -321,7 +321,7 @@ public class XPathEvalTest extends TestCase {
         // round, with a single argument
         testEval("round('14.29123456789')", 14.0);
         testEval("round('14.6')",           15.0);
-        // round, with a two arguments
+        // round, with two arguments
         testEval("round('14.29123456789', 0)", 14.0);
         testEval("round('14.29123456789', 1)", 14.3);
         testEval("round('14.29123456789', 1.5)", 14.3);

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -318,6 +318,10 @@ public class XPathEvalTest extends TestCase {
 
         logTestCategory("math functions");
         testEval("abs(-3.5)", 3.5);
+        // round, with a single argument
+        testEval("round('14.29123456789')", 14.0);
+        testEval("round('14.6')",           15.0);
+        // round, with a two arguments
         testEval("round('14.29123456789', 0)", 14.0);
         testEval("round('14.29123456789', 1)", 14.3);
         testEval("round('14.29123456789', 1.5)", 14.3);
@@ -331,9 +335,20 @@ public class XPathEvalTest extends TestCase {
         testEval("round('12345.12345', -2)", 12300.0);
         testEval("round('12350.12345', -2)", 12400.0);
         testEval("round('12345.12345', -3)", 12000.0);
+        // XPath specification tests
         testEval("round('1 div 0', 0)", NaN);
-        // Todo: get round('12345.15', 1) and round('-12345.15', 1) working on Java 8
+        testEval("round('14.5')", 15.0);
+        testEval("round('NaN')", NaN);
+        testEval("round('-NaN')", -NaN);
+        testEval("round('0')", 0.0);
+        testEval("round('-0')", -0.0);
+        testEval("round('-0.5')", -0.0);
+        // non US format
+        testEval("round('14,6')", 15.0);
+        // Java 8 tests deprecated by XPath 3.0 specification
         // See discussion at https://github.com/opendatakit/javarosa/pull/42#issuecomment-299527754
+        testEval("round('12345.15',     1)", 12345.2);
+        testEval("round('-12345.15',    1)", -12345.1);
 
         logTestCategory("strange operators");
         testEval("true() + 8" , 9.0);


### PR DESCRIPTION
Closes #173 

#### What has been done to verify that this works as intended?
Passes old and new unit tests.
#### Why is this the best possible solution? Were any other approaches considered?
Regarding locale specific number formats, yes, however,  
it's complicated to handle comma separated numbers via Locale class, so string methods used.
To handle the XPath 3.0 specification, only ROUND_HALF_XXX was considered because
it specifies that negative numbers round toward zero, i.e., up.
#### Are there any risks to merging this code? If so, what are they?
It needs to be tested in French and other locales with comma decimal separators.