### PR TITLE
Fix round bug with decimal type

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -200,8 +200,7 @@ public class XPathFuncExpr extends XPathExpression {
                 assertArgsCount(name, args, 2);
                 places = toNumeric(argVals[1]).intValue();
             }
-            // Some locales use ',' instead of '.' as a decimal separator, but not supported by Decimal class.
-            return round(toNumeric(argVals[0].toString().replace(',','.')), places);
+            return round(toNumeric(argVals[0]), places);
         } else if (name.equals("string")) {
             assertArgsCount(name, args, 1);
             return toString(argVals[0]);
@@ -656,18 +655,18 @@ public class XPathFuncExpr extends XPathExpression {
              * when converting a string to a number
              */
 
-            String s = (String)o;
-            double d;
+            final String s = ((String) o)
+                    .replace(',', '.') // Some locales use ',' instead of '.'
+                    .trim();
+
             try {
-                s = s.trim();
                 for (int i = 0; i < s.length(); i++) {
                     char c = s.charAt(i);
                     if (c != '-' && c != '.' && (c < '0' || c > '9'))
                         throw new NumberFormatException();
                 }
 
-                d = Double.parseDouble(s);
-                val = d;
+                val = Double.parseDouble(s);
             } catch (NumberFormatException nfe) {
                 val = NaN;
             }
@@ -679,9 +678,9 @@ public class XPathFuncExpr extends XPathExpression {
 
         if (val != null) {
             return val;
-        } else {
-            throw new XPathTypeMismatchException("converting to numeric");
         }
+
+        throw new XPathTypeMismatchException("converting to numeric");
     }
 
     /**

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -335,6 +335,8 @@ public class XPathEvalTest extends TestCase {
         testEval("round('12345.12345', -2)", 12300.0);
         testEval("round('12350.12345', -2)", 12400.0);
         testEval("round('12345.12345', -3)", 12000.0);
+        // round, with a comma instead of a decimal point
+        testEval("round('4,6'            )", 5.0);
         // XPath specification tests
         testEval("round('1 div 0', 0)", NaN);
         testEval("round('14.5')", 15.0);


### PR DESCRIPTION
Pull request #201 attempted to support rounding of numbers in locales where a comma is used as a decimal point, with this approach:

toNumeric(argVals[0].toString().replace(',','.'))
This causes the failure reported in issue #71, because it calls toString on a XPathNodeset, rather than allowing toNumeric to first unpack it.
This commit solves the problem by moving the code that replaces commas with decimal points inside isNumeric, after the unpack. It also improves code quality by putting this logic inside isNumeric where it belongs.

Closes #71 

#### What has been done to verify that this works as intended?
I added a test asserting that “4,6” is rounded to 5.0. I successfully processed the form provided in the Issue 71 complaint. I then changed the type from decimal to string, so that I could enter a number with a comma instead of a decimal point, and saw that it was rounded correctly.

#### Why is this the best possible solution? Were any other approaches considered?
This solves the problem with a simple change.

#### Are there any risks to merging this code? If so, what are they?
It seems pretty safe.