### PR TITLE
Issue 164 add digest function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 
 # intellij
 .idea
+out
 
 # mvn
 target

--- a/src/org/javarosa/xpath/expr/DigestAlgorithm.java
+++ b/src/org/javarosa/xpath/expr/DigestAlgorithm.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.javarosa.xpath.XPathUnsupportedException;
+
+/**
+ * Implements the digest algorithms for XPathFuncExpr digest() function
+ */
+public enum DigestAlgorithm {
+  MD5("MD5"),
+  SHA1("SHA-1"),
+  SHA256("SHA-256"),
+  SHA384("SHA-384"),
+  SHA512("SHA-512");
+
+  private final String name;
+
+  DigestAlgorithm(String name) {
+    this.name = name;
+  }
+
+  private MessageDigest getDigestInstance() {
+    try {
+      return MessageDigest.getInstance(name);
+    } catch (NoSuchAlgorithmException e) {
+      // It’s unlikely that these algorithms would not all be implemented
+      throw new XPathUnsupportedException("digest(..., '" + name + "', ...)");
+    }
+  }
+
+  static DigestAlgorithm from(String name) {
+    try {
+      return valueOf(name.toUpperCase().replaceAll("-", ""));
+    } catch (IllegalArgumentException ex) {
+      throw new XPathUnsupportedException("digest(..., '" + name + "', ...)");
+    }
+  }
+
+  public String digest(String payload, Encoding encoding) {
+    return encoding.encode(getDigestInstance().digest(uncheckedGetUtf8Bytes(payload)));
+  }
+
+  private byte[] uncheckedGetUtf8Bytes(String payload) {
+    try {
+      // Use UTF-8 encoding when reading data to be hashed by default
+      return payload.getBytes("UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // It’s unlikely that UTF-8 would not be supported
+      throw new RuntimeException("The function digest failed to use UTF-8 encoding");
+    }
+  }
+
+}

--- a/src/org/javarosa/xpath/expr/Encoding.java
+++ b/src/org/javarosa/xpath/expr/Encoding.java
@@ -1,0 +1,38 @@
+package org.javarosa.xpath.expr;
+
+import javax.xml.bind.DatatypeConverter;
+import org.javarosa.xpath.XPathUnsupportedException;
+
+/**
+ * Implements the hash encoding methods for XPathFuncExpr digest() function
+ */
+enum Encoding {
+  HEX("hex") {
+    @Override
+    String encode(byte[] bytes) {
+      return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+    }
+  },
+  BASE64("base64") {
+    @Override
+    String encode(byte[] bytes) {
+      return DatatypeConverter.printBase64Binary(bytes);
+    }
+  };
+
+  private final String name;
+
+  Encoding(String name) {
+    this.name = name;
+  }
+
+  static Encoding from(String name) {
+    try {
+      return valueOf(name.toUpperCase());
+    } catch (IllegalArgumentException ex) {
+      throw new XPathUnsupportedException("digest(..., ..., '" + name + "')");
+    }
+  }
+
+  abstract String encode(byte[] bytes);
+}

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -470,7 +470,7 @@ public class XPathFuncExpr extends XPathExpression {
             try {
                 digest = MessageDigest.getInstance((String) argVals[1]);
             } catch (NoSuchAlgorithmException e) {
-                throw new XPathTypeMismatchException("The function digest received a non supported cryptographic hashing algorithm '"+ argVals[0] +"'. Valid values are MD5, SHA-1, SHA-256");
+                throw new XPathTypeMismatchException("The function digest received a non supported cryptographic hashing algorithm '" + argVals[1] + "'. Valid values are MD5, SHA-1, SHA-256");
             }
 
             // Use UTF-8 encoding when reading data to be hashed by default
@@ -980,7 +980,7 @@ public class XPathFuncExpr extends XPathExpression {
                  */
                 groupIdx = 1;
             }
-            
+
             contextRef.setMultiplicity(groupRef.size()-1, groupIdx-1);
         }
 
@@ -1388,7 +1388,7 @@ public class XPathFuncExpr extends XPathExpression {
             for(HashEncodingMethod candidate : values())
                 if (candidate.value.equals(value))
                     return candidate;
-            throw new XPathTypeMismatchException("Unsupported hash encoding algorithm \"\". Supported values are: \"hex\", \"base64\"");
+            throw new XPathTypeMismatchException("Unsupported hash encoding algorithm \"" + value + "\". Supported values are: \"hex\", \"base64\"");
         }
 
         abstract String encode(byte[] bytes);

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -16,10 +16,6 @@
 
 package org.javarosa.xpath.expr;
 
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import javax.xml.bind.DatatypeConverter;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
@@ -466,26 +462,10 @@ public class XPathFuncExpr extends XPathExpression {
 
             return GeoUtils.calculateAreaOfGPSPolygonOnEarthInSquareMeters(gpsCoordinatesList);
         } else if (name.equals("digest") && (args.length == 2 || args.length == 3)) {
-            MessageDigest digest;
-            try {
-                digest = MessageDigest.getInstance((String) argVals[1]);
-            } catch (NoSuchAlgorithmException e) {
-                throw new XPathTypeMismatchException("The function digest received a non supported cryptographic hashing algorithm '" + argVals[1] + "'. Valid values are MD5, SHA-1, SHA-256");
-            }
-
-            // Use UTF-8 encoding when reading data to be hashed by default
-            byte[] result;
-            try {
-                result = digest.digest(((String) argVals[0]).getBytes("UTF-8"));
-            } catch (UnsupportedEncodingException e) {
-                throw new XPathTypeMismatchException("The function digest failed to use UTF-8 encoding");
-            }
-
-            // Hash encoding method defaults to base64 if no third arg is received
-            HashEncodingMethod encodingMethod = args.length == 3
-                ? HashEncodingMethod.from((String) argVals[2])
-                : HashEncodingMethod.BASE64;
-            return encodingMethod.encode(result);
+            return DigestAlgorithm.from((String) argVals[1]).digest(
+                (String) argVals[0],
+                args.length == 3 ? Encoding.from((String)argVals[2]) : Encoding.BASE64
+            );
         } else {
             //check for custom handler
             IFunctionHandler handler = funcHandlers.get(name);
@@ -1361,36 +1341,4 @@ public class XPathFuncExpr extends XPathExpression {
 
     }
 
-    enum HashEncodingMethod {
-        HEX("hex") {
-            @Override
-            String encode(byte[] bytes) {
-                StringBuilder stringBuffer = new StringBuilder();
-                for (byte aResult : bytes)
-                    stringBuffer.append(Integer.toString((aResult & 0xff) + 0x100, 16).substring(1));
-                return stringBuffer.toString();
-            }
-        },
-        BASE64("base64") {
-            @Override
-            String encode(byte[] bytes) {
-                return DatatypeConverter.printBase64Binary(bytes);
-            }
-        };
-
-        private final String value;
-
-        HashEncodingMethod(String value) {
-            this.value = value;
-        }
-
-        static HashEncodingMethod from(String value) {
-            for(HashEncodingMethod candidate : values())
-                if (candidate.value.equals(value))
-                    return candidate;
-            throw new XPathTypeMismatchException("Unsupported hash encoding algorithm \"" + value + "\". Supported values are: \"hex\", \"base64\"");
-        }
-
-        abstract String encode(byte[] bytes);
-    }
 }

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -465,7 +465,7 @@ public class XPathFuncExpr extends XPathExpression {
             }
 
             return GeoUtils.calculateAreaOfGPSPolygonOnEarthInSquareMeters(gpsCoordinatesList);
-        } else if (name.equals("digest") && (args.length == 3)) {
+        } else if (name.equals("digest") && (args.length == 2 || args.length == 3)) {
             MessageDigest digest;
             try {
                 digest = MessageDigest.getInstance((String) argVals[1]);
@@ -481,7 +481,11 @@ public class XPathFuncExpr extends XPathExpression {
                 throw new XPathTypeMismatchException("The function digest failed to use UTF-8 encoding");
             }
 
-            return HashEncodingMethod.from((String) argVals[2]).encode(result);
+            // Hash encoding method defaults to base64 if no third arg is received
+            HashEncodingMethod encodingMethod = args.length == 3
+                ? HashEncodingMethod.from((String) argVals[2])
+                : HashEncodingMethod.BASE64;
+            return encodingMethod.encode(result);
         } else {
             //check for custom handler
             IFunctionHandler handler = funcHandlers.get(name);

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -19,6 +19,7 @@ package org.javarosa.xpath.expr;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import javax.xml.bind.DatatypeConverter;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
@@ -1364,6 +1365,12 @@ public class XPathFuncExpr extends XPathExpression {
                 for (byte aResult : bytes)
                     stringBuffer.append(Integer.toString((aResult & 0xff) + 0x100, 16).substring(1));
                 return stringBuffer.toString();
+            }
+        },
+        BASE64("base64") {
+            @Override
+            String encode(byte[] bytes) {
+                return DatatypeConverter.printBase64Binary(bytes);
             }
         };
 

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -16,6 +16,9 @@
 
 package org.javarosa.xpath.expr;
 
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
@@ -461,6 +464,23 @@ public class XPathFuncExpr extends XPathExpression {
             }
 
             return GeoUtils.calculateAreaOfGPSPolygonOnEarthInSquareMeters(gpsCoordinatesList);
+        } else if (name.equals("digest") && (args.length == 3)) {
+            MessageDigest digest;
+            try {
+                digest = MessageDigest.getInstance((String) argVals[1]);
+            } catch (NoSuchAlgorithmException e) {
+                throw new XPathTypeMismatchException("The function digest received a non supported cryptographic hashing algorithm '"+ argVals[0] +"'. Valid values are MD5, SHA-1, SHA-256");
+            }
+
+            // Use UTF-8 encoding when reading data to be hashed by default
+            byte[] result;
+            try {
+                result = digest.digest(((String) argVals[0]).getBytes("UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                throw new XPathTypeMismatchException("The function digest failed to use UTF-8 encoding");
+            }
+
+            return HashEncodingMethod.from((String) argVals[2]).encode(result);
         } else {
             //check for custom handler
             IFunctionHandler handler = funcHandlers.get(name);
@@ -1334,5 +1354,32 @@ public class XPathFuncExpr extends XPathExpression {
         //TODO: Inner eval here with eval'd args to improve speed
         return eval(model, evalContext);
 
+    }
+
+    enum HashEncodingMethod {
+        HEX("hex") {
+            @Override
+            String encode(byte[] bytes) {
+                StringBuilder stringBuffer = new StringBuilder();
+                for (byte aResult : bytes)
+                    stringBuffer.append(Integer.toString((aResult & 0xff) + 0x100, 16).substring(1));
+                return stringBuffer.toString();
+            }
+        };
+
+        private final String value;
+
+        HashEncodingMethod(String value) {
+            this.value = value;
+        }
+
+        static HashEncodingMethod from(String value) {
+            for(HashEncodingMethod candidate : values())
+                if (candidate.value.equals(value))
+                    return candidate;
+            throw new XPathTypeMismatchException("Unsupported hash encoding algorithm \"\". Supported values are: \"hex\", \"base64\"");
+        }
+
+        abstract String encode(byte[] bytes);
     }
 }

--- a/test/org/javarosa/xpath/expr/DigestAlgorithmTest.java
+++ b/test/org/javarosa/xpath/expr/DigestAlgorithmTest.java
@@ -1,0 +1,45 @@
+package org.javarosa.xpath.expr;
+
+
+import static org.javarosa.xpath.expr.DigestAlgorithm.MD5;
+import static org.javarosa.xpath.expr.DigestAlgorithm.SHA1;
+import static org.javarosa.xpath.expr.DigestAlgorithm.SHA256;
+import static org.javarosa.xpath.expr.DigestAlgorithm.SHA384;
+import static org.javarosa.xpath.expr.DigestAlgorithm.SHA512;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class DigestAlgorithmTest {
+  @Parameterized.Parameter(value = 0)
+  public String testName;
+
+  @Parameterized.Parameter(value = 1)
+  public DigestAlgorithm algorithm;
+
+  @Parameterized.Parameter(value = 2)
+  public String input;
+
+  @Parameterized.Parameter(value = 3)
+  public String expectedOutput;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"MD5", MD5, "some text", "552e21cd4cd9918678e3c1a0df491bc3"},
+        {"SHA-1", SHA1, "some text", "37aa63c77398d954473262e1a0057c1e632eda77"},
+        {"SHA-256", SHA256, "some text", "b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2"},
+        {"SHA-384", SHA384, "some text", "cc94ec3e9873c0b9a72486442958f671067cdf77b9427416d031440cc62041e2ee1344498447ec0ced9f7043461bd1f3"},
+        {"SHA-512", SHA512, "some text", "e2732baedca3eac1407828637de1dbca702c3fc9ece16cf536ddb8d6139cd85dfe7464b8235b29826f608ccf4ac643e29b19c637858a3d8710a59111df42ddb5"},
+    });
+  }
+
+  @Test
+  public void generates_a_digest() {
+    assertEquals(expectedOutput, algorithm.digest(input, Encoding.HEX));
+  }
+}

--- a/test/org/javarosa/xpath/expr/EncodingTest.java
+++ b/test/org/javarosa/xpath/expr/EncodingTest.java
@@ -1,8 +1,8 @@
 package org.javarosa.xpath.expr;
 
 
-import static org.javarosa.xpath.expr.XPathFuncExpr.HashEncodingMethod.BASE64;
-import static org.javarosa.xpath.expr.XPathFuncExpr.HashEncodingMethod.HEX;
+import static org.javarosa.xpath.expr.Encoding.BASE64;
+import static org.javarosa.xpath.expr.Encoding.HEX;
 import static org.junit.Assert.assertEquals;
 
 import java.io.UnsupportedEncodingException;
@@ -12,12 +12,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class HashEncodingMethodTest {
+public class EncodingTest {
   @Parameterized.Parameter(value = 0)
   public String testName;
 
   @Parameterized.Parameter(value = 1)
-  public XPathFuncExpr.HashEncodingMethod encodingMethod;
+  public Encoding encodingMethod;
 
   @Parameterized.Parameter(value = 2)
   public String input;

--- a/test/org/javarosa/xpath/expr/HashEncodingMethodTest.java
+++ b/test/org/javarosa/xpath/expr/HashEncodingMethodTest.java
@@ -1,18 +1,40 @@
 package org.javarosa.xpath.expr;
 
 
+import static org.javarosa.xpath.expr.XPathFuncExpr.HashEncodingMethod.BASE64;
 import static org.javarosa.xpath.expr.XPathFuncExpr.HashEncodingMethod.HEX;
 import static org.junit.Assert.assertEquals;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class HashEncodingMethodTest {
+  @Parameterized.Parameter(value = 0)
+  public String testName;
+
+  @Parameterized.Parameter(value = 1)
+  public XPathFuncExpr.HashEncodingMethod encodingMethod;
+
+  @Parameterized.Parameter(value = 2)
+  public String input;
+
+  @Parameterized.Parameter(value = 3)
+  public String expectedOutput;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"Hexadecimal", HEX, "some text", "736f6d652074657874"},
+        {"Base64", BASE64, "some text", "c29tZSB0ZXh0"},
+    });
+  }
+
   @Test
   public void encodes_byte_arrays() throws UnsupportedEncodingException {
-    assertEquals(
-        "3031323334353637383961626364656620736f6d652074657874",
-        HEX.encode("0123456789abcdef some text".getBytes("UTF-8"))
-    );
+    assertEquals(expectedOutput, encodingMethod.encode(input.getBytes("UTF-8")));
   }
 }

--- a/test/org/javarosa/xpath/expr/HashEncodingMethodTest.java
+++ b/test/org/javarosa/xpath/expr/HashEncodingMethodTest.java
@@ -1,0 +1,18 @@
+package org.javarosa.xpath.expr;
+
+
+import static org.javarosa.xpath.expr.XPathFuncExpr.HashEncodingMethod.HEX;
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import org.junit.Test;
+
+public class HashEncodingMethodTest {
+  @Test
+  public void encodes_byte_arrays() throws UnsupportedEncodingException {
+    assertEquals(
+        "3031323334353637383961626364656620736f6d652074657874",
+        HEX.encode("0123456789abcdef some text".getBytes("UTF-8"))
+    );
+  }
+}

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -511,6 +511,8 @@ public class XPathEvalTest extends TestCase {
 
         logTestCategory("crypto functions");
         testEval("digest('some text', 'MD5', 'hex')", "552e21cd4cd9918678e3c1a0df491bc3");
+        testEval("digest('some text', 'SHA-1', 'hex')", "37aa63c77398d954473262e1a0057c1e632eda77");
+        testEval("digest('some text', 'SHA-256', 'hex')", "b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2");
 
         //Attribute XPath References
         //testEval("/@blah", new XPathUnsupportedException());

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -509,6 +509,9 @@ public class XPathEvalTest extends TestCase {
         expected = createExpectedNodesetFromIndexedRepeatFunction(testInstance, 0, "name");
         testEval("indexed-repeat( /data/repeat/name , /data/repeat , /data/index1 )", testInstance, null, expected);
 
+        logTestCategory("crypto functions");
+        testEval("digest('some text', 'MD5', 'hex')", "552e21cd4cd9918678e3c1a0df491bc3");
+
         //Attribute XPath References
         //testEval("/@blah", new XPathUnsupportedException());
         //TODO: Need to test with model, probably in a different file

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -510,17 +510,16 @@ public class XPathEvalTest extends TestCase {
         testEval("indexed-repeat( /data/repeat/name , /data/repeat , /data/index1 )", testInstance, null, expected);
 
         logTestCategory("crypto functions");
-        testEval("digest('some text', 'MD5', 'hex')", "552e21cd4cd9918678e3c1a0df491bc3");
-        testEval("digest('some text', 'SHA-1', 'hex')", "37aa63c77398d954473262e1a0057c1e632eda77");
-        testEval("digest('some text', 'SHA-256', 'hex')", "b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2");
+        // Support for all 5 supported digest algorithms (required and optional) and default base64 encoding
         testEval("digest('some text', 'MD5', 'base64')", "VS4hzUzZkYZ448Gg30kbww==");
         testEval("digest('some text', 'SHA-1', 'base64')", "N6pjx3OY2VRHMmLhoAV8HmMu2nc=");
         testEval("digest('some text', 'SHA-256', 'base64')", "uU9vElx546X/qoJvWEwQ1SraZp5nYgUbgmtVd20FrtI=");
-        testEval("digest('abc', 'SHA-1', 'hex')", "a9993e364706816aba3e25717850c26c9cd0d89d");
-        testEval("digest('abc', 'MD5', 'hex')", "900150983cd24fb0d6963f7d28e17f72");
-        testEval("digest('abc', 'SHA-256', 'hex')", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
-        // Third arg is optional and defaults to 'base64'
-        testEval("digest('some text', 'SHA-1')", "N6pjx3OY2VRHMmLhoAV8HmMu2nc=");
+        testEval("digest('some text', 'SHA-384', 'base64')", "zJTsPphzwLmnJIZEKVj2cQZ833e5QnQW0DFEDMYgQeLuE0RJhEfsDO2fcENGG9Hz");
+        testEval("digest('some text', 'SHA-512', 'base64')", "4nMrrtyj6sFAeChjfeHbynAsP8ns4Wz1Nt241hOc2F3+dGS4I1spgm9gjM9KxkPimxnGN4WKPYcQpZER30LdtQ==");
+        // Support for hexadecimal encoding
+        testEval("digest('some text', 'MD5', 'hex')", "552e21cd4cd9918678e3c1a0df491bc3");
+        // Support for optional third argument (defaults to 'base64')
+        testEval("digest('some text', 'MD5')", "VS4hzUzZkYZ448Gg30kbww==");
 
         //Attribute XPath References
         //testEval("/@blah", new XPathUnsupportedException());

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -516,6 +516,10 @@ public class XPathEvalTest extends TestCase {
         testEval("digest('some text', 'MD5', 'base64')", "VS4hzUzZkYZ448Gg30kbww==");
         testEval("digest('some text', 'SHA-1', 'base64')", "N6pjx3OY2VRHMmLhoAV8HmMu2nc=");
         testEval("digest('some text', 'SHA-256', 'base64')", "uU9vElx546X/qoJvWEwQ1SraZp5nYgUbgmtVd20FrtI=");
+        testEval("digest('abc', 'SHA-1', 'hex')", "a9993e364706816aba3e25717850c26c9cd0d89d");
+        testEval("digest('abc', 'MD5', 'hex')", "900150983cd24fb0d6963f7d28e17f72");
+        testEval("digest('abc', 'SHA-256', 'hex')", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+
 
         //Attribute XPath References
         //testEval("/@blah", new XPathUnsupportedException());

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -519,7 +519,8 @@ public class XPathEvalTest extends TestCase {
         testEval("digest('abc', 'SHA-1', 'hex')", "a9993e364706816aba3e25717850c26c9cd0d89d");
         testEval("digest('abc', 'MD5', 'hex')", "900150983cd24fb0d6963f7d28e17f72");
         testEval("digest('abc', 'SHA-256', 'hex')", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
-
+        // Third arg is optional and defaults to 'base64'
+        testEval("digest('some text', 'SHA-1')", "N6pjx3OY2VRHMmLhoAV8HmMu2nc=");
 
         //Attribute XPath References
         //testEval("/@blah", new XPathUnsupportedException());

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -513,6 +513,9 @@ public class XPathEvalTest extends TestCase {
         testEval("digest('some text', 'MD5', 'hex')", "552e21cd4cd9918678e3c1a0df491bc3");
         testEval("digest('some text', 'SHA-1', 'hex')", "37aa63c77398d954473262e1a0057c1e632eda77");
         testEval("digest('some text', 'SHA-256', 'hex')", "b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2");
+        testEval("digest('some text', 'MD5', 'base64')", "VS4hzUzZkYZ448Gg30kbww==");
+        testEval("digest('some text', 'SHA-1', 'base64')", "N6pjx3OY2VRHMmLhoAV8HmMu2nc=");
+        testEval("digest('some text', 'SHA-256', 'base64')", "uU9vElx546X/qoJvWEwQ1SraZp5nYgUbgmtVd20FrtI=");
 
         //Attribute XPath References
         //testEval("/@blah", new XPathUnsupportedException());


### PR DESCRIPTION
Closes #164 

This PR adds a minimal implementation of the `digest()` function, defined in the [XForms 1.1 specs](https://www.w3.org/TR/xforms/#fn-digest).

- It supports the required MD5, SHA-1, and SHA-256 hashing algorithms
- It supports hexadecimal and base64 hash encoding methods

#### What has been done to verify that this works as intended?
Create new test cases for the `digest()` function in `XPathEvalTest`, including specific examples from the XForms 1.1 specs.

I didn't create failure tests (passing an unsupported hashing algorithm or encoding method).

#### Why is this the best possible solution? Were any other approaches considered?
This is a straightforward implementation, using basic Java7 features.

#### Are there any risks to merging this code? If so, what are they?
None that I'm aware of.