### PR TITLE
Proof-of-concept failing test case with attribute whitelisting

### DIFF
--- a/resources/whitelisted-attributes.xml
+++ b/resources/whitelisted-attributes.xml
@@ -1,0 +1,26 @@
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml">
+
+    <h:head>
+        <h:title>Simple Form</h:title>
+        <model>
+            <instance>
+                <data id="collect197test">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:',uuid())"/>
+        </model>
+    </h:head>
+
+    <h:body>
+        <group appearance="field-list">
+            <input ref="/data/meta/instanceID" rows="2">
+                <label>Instance ID:</label>
+            </input>
+        </group>
+    </h:body>
+
+</h:html>

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -1709,7 +1709,8 @@ public class XFormParser implements IXFormParserFunctions {
             "constraintMsg",
             "calculate",
             "preload",
-            "preloadParams"
+            "preloadParams",
+            "rows"
     ));
 
     protected void parseBind(Element element) {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -386,6 +386,11 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
+    @Test public void parseWithWhitelistedAttributes() throws IOException {
+      ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
+      assertThat(parseResult.errorMessages.size(), is(0));
+    }
+
     private TreeElement findDepthFirst(TreeElement parent, String name) {
         int len = parent.getNumChildren();
         for (int i = 0; i < len; ++i) {


### PR DESCRIPTION
DOESN'T CLOSE #236, status update:

The fix mentioned in the comments doesn't appear to fix it. Doing some more beginner-friendly searching around, I tracked down what I think is the issue to [here](https://github.com/opendatakit/javarosa/blob/6f06d8a60a9f6d9f1a1c5f0312b573ce54bab883/src/org/javarosa/xform/parse/XFormParser.java#L185). Because `parseControl()` isn't being called with `additionalUsedAtts`, the only allowed attributes are actually specified [here](https://github.com/opendatakit/javarosa/blob/6f06d8a60a9f6d9f1a1c5f0312b573ce54bab883/src/org/javarosa/xform/parse/XFormParser.java#L880).

I'll need to read the spec to better understand where it's appropriate to add these additional whitelisted elements, but if anyone else knows off the top of their head where they should go (or any suggestions at all, really), that's more than welcome!