### PR TITLE
Add count non empty func

### DIFF
--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -19,7 +19,7 @@ import java.util.List;
  * instance.
  *
  * 2) A nodeset which wasn't able to reference into any known model (generally a reference which is
- * written in error). In this state, the size of the nodeset can be evaluated, but the acual reference
+ * written in error). In this state, the size of the nodeset can be evaluated, but the actual reference
  * cannot be returned, since it doesn't have any semantic value.
  *
  * (2) may be a deviation from normal XPath. This should be evaluated in the future.
@@ -130,6 +130,25 @@ public class XPathNodeset {
             return 0;
         }
         return nodes.size();
+    }
+
+    /**
+     * @return The number of nodes that are not empty
+     */
+    public int getNonEmptySize() {
+        if (nodes == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (TreeReference node : nodes) {
+            String value = node.toString();
+            if (value != null && !value.isEmpty()) {
+                ++count;
+            }
+        }
+
+        return count;
     }
 
     public TreeReference getRefAt (int i) {

--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -1,6 +1,7 @@
 package org.javarosa.xpath;
 
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.xpath.expr.XPathPathExpr;
@@ -142,8 +143,8 @@ public class XPathNodeset {
 
         int count = 0;
         for (TreeReference node : nodes) {
-            String value = node.toString();
-            if (value != null && !value.isEmpty()) {
+            AbstractTreeElement element = ec.getMainInstance().resolveReference(node);
+            if (element.getNumChildren() > 0 || element.getValue() != null) {
                 ++count;
             }
         }

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -95,7 +95,7 @@ public class XPathFuncExpr extends XPathExpression {
         if (o instanceof XPathFuncExpr) {
             XPathFuncExpr x = (XPathFuncExpr)o;
 
-            //Shortcuts for very easily comprable values
+            //Shortcuts for very easily comparable values
             //We also only return "True" for methods we expect to return the same thing. This is not good
             //practice in Java, since o.equals(o) will return false. We should evaluate that differently.
             //Dec 8, 2011 - Added "uuid", since we should never assume one uuid equals another
@@ -305,6 +305,9 @@ public class XPathFuncExpr extends XPathExpression {
         } else if (name.equals("count")) {
             assertArgsCount(name, args, 1);
             return count(argVals[0]);
+        } else if (name.equals("count-non-empty")) {
+            assertArgsCount(name, args, 1);
+            return countNonEmpty(argVals[0]);
         } else if (name.equals("sum")) {
             assertArgsCount(name, args, 1);
             if (argVals[0] instanceof XPathNodeset) {
@@ -1022,6 +1025,21 @@ public class XPathFuncExpr extends XPathExpression {
             throw new XPathTypeMismatchException("not a nodeset");
         }
     }
+
+    /**
+     * A node is considered non-empty if it is convertible into a string with a greater-than-zero length.
+     *
+     * @param o NodeSet to evaluate. Throws if not a NodeSet
+     * @return the number of non-empty nodes in argument node-set.
+     */
+    private int countNonEmpty (Object o) {
+        if (o instanceof XPathNodeset) {
+            return ((XPathNodeset) o).getNonEmptySize();
+        }
+
+        throw new XPathTypeMismatchException("not a nodeset");
+    }
+
 
     /**
      * sum the values in a nodeset; each element is coerced to a numeric value

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.data.IntegerData;
@@ -139,7 +138,7 @@ public class XPathEvalTest extends TestCase {
         FormInstance countNonEmptyInstance = createCountNonEmptyTestInstance();
 
         logTestCategory("counting");
-        testEval("count(/data)", countNonEmptyInstance, null, 1.0);
+        testEval("count(/data/path)", countNonEmptyInstance, null, 5.0);
         testEval("count-non-empty(/data/path)", countNonEmptyInstance, null, 3);
 
         logTestCategory("unsupporteds");
@@ -578,9 +577,23 @@ public class XPathEvalTest extends TestCase {
 
     public FormInstance createCountNonEmptyTestInstance() {
         TreeElement data = new TreeElement("data");
-        data.addChild(new TreeElement("path", 0));
+
+        TreeElement path = new TreeElement("path", 0);
+        path.addChild(new TreeElement("child", 0));
+        path.addChild(new TreeElement("child", 1));
+        data.addChild(path);
+
         data.addChild(new TreeElement("path", 1));
-        data.addChild(new TreeElement("path", 2));
+
+        path = new TreeElement("path", 2);
+        path.setValue(new StringData("some value"));
+        data.addChild(path);
+
+        path = new TreeElement("path", 3);
+        path.addChild(new TreeElement("child", 0));
+        data.addChild(path);
+
+        data.addChild(new TreeElement("path", 4));
 
         return new FormInstance(data);
     }
@@ -740,7 +753,7 @@ public class XPathEvalTest extends TestCase {
             @Override
             public boolean realTime () { return false; }
             @Override
-            public Object eval (Object[] args, EvaluationContext ec) { return new IExprDataType () {
+            public Object eval (Object[] args, EvaluationContext ec) { return new IExprDataType() {
                     @Override
                     public Boolean toBoolean () { return TRUE; }
                     @Override

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -136,6 +136,12 @@ public class XPathEvalTest extends TestCase {
 
         FormInstance instance = createTestInstance();
 
+        FormInstance countNonEmptyInstance = createCountNonEmptyTestInstance();
+
+        logTestCategory("counting");
+        testEval("count(/data)", countNonEmptyInstance, null, 1.0);
+        testEval("count-non-empty(/data/path)", countNonEmptyInstance, null, 3);
+
         logTestCategory("unsupporteds");
         testEval("/union | /expr", new XPathUnsupportedException());
         testEval("/descendant::blah", new XPathUnsupportedException());
@@ -567,6 +573,15 @@ public class XPathEvalTest extends TestCase {
     public FormInstance createTestInstance() {
         TreeElement data = new TreeElement("data");
         data.addChild(new TreeElement("path"));
+        return new FormInstance(data);
+    }
+
+    public FormInstance createCountNonEmptyTestInstance() {
+        TreeElement data = new TreeElement("data");
+        data.addChild(new TreeElement("path", 0));
+        data.addChild(new TreeElement("path", 1));
+        data.addChild(new TreeElement("path", 2));
+
         return new FormInstance(data);
     }
     


### PR DESCRIPTION
Closes #163

#### What has been done to verify that this works as intended?
Currently hung up on getting a unit test for this method. Looking for direction

#### Why is this the best possible solution? Were any other approaches considered?
It mirrors closely the method "count(object)" which uses the `.size()` method on the Nodeset to return the count. I considered not adding the method `.nonEmptySize()` to the nodeset, but I needed the `.toString()` value of the private `nodes` attribute to determine if the node was empty or not.

#### Are there any risks to merging this code? If so, what are they?
There are currently no tests to this code. Working to get that in.


I was attempting to add a test to `test/org/javarosa/xpath/test/XPathEvalTest.java` but i'm not familiar enough with Javarosa to actually know what to actually pass as an argument.