### PR TITLE
Issue 256 Remove javax

### DIFF
--- a/src/org/javarosa/xpath/expr/Encoding.java
+++ b/src/org/javarosa/xpath/expr/Encoding.java
@@ -1,6 +1,6 @@
 package org.javarosa.xpath.expr;
 
-import javax.xml.bind.DatatypeConverter;
+import java.io.UnsupportedEncodingException;
 import org.javarosa.xpath.XPathUnsupportedException;
 
 /**
@@ -10,13 +10,52 @@ enum Encoding {
   HEX("hex") {
     @Override
     String encode(byte[] bytes) {
-      return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+      StringBuilder sb = new StringBuilder(bytes.length * 2);
+      for (byte b : bytes) {
+        sb.append(HEX_TBL[(b >> 4) & 0xF]);
+        sb.append(HEX_TBL[(b & 0xF)]);
+      }
+      return sb.toString();
     }
   },
   BASE64("base64") {
     @Override
-    String encode(byte[] bytes) {
-      return DatatypeConverter.printBase64Binary(bytes);
+    String encode(byte[] sArr) {
+      // Copied from: https://github.com/brsanthu/migbase64/blob/master/src/main/java/com/migcomponents/migbase64/Base64.java
+      // Irrelevant after Java8
+      int sLen = sArr.length;
+      int sOff = 0;
+
+      if (sLen == 0)
+        return "";
+
+      int eLen = (sLen / 3) * 3;
+      int dLen = ((sLen - 1) / 3 + 1) << 2;
+      byte[] dArr = new byte[dLen];
+
+      for (int s = sOff, d = 0; s < sOff + eLen; ) {
+        int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
+        dArr[d++] = (byte) BASE_64_TBL[(i >>> 18) & 0x3f];
+        dArr[d++] = (byte) BASE_64_TBL[(i >>> 12) & 0x3f];
+        dArr[d++] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
+        dArr[d++] = (byte) BASE_64_TBL[i & 0x3f];
+      }
+
+      int left = sLen - eLen;
+      if (left > 0) {
+        int i = ((sArr[sOff + eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sOff + sLen - 1] & 0xff) << 2) : 0);
+        dArr[dLen - 4] = (byte) BASE_64_TBL[i >> 12];
+        dArr[dLen - 3] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
+        dArr[dLen - 2] = left == 2 ? (byte) BASE_64_TBL[i & 0x3f] : (byte) '=';
+        dArr[dLen - 1] = '=';
+      }
+
+      try {
+        return new String(dArr, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        // It’s unlikely that UTF-8 would not be supported
+        throw new RuntimeException("Encoding to base64 failed to use UTF-8");
+      }
     }
   };
 
@@ -33,6 +72,10 @@ enum Encoding {
       throw new XPathUnsupportedException("digest(..., ..., '" + name + "')");
     }
   }
+
+  private static final char[] HEX_TBL = "0123456789abcdef".toCharArray();
+
+  private static final char[] BASE_64_TBL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
 
   abstract String encode(byte[] bytes);
 }

--- a/test/org/javarosa/xpath/expr/EncodingTest.java
+++ b/test/org/javarosa/xpath/expr/EncodingTest.java
@@ -29,7 +29,9 @@ public class EncodingTest {
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][]{
         {"Hexadecimal", HEX, "some text", "736f6d652074657874"},
+        {"Hexadecimal (empty string)", HEX, "", ""},
         {"Base64", BASE64, "some text", "c29tZSB0ZXh0"},
+        {"Base64 (empty string)", BASE64, "", ""},
     });
   }
 


### PR DESCRIPTION
Closes #256 

This PR removes the dependency on javax components for encoding to hexadecimal and base64.

#### What has been done to verify that this works as intended?
Ran the automated tests that were already covering the implementation (Refactoring, yay!)

#### Why is this the best possible solution? Were any other approaches considered?
There are tons of implementations of encoders for Java7. I've chosen the ones that were advertised as being fast and efficient.

#### Are there any risks to merging this code? If so, what are they?
None