### PR TITLE
#213 Fix recalculations when deleting a repeat group

### DIFF
--- a/resources/org/javarosa/core/model/calculation-dependent-on-the-repeat-groups-number.xml
+++ b/resources/org/javarosa/core/model/calculation-dependent-on-the-repeat-groups-number.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Calculation dependent on the repeat groups number</h:title>
+        <model>
+            <instance>
+                <rgwp id="rgwp">
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                    </houseM>
+                    <summary/>
+                </rgwp>
+            </instance>
+            <bind calculate= "position(..)" nodeset="/rgwp/houseM/no" type="string"/>
+            <bind calculate="sum(/rgwp/houseM/no)" nodeset="/rgwp/summary" type="int"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/rgwp/houseM">
+            <label>members</label>
+            <repeat nodeset="/rgwp/houseM">
+                <input ref="/rgwp/houseM/no">
+                    <label>No</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/calculation-indirectly-dependent-on-the-repeat-groups-number.xml
+++ b/resources/org/javarosa/core/model/calculation-indirectly-dependent-on-the-repeat-groups-number.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Calculation indirectly dependent on the repeat groups number</h:title>
+        <model>
+            <instance>
+                <rgwp id="rgwp">
+                    <houseM>
+                        <name>A</name>
+                    </houseM>
+                    <houseM>
+                        <name>B</name>
+                    </houseM>
+                    <houseM>
+                        <name>C</name>
+                    </houseM>
+                    <houseM>
+                        <name>D</name>
+                    </houseM>
+                    <houseM>
+                        <name>E</name>
+                    </houseM>
+                    <summary/>
+                </rgwp>
+            </instance>
+            <bind nodeset="/rgwp/houseM/name" type="string"/>
+            <bind calculate="concat(/rgwp/houseM/name)" nodeset="/rgwp/summary" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/rgwp/houseM">
+            <label>members</label>
+            <repeat nodeset="/rgwp/houseM">
+                <input ref="/rgwp/houseM/name">
+                    <label>No</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/delete-repeat-group-with-calculations-timing-test.xml
+++ b/resources/org/javarosa/core/model/delete-repeat-group-with-calculations-timing-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Delete a repeat group with calculations timing test</h:title>
+        <model>
+            <instance>
+                <rgwp id="rgwp">
+                    <!--
+                         Repeats will be added programmatically in the test method
+                         to make it easier to control their number.
+                    -->
+                    <houseM jr:template="">
+                        <current_position/>
+                        <int1/>
+                        <int2/>
+                        <double1/>
+                    </houseM>
+
+                    <summary/>
+                </rgwp>
+            </instance>
+            <bind calculate="position(..)" nodeset="/rgwp/houseM/current_position" type="int"/>
+            <bind calculate="pow(/rgwp/houseM/current_position, 3)" nodeset="/rgwp/houseM/int1" type="int"/>
+            <bind calculate="log10(/rgwp/houseM/int1)" nodeset="/rgwp/houseM/double1" type="double"/>
+            <bind calculate="round(/rgwp/houseM/double1)" nodeset="/rgwp/houseM/int2" type="int"/>
+
+            <bind calculate="sum(/rgwp/houseM/int2)" nodeset="/rgwp/summary" type="double"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/rgwp/houseM">
+            <label>members</label>
+            <repeat nodeset="/rgwp/houseM">
+                <input ref="/rgwp/houseM/current_position"/>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/repeat-group-with-children-calculations-dependent-on-the-parent.xml
+++ b/resources/org/javarosa/core/model/repeat-group-with-children-calculations-dependent-on-the-parent.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Repeat group with children calculation dependent on the parent</h:title>
+        <model>
+            <instance>
+                <rgwp id="rgwp">
+                    <houseM>
+                        <no/>
+                        <name>A</name>
+                        <name_and_no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>B</name>
+                        <name_and_no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>C</name>
+                        <name_and_no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>D</name>
+                        <name_and_no/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>E</name>
+                        <name_and_no/>
+                    </houseM>
+                </rgwp>
+            </instance>
+            <bind calculate="position(..)" nodeset="/rgwp/houseM/no" type="int"/>
+            <bind nodeset="/rgwp/houseM/name" type="string"/>
+            <bind calculate="concat(/rgwp/houseM/name, /rgwp/houseM/no)" nodeset="/rgwp/houseM/name_and_no" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/rgwp/houseM">
+            <label>members</label>
+            <repeat nodeset="/rgwp/houseM">
+                <input ref="/rgwp/houseM/no">
+                    <label>No</label>
+                </input>
+                <input ref="/rgwp/houseM/name">
+                    <label>Name</label>
+                </input>
+                <input ref="/rgwp/houseM/name_and_no">
+                    <label>Name and No</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/repeat-group-with-children-calculations-not-dependent-on-the-parent.xml
+++ b/resources/org/javarosa/core/model/repeat-group-with-children-calculations-not-dependent-on-the-parent.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Repeat group with children calculation NOT dependent on the parent</h:title>
+        <model>
+            <instance>
+                <rgwp id="rgwp">
+                    <houseM>
+                        <no/>
+                        <name>A</name>
+                        <name_concat/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>B</name>
+                        <name_concat/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>C</name>
+                        <name_concat/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>D</name>
+                        <name_concat/>
+                    </houseM>
+                    <houseM>
+                        <no/>
+                        <name>E</name>
+                        <name_concat/>
+                    </houseM>
+                </rgwp>
+            </instance>
+            <bind calculate="position(..)" nodeset="/rgwp/houseM/no" type="int"/>
+            <bind nodeset="/rgwp/houseM/name" type="string"/>
+            <bind calculate="concat(/rgwp/houseM/name, 'X')" nodeset="/rgwp/houseM/name_concat" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/rgwp/houseM">
+            <label>members</label>
+            <repeat nodeset="/rgwp/houseM">
+                <input ref="/rgwp/houseM/name">
+                    <label>Name</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/repeat-group-with-children-position-calculation.xml
+++ b/resources/org/javarosa/core/model/repeat-group-with-children-position-calculation.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <h:head>
-        <h:title>RepeatGroupWithPosition</h:title>
+        <h:title>Repeat group with position calculation</h:title>
         <model>
             <instance>
                 <rgwp id="rgwp">
                     <houseM>
-                        <no>1</no>
+                        <no/>
                     </houseM>
                     <houseM>
-                        <no>2</no>
+                        <no/>
                     </houseM>
                     <houseM>
-                        <no>3</no>
+                        <no/>
                     </houseM>
                     <houseM>
-                        <no>4</no>
+                        <no/>
                     </houseM>
                     <houseM>
-                        <no>5</no>
+                        <no/>
                     </houseM>
                 </rgwp>
             </instance>

--- a/resources/org/javarosa/core/model/repeat-group-with-position-calculation.xml
+++ b/resources/org/javarosa/core/model/repeat-group-with-position-calculation.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>RepeatGroupWithPosition</h:title>
+        <model>
+            <instance>
+                <rgwp id="rgwp">
+                    <houseM>
+                        <no>1</no>
+                    </houseM>
+                    <houseM>
+                        <no>2</no>
+                    </houseM>
+                    <houseM>
+                        <no>3</no>
+                    </houseM>
+                    <houseM>
+                        <no>4</no>
+                    </houseM>
+                    <houseM>
+                        <no>5</no>
+                    </houseM>
+                </rgwp>
+            </instance>
+            <bind calculate="position(..)" nodeset="/rgwp/houseM/no" type="int"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/rgwp/houseM">
+            <label>members</label>
+            <repeat nodeset="/rgwp/houseM">
+                <input ref="/rgwp/houseM/no">
+                    <label>No</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/Safe2014DagImpl.java
+++ b/src/org/javarosa/core/model/Safe2014DagImpl.java
@@ -61,13 +61,20 @@ public class Safe2014DagImpl extends LatestDagBase {
          EvaluationContext evalContext, TreeReference deleteRef,
          TreeElement parentElement, TreeElement deletedElement) {
 
-      Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(
-            mainInstance, evalContext, deleteRef,
-            new HashSet<QuickTriggerable>(0));
-      publishSummary("Deleted", deleteRef, alreadyEvaluated);
+      // After a repeat group has been deleted, the following repeat groups position has changed.
+      // Evaluate triggerables which depend on the position of the following repeats or on their children.
+      final String repeatGroupName = deletedElement.getName();
+      for (int i = deletedElement.getMultiplicity(); i < parentElement.getChildMultiplicity(repeatGroupName); i++) {
+         final TreeElement repeatGroup = parentElement.getChild(repeatGroupName, i);
 
-      evaluateChildrenTriggerables(mainInstance, evalContext,
-            deletedElement, false, alreadyEvaluated);
+         Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(
+                 mainInstance, evalContext, repeatGroup.getRef(),
+                 new HashSet<QuickTriggerable>(0));
+         publishSummary("Deleted", repeatGroup.getRef(), alreadyEvaluated);
+
+         evaluateChildrenTriggerables(mainInstance, evalContext,
+                 repeatGroup, false, alreadyEvaluated);
+      }
    }
 
    @Override

--- a/test/org/javarosa/core/model/Safe2014DagImplTest.java
+++ b/test/org/javarosa/core/model/Safe2014DagImplTest.java
@@ -82,6 +82,263 @@ public class Safe2014DagImplTest {
         }
     }
 
+    @Test
+    public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnTheParentPosition() throws Exception {
+        // Given
+        final FormDef formDef =
+                parse(r("repeat-group-with-children-calculations-dependent-on-the-parent.xml")).formDef;
+
+        assertIDagImplUnderTest(formDef);
+
+        formDef.initialize(false, new InstanceInitializationFactory()); // trigger all calculations
+        formDef.setEventNotifier(eventNotifier); // it's important to set the test event notifier now to avoid storing events from the above initialization
+
+        final FormInstance mainInstance = formDef.getMainInstance();
+
+        final TreeElement elementToBeDeleted = mainInstance.getRoot().getChildAt(2);
+        final TreeReference elementToBeDeletedRef = elementToBeDeleted.getRef();
+
+        // Index pointing to the second repeat group
+        final FormIndex indexToBeDeleted = new FormIndex(0, 1, elementToBeDeletedRef);
+
+        // When
+
+        // Safe2014DagImplTest.deleteRepeatGroup is called by the below method
+        formDef.deleteRepeat(indexToBeDeleted);
+
+        // Then
+        final List<TreeElement> repeats = mainInstance.getRoot().getChildrenWithName("houseM");
+
+        // check the values based on the position of the parents
+        assertThat(repeats.get(0).getChildAt(0).getValue().getDisplayText(), equalTo("1"));
+        assertThat(repeats.get(0).getChildAt(2).getValue().getDisplayText(), equalTo("A1"));
+        assertThat(repeats.get(1).getChildAt(0).getValue().getDisplayText(), equalTo("2"));
+        assertThat(repeats.get(1).getChildAt(2).getValue().getDisplayText(), equalTo("C2"));
+        assertThat(repeats.get(2).getChildAt(0).getValue().getDisplayText(), equalTo("3"));
+        assertThat(repeats.get(2).getChildAt(2).getValue().getDisplayText(), equalTo("D3"));
+        assertThat(repeats.get(3).getChildAt(0).getValue().getDisplayText(), equalTo("4"));
+        assertThat(repeats.get(3).getChildAt(2).getValue().getDisplayText(), equalTo("E4"));
+
+        // check that correct calculations were triggered
+        final String[] expectedMessages = {
+                "Processing 'Recalculate' for no [2_1] (2.0)",
+                "Processing 'Recalculate' for name_and_no [2_1] (C2)",
+                "Processing 'Deleted: houseM [2]: 2 triggerables were fired.' for ",
+                "Processing 'Deleted: no [2_1]: 0 triggerables were fired.' for ",
+                "Processing 'Deleted: name [2_1]: 0 triggerables were fired.' for ",
+                "Processing 'Deleted: name_and_no [2_1]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [3_1] (3.0)",
+                "Processing 'Recalculate' for name_and_no [3_1] (D3)",
+                "Processing 'Deleted: houseM [3]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [4_1] (4.0)",
+                "Processing 'Recalculate' for name_and_no [4_1] (E4)",
+                "Processing 'Deleted: houseM [4]: 2 triggerables were fired.' for ",
+        };
+
+        assertThat(dagEvents.size(), equalTo(expectedMessages.length));
+
+        int messageIndex = 0;
+        for (String expectedMessage : expectedMessages) {
+            assertThat(dagEvents.get(messageIndex++).getDisplayMessage(), equalTo(expectedMessage));
+        }
+    }
+
+    @Test
+    public void deleteSecondRepeatGroup_doesNotEvaluateTriggerables_notDependentOnTheParentPosition() throws Exception {
+        // Given
+        final FormDef formDef =
+                parse(r("repeat-group-with-children-calculations-not-dependent-on-the-parent.xml")).formDef;
+
+        assertIDagImplUnderTest(formDef);
+
+        formDef.initialize(false, new InstanceInitializationFactory()); // trigger all calculations
+        formDef.setEventNotifier(eventNotifier); // it's important to set the test event notifier now to avoid storing events from the above initialization
+
+        final FormInstance mainInstance = formDef.getMainInstance();
+
+        final TreeElement elementToBeDeleted = mainInstance.getRoot().getChildAt(2);
+        final TreeReference elementToBeDeletedRef = elementToBeDeleted.getRef();
+
+        // Index pointing to the second repeat group
+        final FormIndex indexToBeDeleted = new FormIndex(0, 1, elementToBeDeletedRef);
+
+        // When
+
+        // Safe2014DagImplTest.deleteRepeatGroup is called by the below method
+        formDef.deleteRepeat(indexToBeDeleted);
+
+        // Then
+        final List<TreeElement> repeats = mainInstance.getRoot().getChildrenWithName("houseM");
+
+        // check the values based on the position of the parents
+        assertThat(repeats.get(0).getChildAt(0).getValue().getDisplayText(), equalTo("1"));
+        assertThat(repeats.get(0).getChildAt(2).getValue().getDisplayText(), equalTo("AX"));
+        assertThat(repeats.get(1).getChildAt(0).getValue().getDisplayText(), equalTo("2"));
+        assertThat(repeats.get(1).getChildAt(2).getValue().getDisplayText(), equalTo("CX"));
+        assertThat(repeats.get(2).getChildAt(0).getValue().getDisplayText(), equalTo("3"));
+        assertThat(repeats.get(2).getChildAt(2).getValue().getDisplayText(), equalTo("DX"));
+        assertThat(repeats.get(3).getChildAt(0).getValue().getDisplayText(), equalTo("4"));
+        assertThat(repeats.get(3).getChildAt(2).getValue().getDisplayText(), equalTo("EX"));
+
+        // check that correct calculations were triggered
+        final String[] expectedMessages = {
+                "Processing 'Recalculate' for no [2_1] (2.0)",
+                "Processing 'Deleted: houseM [2]: 1 triggerables were fired.' for ",
+                "Processing 'Deleted: no [2_1]: 1 triggerables were fired.' for ",
+                "Processing 'Recalculate' for name_concat [2_1] (CX)",
+                "Processing 'Deleted: name [2_1]: 1 triggerables were fired.' for ",
+                "Processing 'Deleted: name_concat [2_1]: 1 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [3_1] (3.0)",
+                "Processing 'Deleted: houseM [3]: 1 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [4_1] (4.0)",
+                "Processing 'Deleted: houseM [4]: 1 triggerables were fired.' for "
+        };
+
+        assertThat(dagEvents.size(), equalTo(expectedMessages.length));
+
+        int messageIndex = 0;
+        for (String expectedMessage : expectedMessages) {
+            assertThat(dagEvents.get(messageIndex++).getDisplayMessage(), equalTo(expectedMessage));
+        }
+    }
+
+    @Test
+    public void deleteThirdRepeatGroup_evaluatesTriggerables_dependentOnTheRepeatGroupsNumber() throws Exception {
+        // Given
+        final FormDef formDef =
+                parse(r("calculation-dependent-on-the-repeat-groups-number.xml")).formDef;
+
+        assertIDagImplUnderTest(formDef);
+
+        formDef.initialize(false, new InstanceInitializationFactory()); // trigger all calculations
+        formDef.setEventNotifier(eventNotifier); // it's important to set the test event notifier now to avoid storing events from the above initialization
+
+        final FormInstance mainInstance = formDef.getMainInstance();
+
+        final TreeElement elementToBeDeleted = mainInstance.getRoot().getChildAt(2);
+        final TreeReference elementToBeDeletedRef = elementToBeDeleted.getRef();
+
+        // Index pointing to the second repeat group
+        final FormIndex indexToBeDeleted = new FormIndex(0, 2, elementToBeDeletedRef);
+
+        // When
+
+        TreeElement summaryNode = mainInstance.getRoot().getChildrenWithName("summary").get(0);
+        assertThat(summaryNode.getValue().getDisplayText(), equalTo("55")); // check the calculation result for 10 repeat groups
+
+        // Safe2014DagImplTest.deleteRepeatGroup is called by the below method
+        formDef.deleteRepeat(indexToBeDeleted);
+
+        // Then
+        final List<TreeElement> repeats = mainInstance.getRoot().getChildrenWithName("houseM");
+
+        // check the values based on the position of the parents
+        assertThat(repeats.get(0).getChildAt(0).getValue().getDisplayText(), equalTo("1"));
+        assertThat(repeats.get(1).getChildAt(0).getValue().getDisplayText(), equalTo("2"));
+        assertThat(repeats.get(2).getChildAt(0).getValue().getDisplayText(), equalTo("3"));
+        assertThat(repeats.get(3).getChildAt(0).getValue().getDisplayText(), equalTo("4"));
+        assertThat(repeats.get(4).getChildAt(0).getValue().getDisplayText(), equalTo("5"));
+        assertThat(repeats.get(5).getChildAt(0).getValue().getDisplayText(), equalTo("6"));
+        assertThat(repeats.get(6).getChildAt(0).getValue().getDisplayText(), equalTo("7"));
+        assertThat(repeats.get(7).getChildAt(0).getValue().getDisplayText(), equalTo("8"));
+        assertThat(repeats.get(8).getChildAt(0).getValue().getDisplayText(), equalTo("9"));
+
+        assertThat(summaryNode.getValue().getDisplayText(), equalTo("45"));
+
+        // check that correct calculations were triggered
+        final String[] expectedMessages = {
+                "Processing 'Recalculate' for no [3_1] (3.0)",
+                "Processing 'Recalculate' for summary [1] (51.0)",
+                "Processing 'Deleted: houseM [3]: 2 triggerables were fired.' for ",
+                "Processing 'Deleted: no [3_1]: 0 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [4_1] (4.0)",
+                "Processing 'Recalculate' for summary [1] (50.0)",
+                "Processing 'Deleted: houseM [4]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [5_1] (5.0)",
+                "Processing 'Recalculate' for summary [1] (49.0)",
+                "Processing 'Deleted: houseM [5]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [6_1] (6.0)",
+                "Processing 'Recalculate' for summary [1] (48.0)",
+                "Processing 'Deleted: houseM [6]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [7_1] (7.0)",
+                "Processing 'Recalculate' for summary [1] (47.0)",
+                "Processing 'Deleted: houseM [7]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [8_1] (8.0)",
+                "Processing 'Recalculate' for summary [1] (46.0)",
+                "Processing 'Deleted: houseM [8]: 2 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [9_1] (9.0)",
+                "Processing 'Recalculate' for summary [1] (45.0)",
+                "Processing 'Deleted: houseM [9]: 2 triggerables were fired.' for "
+        };
+
+        assertThat(dagEvents.size(), equalTo(expectedMessages.length));
+
+        int messageIndex = 0;
+        for (String expectedMessage : expectedMessages) {
+            assertThat(dagEvents.get(messageIndex++).getDisplayMessage(), equalTo(expectedMessage));
+        }
+    }
+
+    /**
+     * Indirectly means that the calculation - `concat(/rgwp/houseM/name)` - does not take the
+     * `/rgwp/houseM` nodeset (the repeat group) as an argument
+     * but since it takes one of its children (`name` children),
+     * the calculation must re-evaluated once after a repeat group deletion because one of the children
+     * has been deleted along with its parent (the repeat group instance).
+     */
+    @Test
+    public void deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber() throws Exception {
+        // Given
+        final FormDef formDef =
+                parse(r("calculation-indirectly-dependent-on-the-repeat-groups-number.xml")).formDef;
+
+        assertIDagImplUnderTest(formDef);
+
+        formDef.initialize(false, new InstanceInitializationFactory()); // trigger all calculations
+        formDef.setEventNotifier(eventNotifier); // it's important to set the test event notifier now to avoid storing events from the above initialization
+
+        final FormInstance mainInstance = formDef.getMainInstance();
+
+        final TreeElement elementToBeDeleted = mainInstance.getRoot().getChildAt(2);
+        final TreeReference elementToBeDeletedRef = elementToBeDeleted.getRef();
+
+        // Index pointing to the second repeat group
+        final FormIndex indexToBeDeleted = new FormIndex(0, 2, elementToBeDeletedRef);
+
+        // When
+        TreeElement summaryNode = mainInstance.getRoot().getChildrenWithName("summary").get(0);
+        assertThat(summaryNode.getValue().getDisplayText(), equalTo("ABCDE"));
+
+        // Safe2014DagImplTest.deleteRepeatGroup is called by the below method
+        formDef.deleteRepeat(indexToBeDeleted);
+
+        // Then
+        final List<TreeElement> repeats = mainInstance.getRoot().getChildrenWithName("houseM");
+
+        assertThat(repeats.size(), equalTo(4));
+        assertThat(repeats.get(0).getChildAt(0).getValue().getDisplayText(), equalTo("A"));
+        assertThat(repeats.get(1).getChildAt(0).getValue().getDisplayText(), equalTo("B"));
+        assertThat(repeats.get(2).getChildAt(0).getValue().getDisplayText(), equalTo("D"));
+        assertThat(repeats.get(3).getChildAt(0).getValue().getDisplayText(), equalTo("E"));
+
+        assertThat(summaryNode.getValue().getDisplayText(), equalTo("ABDE"));
+
+        // check that correct calculations were triggered
+        final String[] expectedMessages = {
+                "Processing 'Deleted: houseM [3]: 0 triggerables were fired.' for ",
+                "Processing 'Recalculate' for summary [1] (ABDE)",
+                "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for ",
+                "Processing 'Deleted: houseM [4]: 0 triggerables were fired.' for "
+        };
+
+        assertThat(dagEvents.size(), equalTo(expectedMessages.length));
+
+        int messageIndex = 0;
+        for (String expectedMessage : expectedMessages) {
+            assertThat(dagEvents.get(messageIndex++).getDisplayMessage(), equalTo(expectedMessage));
+        }
+    }
+
     /**
      * Assert that {@param formDef} holds the expected {@link IDag} implementation.
      * The field is private in {@link FormDef} so the reflection must be used.

--- a/test/org/javarosa/core/model/Safe2014DagImplTest.java
+++ b/test/org/javarosa/core/model/Safe2014DagImplTest.java
@@ -33,7 +33,7 @@ public class Safe2014DagImplTest {
     public void deleteSecondRepeatGroup_evaluatesTriggerables_dependedOnFollowingRepeatGroupSiblings() throws Exception {
         // Given
         final FormDef formDef =
-                parse(r("org/javarosa/core/model/repeat-group-with-position-calculation.xml")).formDef;
+                parse(r("repeat-group-with-position-calculation.xml")).formDef;
 
         assertIDagImplUnderTest(formDef);
         formDef.setEventNotifier(eventNotifier);

--- a/test/org/javarosa/core/model/Safe2014DagImplTest.java
+++ b/test/org/javarosa/core/model/Safe2014DagImplTest.java
@@ -1,0 +1,91 @@
+package org.javarosa.core.model;
+
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.debug.Event;
+import org.javarosa.debug.EventNotifier;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.javarosa.xform.parse.FormParserHelper.parse;
+import static org.junit.Assert.assertThat;
+
+public class Safe2014DagImplTest {
+
+    private final List<Event> dagEvents = new ArrayList<>();
+
+    private final EventNotifier eventNotifier = new EventNotifier() {
+
+        @Override
+        public void publishEvent(Event event) {
+            dagEvents.add(event);
+        }
+    };
+
+    @Test
+    public void deleteSecondRepeatGroup_evaluatesTriggerables_dependedOnFollowingRepeatGroupSiblings() throws Exception {
+        // Given
+        final FormDef formDef =
+                parse(r("org/javarosa/core/model/repeat-group-with-position-calculation.xml")).formDef;
+
+        assertIDagImplUnderTest(formDef);
+        formDef.setEventNotifier(eventNotifier);
+
+        final FormInstance mainInstance = formDef.getMainInstance();
+
+        final TreeElement elementToBeDeleted = mainInstance.getRoot().getChildAt(2);
+        final TreeReference elementToBeDeletedRef = elementToBeDeleted.getRef();
+
+        // Index pointing to the second repeat group
+        final FormIndex indexToBeDeleted = new FormIndex(0, 1, elementToBeDeletedRef);
+
+        // When
+
+        // Safe2014DagImplTest.deleteRepeatGroup is called by the below method
+        formDef.deleteRepeat(indexToBeDeleted);
+
+        // Then
+        final List<TreeElement> repeats = mainInstance.getRoot().getChildrenWithName("houseM");
+
+        // check the values based on the position of the parents
+        assertThat(repeats.get(0).getChildAt(0).getValue().getDisplayText(), equalTo("1"));
+        assertThat(repeats.get(1).getChildAt(0).getValue().getDisplayText(), equalTo("2"));
+        assertThat(repeats.get(2).getChildAt(0).getValue().getDisplayText(), equalTo("3"));
+        assertThat(repeats.get(3).getChildAt(0).getValue().getDisplayText(), equalTo("4"));
+
+        // check that calculations have not been triggered for the repeat group prior to the deleted one
+        final String[] expectedMessages = {
+                "Processing 'Recalculate' for no [2_1] (2.0)",
+                "Processing 'Deleted: houseM [2]: 1 triggerables were fired.' for ",
+                "Processing 'Deleted: no [2_1]: 1 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [3_1] (3.0)",
+                "Processing 'Deleted: houseM [3]: 1 triggerables were fired.' for ",
+                "Processing 'Deleted: no [3_1]: 1 triggerables were fired.' for ",
+                "Processing 'Recalculate' for no [4_1] (4.0)",
+                "Processing 'Deleted: houseM [4]: 1 triggerables were fired.' for ",
+                "Processing 'Deleted: no [4_1]: 1 triggerables were fired.' for "
+        };
+        int messageIndex = 0;
+        for (String expectedMessage : expectedMessages) {
+            assertThat(dagEvents.get(messageIndex++).getDisplayMessage(), equalTo(expectedMessage));
+        }
+    }
+
+    /**
+     * Assert that {@param formDef} holds the expected {@link IDag} implementation.
+     * The field is private in {@link FormDef} so the reflection must be used.
+     */
+    private void assertIDagImplUnderTest(FormDef formDef) throws NoSuchFieldException, IllegalAccessException {
+        Field dagImplFromFormDef = FormDef.class.getDeclaredField("dagImpl");
+        dagImplFromFormDef.setAccessible(true);
+        assertThat(dagImplFromFormDef.get(formDef), instanceOf(Safe2014DagImpl.class));
+    }
+
+}

--- a/test/org/javarosa/test/utils/ResourcePathHelper.java
+++ b/test/org/javarosa/test/utils/ResourcePathHelper.java
@@ -6,8 +6,6 @@ import java.nio.file.Paths;
 
 public class ResourcePathHelper {
 
-    private static final int CALLER_CLASS_INDEX_IN_STACKTRACE = 3;
-
     /** Makes a Path for a resource file */
     public static Path r(String filename) {
         final String resourceFileParentPath = inferResourceFileParentPath();
@@ -26,10 +24,15 @@ public class ResourcePathHelper {
      * @return Caller test class package as a path
      */
     private static String inferResourceFileParentPath() {
-        final StackTraceElement callingClass =  Thread.currentThread().getStackTrace()[CALLER_CLASS_INDEX_IN_STACKTRACE];
-        final String callerPackage = callingClass.getClassName();
-        return callerPackage
-                .substring(0, callerPackage.lastIndexOf(".")) // strip the class name
-                .replaceAll("\\.", "\\" + File.separator); // change all '.' to '/' ('\' on Windows)
+        final StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        int callerStackIndex = 2; // 0 is getStackTrace, 1 is this method, 2 is immediate caller
+        while (callerStackIndex < stackTrace.length &&
+                stackTrace[callerStackIndex].getClassName().equals(ResourcePathHelper.class.getName())) {
+            ++callerStackIndex;
+        }
+        final String callerClassName = stackTrace[callerStackIndex].getClassName();
+        return callerClassName
+                .substring(0, callerClassName.lastIndexOf(".")) // strip the class name
+                .replace(".", File.separator);  // change all '.' to '/' ('\' on Windows)
     }
 }

--- a/test/org/javarosa/test/utils/ResourcePathHelper.java
+++ b/test/org/javarosa/test/utils/ResourcePathHelper.java
@@ -1,11 +1,35 @@
 package org.javarosa.test.utils;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class ResourcePathHelper {
+
+    private static final int CALLER_CLASS_INDEX_IN_STACKTRACE = 3;
+
     /** Makes a Path for a resource file */
     public static Path r(String filename) {
-        return Paths.get("resources", filename);
+        final String resourceFileParentPath = inferResourceFileParentPath();
+        final Path resourceFilePath = Paths.get("resources", resourceFileParentPath, filename);
+
+        if (resourceFilePath.toFile().exists()) {
+            return resourceFilePath;
+        } else { // try to find the file in the resources root directory
+            return Paths.get("resources", filename);
+        }
+    }
+
+    /**
+     * If the class that called {@link ResourcePathHelper#r(String)} is {@link org.javarosa.core.model.Safe2014DagImpl}
+     * then this method will return "org/javarosa/core/model"
+     * @return Caller test class package as a path
+     */
+    private static String inferResourceFileParentPath() {
+        final StackTraceElement callingClass =  Thread.currentThread().getStackTrace()[CALLER_CLASS_INDEX_IN_STACKTRACE];
+        final String callerPackage = callingClass.getClassName();
+        return callerPackage
+                .substring(0, callerPackage.lastIndexOf(".")) // strip the class name
+                .replaceAll("\\.", "\\" + File.separator); // change all '.' to '/' ('\' on Windows)
     }
 }

--- a/test/org/javarosa/test/utils/ResourcePathHelper.java
+++ b/test/org/javarosa/test/utils/ResourcePathHelper.java
@@ -1,0 +1,11 @@
+package org.javarosa.test.utils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ResourcePathHelper {
+    /** Makes a Path for a resource file */
+    public static Path r(String filename) {
+        return Paths.get("resources", filename);
+    }
+}

--- a/test/org/javarosa/xform/parse/FormParserHelper.java
+++ b/test/org/javarosa/xform/parse/FormParserHelper.java
@@ -1,0 +1,45 @@
+package org.javarosa.xform.parse;
+
+import org.javarosa.core.model.FormDef;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class FormParserHelper {
+
+    private FormParserHelper() {
+    }
+
+    public static ParseResult parse(Path formName) throws IOException {
+        XFormParser parser = new XFormParser(new FileReader(formName.toString()));
+        final List<String> errorMessages = new ArrayList<>();
+        parser.attachReporter(new XFormParserReporter() {
+            @Override
+            public void warning(String type, String message, String xmlLocation) {
+                errorMessages.add(message);
+                super.warning(type, message, xmlLocation);
+            }
+
+            @Override
+            public void error(String message) {
+                errorMessages.add(message);
+                super.error(message);
+            }
+        });
+
+        return new ParseResult(parser.parse(), errorMessages);
+    }
+
+    public static class ParseResult {
+        public final FormDef formDef;
+        public final List<String> errorMessages;
+
+        ParseResult(FormDef formDef, List<String> errorMessages) {
+            this.formDef = formDef;
+            this.errorMessages = errorMessages;
+        }
+    }
+}

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -16,6 +16,7 @@ import org.javarosa.core.util.JavaRosaCoreModule;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.model.xform.XFormsModule;
+import org.javarosa.xform.parse.FormParserHelper.ParseResult;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.After;
@@ -24,13 +25,11 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,16 +39,14 @@ import static java.nio.file.Files.readAllBytes;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.javarosa.core.model.Constants.CONTROL_RANGE;
 import static org.javarosa.core.util.externalizable.ExtUtil.defaultPrototypes;
+import static org.javarosa.xform.parse.FormParserHelper.parse;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.javarosa.xpath.XPathParseTool.parseXPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class XFormParserTest {
 
-    /** Makes a Path for a resource file */
-    private static Path r(String filename) {
-        return Paths.get("resources", filename);
-    }
     private static final Path FORM_INSTANCE_XML_FILE_NAME           = r("instance.xml");
     private static final Path SECONDARY_INSTANCE_XML                = r("secondary-instance.xml");
     private static final Path SECONDARY_INSTANCE_LARGE_XML          = r("secondary-instance-large.xml");
@@ -281,35 +278,6 @@ public class XFormParserTest {
         // Then
         assertEquals(parseResult.formDef.getTitle(), "eIMCI by D-Tree");
         assertEquals("Number of error messages", 0, parseResult.errorMessages.size());
-    }
-
-    private ParseResult parse(Path formName) throws IOException {
-        XFormParser parser = new XFormParser(new FileReader(formName.toString()));
-        final List<String> errorMessages = new ArrayList<>();
-        parser.reporter = new XFormParserReporter() {
-            @Override
-            public void warning(String type, String message, String xmlLocation) {
-                errorMessages.add(message);
-                super.warning(type, message, xmlLocation);
-            }
-
-            @Override
-            public void error(String message) {
-                errorMessages.add(message);
-                super.error(message);
-            }
-        };
-        return new ParseResult(parser.parse(), errorMessages);
-    }
-
-    class ParseResult {
-        final FormDef formDef;
-        final List<String> errorMessages;
-
-        ParseResult(FormDef formDef, List<String> errorMessages) {
-            this.formDef = formDef;
-            this.errorMessages = errorMessages;
-        }
     }
 
     private TreeElement findDepthFirst(TreeElement parent, String name) {


### PR DESCRIPTION
Closes #213

#### What has been done to verify that this works as intended?
So far only manual testing. Unit tests are in progress.

#### Why is this the best possible solution? Were any other approaches considered?
It seems to be most 'natural' to me. However there were other approaches considered. More details in the conversation under #213.
I think a really slow-down may be acceptable as `Safe2014DagImpl` seems to focous on being bugs-free. There are other implementations - like `Fast2014DagImpl` - which seem to be focused on the performance. Even at the expense of some bugs or not being as accurate as the safe implementations.

#### Are there any risks to merging this code? If so, what are they?
Well, when deleting a repeat, the default evaluation logic (`Safe2014DagImpl`) goes over all remaining repeats and fires all recalculations that were depended on the remaining repeat groups (their position) or their children. It might have a performance impact if there are a lot of repeats with depended calculations. I haven't tested it yet though. 
