### PR TITLE
CircleCI 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/code
+    docker:
+      - image: circleci/openjdk:latest
+    steps:
+      - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}
+      - run: ./gradlew check test javadoc jar
+      - save_cache:
+          paths:
+            - ~/.gradle
+            - ~/code/.gradle
+          key: jars-{{ checksum "build.gradle" }}
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+      - store_artifacts:
+          path: build/docs
+          destination: docs
+       - store_artifacts:
+          path: build/libs
+          destination: libs
+      - store_test_results:
+          path: build/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - store_artifacts:
           path: build/docs
           destination: docs
-       - store_artifacts:
+      - store_artifacts:
           path: build/libs
           destination: libs
       - store_test_results:

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-test:
-  override:
-    - ./gradlew check test javadoc jar
-  post:
-    - cp -r build/libs $CIRCLE_ARTIFACTS
-    - cp -r build/reports/tests/test $CIRCLE_TEST_REPORTS/junit
-    - cp -r build/docs/javadoc $CIRCLE_TEST_REPORTS
-    - cp -r build/reports/checkstyle $CIRCLE_TEST_REPORTS


### PR DESCRIPTION
I have confirmed that
* The cache is saved and restored (it's mostly ~/.gradle that has the useful jars)
* The reports show up in artifacts and it has HTML that renders
* The jar shows up in artifacts
* The test results show up in test summary

I did not confirm this runs in any app, but visual inspection of the jar has all the right stuff inside.

This cuts build time in half, which is nice. You should squash and merge!