### PR TITLE
Issue 36 constraint msg output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 
 # intellij
 .idea
+out
 
 # mvn
 target

--- a/resources/constraint-message-error.xml
+++ b/resources/constraint-message-error.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>constraintMessageError</h:title>
+    <model>
+      <itext>
+        <translation lang="English">
+          <text id="/constraintMessageError/age:jr:constraintMsg">
+            <value>Child's age must be between <output value=" /constraintMessageError/ageSet "/> months</value>
+          </text>
+          <text id="/constraintMessageError/age:label">
+            <value>Child's age in months</value>
+          </text>
+          <text id="/constraintMessageError/ageSetNote:label">
+            <value>Please only conduct this survey with children aged <output value=" /constraintMessageError/ageSet "/> MONTHS.</value>
+          </text>
+          <text id="/constraintMessageError/village:label">
+            <value>Village</value>
+          </text>
+        </translation>
+      </itext>
+      <instance>
+        <constraintMessageError id="constraintMessageError">
+          <village/>
+          <ageSet/>
+          <monthsUpper/>
+          <ageSetNote/>
+          <age/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </constraintMessageError>
+      </instance>
+      <bind nodeset="/constraintMessageError/village" type="select1"/>
+
+      <bind calculate="if( /constraintMessageError/village &lt;5, &quot;6 TO 24&quot;, &quot;6 TO 59&quot;)" nodeset="/constraintMessageError/ageSet" type="string"/>
+
+      <bind calculate="if( /constraintMessageError/ageSet =&quot;6 TO 24&quot;, 24, 59)" nodeset="/constraintMessageError/monthsUpper" type="int"/>
+
+      <bind nodeset="/constraintMessageError/ageSetNote" readonly="true()" type="string"/>
+
+      <bind constraint=".&gt;=6 and .&lt;= /constraintMessageError/monthsUpper " jr:constraintMsg="jr:itext('/constraintMessageError/ageSetNote:label')" nodeset="/constraintMessageError/age" type="int"/>
+
+      <bind calculate="concat('uuid:', uuid())" nodeset="/constraintMessageError/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <select1 ref="/constraintMessageError/village">
+      <label ref="jr:itext('/constraintMessageError/village:label')"/>
+      <hint>Depending on which village is chosen, the child's age will be accepted either between 6-24 months or 6-59 months.</hint>
+      <item>
+        <label>Village 1</label>
+        <value>1</value>
+      </item>
+      <item>
+        <label>Village 2</label>
+        <value>2</value>
+      </item>
+      <item>
+        <label>Village 3</label>
+        <value>3</value>
+      </item>
+      <item>
+        <label>Village 4</label>
+        <value>4</value>
+      </item>
+      <item>
+        <label>Village 5</label>
+        <value>5</value>
+      </item>
+      <item>
+        <label>Village 6</label>
+        <value>6</value>
+      </item>
+      <item>
+        <label>Village 7</label>
+        <value>7</value>
+      </item>
+      <item>
+        <label>Village 8</label>
+        <value>8</value>
+      </item>
+    </select1>
+    <input ref="/constraintMessageError/ageSetNote">
+      <label ref="jr:itext('/constraintMessageError/ageSetNote:label')"/>
+      <hint>This displays the age range correctly in a note.</hint>
+    </input>
+    <input ref="/constraintMessageError/age">
+      <label ref="jr:itext('/constraintMessageError/age:label')"/>
+      <hint>(Enter e.g. 60 to see constraint message with error)</hint>
+    </input>
+  </h:body>
+</h:html>

--- a/src/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/org/javarosa/form/api/FormEntryPrompt.java
@@ -217,7 +217,9 @@ public class FormEntryPrompt extends FormEntryCaption {
                 ec.isConstraint = true;
                 ec.candidateValue = attemptedValue;
             }
-            return mTreeElement.getConstraint().getConstraintMessage(ec, form.getMainInstance(), textForm);
+            String constraintMessage = mTreeElement.getConstraint().getConstraintMessage(ec, form.getMainInstance(), textForm);
+
+            return substituteStringArgs(constraintMessage);
         }
     }
 

--- a/test/org/javarosa/core/form/api/test/OutputInComputedConstraintTextTest.java
+++ b/test/org/javarosa/core/form/api/test/OutputInComputedConstraintTextTest.java
@@ -1,0 +1,86 @@
+package org.javarosa.core.form.api.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import org.javarosa.core.PathConst;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.IFormElement;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.data.LongData;
+import org.javarosa.core.services.PrototypeManager;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryCaption;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OutputInComputedConstraintTextTest {
+  static {
+    PrototypeManager.registerPrototype("org.javarosa.model.xform.XPathReference");
+  }
+
+  private Map<String, FormIndex> formIndexesById = new HashMap<>();
+  private FormDef formDef;
+  private FormEntryController ctrl;
+  private FormEntryModel model;
+
+  @Before
+  public void setUp() {
+    FormParseInit fpi = new FormParseInit();
+    fpi.setFormToParse((new File(PathConst.getTestResourcePath(), "constraint-message-error.xml")).getAbsolutePath());
+    formDef = fpi.getFormDef();
+    formDef.getLocalizer().setLocale("English");
+    ctrl = fpi.getFormEntryController();
+    model = fpi.getFormEntryModel();
+    buildIndexes();
+  }
+
+  @Test
+  public void testComputedQuestionText() {
+    // Answer first question to check label and constraint texts on next questions
+    ctrl.answerQuestion(getFormIndex("/constraintMessageError/village:label"), new LongData(1), true);
+
+    assertEquals(
+        "Please only conduct this survey with children aged 6 TO 24 MONTHS.",
+        getFormEntryPrompt("/constraintMessageError/ageSetNote:label").getQuestionText()
+    );
+  }
+
+  @Test
+  public void testComputedConstraintText() {
+    // Answer first question to check label and constraint texts on next questions
+    ctrl.answerQuestion(getFormIndex("/constraintMessageError/village:label"), new LongData(1), true);
+
+    assertEquals(
+        "Please only conduct this survey with children aged 6 TO 24 MONTHS.",
+        getFormEntryPrompt("/constraintMessageError/age:label").getConstraintText()
+    );
+  }
+
+  private void buildIndexes() {
+    ctrl.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+    do {
+      FormEntryCaption fep = model.getCaptionPrompt();
+      IFormElement formElement = fep.getFormElement();
+      if (formElement instanceof QuestionDef)
+        formIndexesById.put(formElement.getTextID(), fep.getIndex());
+    } while (ctrl.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
+  }
+
+  private FormIndex getFormIndex(String id) {
+    if (formIndexesById.containsKey(id))
+      return formIndexesById.get(id);
+    throw new RuntimeException("FormIndex with id \"" + id + "\" not found");
+  }
+
+  private FormEntryPrompt getFormEntryPrompt(String id) {
+    return new FormEntryPrompt(formDef, getFormIndex(id));
+  }
+
+}

--- a/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
+++ b/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
@@ -1,4 +1,4 @@
-package org.javarosa.core.form.api.test;
+package org.javarosa.form.api;
 
 import static org.junit.Assert.assertEquals;
 
@@ -13,10 +13,6 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.LongData;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.test.FormParseInit;
-import org.javarosa.form.api.FormEntryCaption;
-import org.javarosa.form.api.FormEntryController;
-import org.javarosa.form.api.FormEntryModel;
-import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Closes #36

Thir PR changes `FormEntryPrompt` to mirror what's done in `FormEntryCaption.getQuestionText(String textID)` to substitute variables inside a constraint text.

#### What has been done to verify that this works as intended?
TDD'ed the development with a new `OutputInComputedConstraintTextTest` test class that covers the change.

#### Why is this the best possible solution? Were any other approaches considered?
It is the simplest solution I've been able to come up with.

#### Are there any risks to merging this code? If so, what are they?
None that I know of.