### PR TITLE
Fix Unexpected multiplicity mismatch IllegalState exception with template repeat

### DIFF
--- a/test/org/javarosa/xform/parse/ChildProcessingTest.java
+++ b/test/org/javarosa/xform/parse/ChildProcessingTest.java
@@ -29,7 +29,7 @@ public class ChildProcessingTest {
         assertFalse(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
     }
 
-    @Test public void WorksWithNoChildren() {
+    @Test public void worksWithNoChildren() {
         Element el = new Element();
         assertFalse(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
     }

--- a/test/org/javarosa/xform/parse/ChildProcessingTest.java
+++ b/test/org/javarosa/xform/parse/ChildProcessingTest.java
@@ -3,6 +3,7 @@ package org.javarosa.xform.parse;
 import org.junit.Test;
 import org.kxml2.kdom.Element;
 
+import static org.javarosa.xform.parse.XFormParser.NAMESPACE_JAVAROSA;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.kxml2.kdom.Node.COMMENT;
@@ -12,32 +13,41 @@ public class ChildProcessingTest {
     @Test public void worksWithOneChild() {
         Element el = new Element();
         el.addChild(ELEMENT, el.createElement(null, "Child Name"));
-        assertTrue(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
+        assertTrue(XFormParser.childOptimizationsOk(el));
     }
 
     @Test public void worksWithTwoMatchingChildren() {
         Element el = new Element();
         el.addChild(ELEMENT, el.createElement(null, "Child Name"));
         el.addChild(ELEMENT, el.createElement(null, "Child Name"));
-        assertTrue(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
+        assertTrue(XFormParser.childOptimizationsOk(el));
     }
 
     @Test public void worksWithTwoNotMatchingChildren() {
         Element el = new Element();
         el.addChild(ELEMENT, el.createElement(null, "Child Name 1"));
         el.addChild(ELEMENT, el.createElement(null, "Child Name 2"));
-        assertFalse(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
+        assertFalse(XFormParser.childOptimizationsOk(el));
+    }
+
+    @Test public void recognizesThatOneChildIsATemplate() {
+        Element el = new Element();
+        Element child1 = el.createElement(null, "Child Name");
+        child1.setAttribute(NAMESPACE_JAVAROSA, "template", "");
+        el.addChild(ELEMENT, child1);
+        el.addChild(ELEMENT, el.createElement(null, "Child Name"));
+        assertFalse(XFormParser.childOptimizationsOk(el));
     }
 
     @Test public void worksWithNoChildren() {
         Element el = new Element();
-        assertFalse(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
+        assertFalse(XFormParser.childOptimizationsOk(el));
     }
 
     @Test public void discoversNonElementChild() {
         Element el = new Element();
         el.addChild(COMMENT, "A string");
-        assertFalse(XFormParser.allChildrenAreElementsAndHaveTheSameName(el));
+        assertFalse(XFormParser.childOptimizationsOk(el));
     }
 
 }

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -20,7 +20,6 @@ import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.After;
 import org.junit.Test;
-import org.kxml2.kdom.Element;
 
 import java.io.BufferedReader;
 import java.io.DataInputStream;
@@ -43,11 +42,7 @@ import static org.javarosa.core.model.Constants.CONTROL_RANGE;
 import static org.javarosa.core.util.externalizable.ExtUtil.defaultPrototypes;
 import static org.javarosa.xpath.XPathParseTool.parseXPath;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.kxml2.kdom.Node.COMMENT;
-import static org.kxml2.kdom.Node.ELEMENT;
 
 public class XFormParserTest {
 

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -265,7 +265,7 @@ public class XFormParserTest {
         assertEquals(AUDIT_3_ANSWER, audit3.getValue().getValue());
     }
 
-    /* todo restore when fixed @Test */ public void parseFormWithTemplateRepeat() throws IOException {
+    @Test public void parseFormWithTemplateRepeat() throws IOException {
         // Given & When
         ParseResult parseResult = parse(r("template-repeat.xml"));
 

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -20,6 +20,7 @@ import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.After;
 import org.junit.Test;
+import org.kxml2.kdom.Element;
 
 import java.io.BufferedReader;
 import java.io.DataInputStream;
@@ -42,7 +43,11 @@ import static org.javarosa.core.model.Constants.CONTROL_RANGE;
 import static org.javarosa.core.util.externalizable.ExtUtil.defaultPrototypes;
 import static org.javarosa.xpath.XPathParseTool.parseXPath;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kxml2.kdom.Node.COMMENT;
+import static org.kxml2.kdom.Node.ELEMENT;
 
 public class XFormParserTest {
 


### PR DESCRIPTION
Closes #202 

#### What has been done to verify that this works as intended?
A new test

#### Why is this the best possible solution? Were any other approaches considered?
It disallows child processing optimization when a template is present

#### Are there any risks to merging this code? If so, what are they?
No