### PR TITLE
bug #236: add attributes to appropriate whitelists

### DIFF
--- a/resources/whitelisted-attributes.xml
+++ b/resources/whitelisted-attributes.xml
@@ -1,0 +1,26 @@
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml">
+
+    <h:head>
+        <h:title>Simple Form</h:title>
+        <model>
+            <instance>
+                <data id="collect197test">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:',uuid())" requiredMsg="this is required" saveIncomplete="false"/>
+        </model>
+    </h:head>
+
+    <h:body>
+        <group appearance="field-list">
+            <input ref="/data/meta/instanceID" rows="2">
+                <label>Instance ID:</label>
+            </input>
+        </group>
+    </h:body>
+
+</h:html>

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -182,7 +182,9 @@ public class XFormParser implements IXFormParserFunctions {
         groupLevelHandlers = new HashMap<String, IElementHandler>() {{
             put("input", new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_INPUT);
+                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_INPUT,
+                            Arrays.asList("rows") // Prevent warning about unexpected attributes
+                    );
                 }
             });
             put("range", new IElementHandler() {
@@ -1709,7 +1711,9 @@ public class XFormParser implements IXFormParserFunctions {
             "constraintMsg",
             "calculate",
             "preload",
-            "preloadParams"
+            "preloadParams",
+            "requiredMsg",
+            "saveIncomplete"
     ));
 
     protected void parseBind(Element element) {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -386,6 +386,11 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
+    @Test public void parseWithWhitelistedAttributes() throws IOException {
+      ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
+      assertThat(parseResult.errorMessages.size(), is(0));
+    }
+
     private TreeElement findDepthFirst(TreeElement parent, String name) {
         int len = parent.getNumChildren();
         for (int i = 0; i < len; ++i) {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -386,7 +386,7 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
-    @Test public void parseWithWhitelistedAttributes() throws IOException {
+    @Test public void parsesWithWhitelistedAttributes() throws IOException {
       ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
       assertThat(parseResult.errorMessages.size(), is(0));
     }


### PR DESCRIPTION
- `saveIncomplete` and `requiredMsg` added to allowed bind node attribs
- `rows` added to allowed input attributes

Closes #236 

#### What has been done to verify that this works as intended?
Added a unit test that parses an example form with the additional attributes

#### Why is this the best possible solution? Were any other approaches considered?
Follows existing conventions

#### Are there any risks to merging this code? If so, what are they?
None that I can see!