### PR TITLE
Fix 'indexed-repeat' error when index is blank

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -946,12 +946,14 @@ public class XPathFuncExpr extends XPathExpression {
             // process index (if valid)
             int groupIdx = toInt(args[idxargi].eval(model, ec)).intValue();
             if (groupIdx <= 0) {
-                // ignore invalid indexes (primarily happens during validation)
+                /*
+                   Don't allow invalid index otherwise an exception will be thrown later by XPathNodeset#unpack().
+                   This may happen if referenced node hadn't gotten a value yet but the calculation was fired. For example when adding a new repeat.
+                 */
+                groupIdx = 1;
             }
-            else {
-                // otherwise, add the index to the context reference
-                contextRef.setMultiplicity(groupRef.size()-1, groupIdx-1);
-            }
+            
+            contextRef.setMultiplicity(groupRef.size()-1, groupIdx-1);
         }
 
         // evaluate and return the XPath expression, in context


### PR DESCRIPTION
Closes #214 

#### What has been done to verify that this works as intended?
Tested with ODK Collect. A unit test is on the way!

#### Why is this the best possible solution? Were any other approaches considered?
That was the simplest solution. It has one minor drawback - if index is blank, it sets its value to one ('1'). So till the the question referenced by the index isn't answered, it'll keep using the first repeat group for the calculation. 
I think other approaches would require a ridiculous amount of work and refactoring. 

#### Are there any risks to merging this code? If so, what are they?
I can't see any risk but let's wait for the unit test.
