### PR TITLE
Issue 152 slf4j migration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 
 # intellij
 .idea
+*.iml
 out
 
 # mvn

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ out
 # mvn
 target
 secrets.xml
+
+# logging
+logback.xml
+logback-test.xml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ sourceSets {
     }
 }
 
+compileJava {
+    options.compilerArgs << "-Xlint:deprecation"
+}
+
+compileTestJava {
+    options.compilerArgs << "-Xlint:deprecation"
+}
+
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,10 @@ sourceCompatibility = '1.7'
 
 dependencies {
     // Be sure to update dependencies in pom.xml to match
-    compileOnly group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    compileOnly group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
+    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,17 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/resources/logback-test.xml.example
+++ b/resources/logback-test.xml.example
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/org/javarosa/core/api/ILogger.java
+++ b/src/org/javarosa/core/api/ILogger.java
@@ -15,38 +15,71 @@
  */
 
 /**
- * 
+ *
  */
 package org.javarosa.core.api;
 
+import java.io.IOException;
+import java.util.Date;
 import org.javarosa.core.log.IFullLogSerializer;
 import org.javarosa.core.log.StreamLogSerializer;
 
-import java.io.IOException;
-import java.util.Date;
-
 /**
+ * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
+ *
  * IIncidentLogger's are used for instrumenting applications to identify usage
  * patterns, usability errors, and general trajectories through applications.
- * 
- * @author Clayton Sims
- * @date Apr 10, 2009 
  *
+ * @author Clayton Sims
+ * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
  */
+@Deprecated
 public interface ILogger {
-
+    /**
+     * @deprecated Use {@link org.slf4j.Logger#info} instead
+     */
+    @Deprecated
     public void log(String type, String message, Date logDate);
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public void clearLogs();
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public <T> T serializeLogs(IFullLogSerializer<T> serializer);
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public void serializeLogs(StreamLogSerializer serializer) throws IOException;
+
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public void serializeLogs(StreamLogSerializer serializer, int limit) throws IOException;
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public void panic();
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public int logSize();
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger} instead
+     */
+    @Deprecated
     public void halt();
 }

--- a/src/org/javarosa/core/io/Std.java
+++ b/src/org/javarosa/core/io/Std.java
@@ -3,16 +3,24 @@ package org.javarosa.core.io;
 import java.io.PrintStream;
 
 /**
+ * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
  * Used to break dependency directly on System.out and System.err.
+ *
+ * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
  */
+@Deprecated
 public class Std {
 
+    @Deprecated
     public static PrintStream out = System.out;
+    @Deprecated
     public static PrintStream err = System.err;
 
     /**
      * Use this to replace stdout in case anything more than assignment is necessary in the future.
+     *
      * @param out
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
      */
     public static void setOut(PrintStream out) {
         Std.out = out;
@@ -20,12 +28,17 @@ public class Std {
 
     /**
      * Use this to replace stderr in case anything more than assignment is necessary in the future.
+     *
      * @param err
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
      */
     public static void setErr(PrintStream err) {
         Std.err = err;
     }
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger#error(String, Throwable)} instead
+     */
     public static void printStack(Throwable t) {
         t.printStackTrace(Std.err);
     }

--- a/src/org/javarosa/core/io/StreamsUtil.java
+++ b/src/org/javarosa/core/io/StreamsUtil.java
@@ -7,23 +7,22 @@ import java.io.OutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * <b>Warning</b>: This class is unused and should remain that way. It will be removed in a future release.
+ *
+ * @deprecated
+ */
+@Deprecated
 public class StreamsUtil {
-    private static final Logger logger = LoggerFactory.getLogger(StreamsUtil.class);
-
     private StreamsUtil() {
-        // private constructor
     }
 
     /**
      *
      * Write everything from input stream to output stream, byte by byte then
      * close the streams
-     *
-     *
-     * @param in
-     * @param out
-     * @throws IOException
      */
+    @Deprecated
     public static void writeFromInputToOutput(InputStream in, OutputStream out, long[] tally) throws InputIOException, OutputIOException {
         //TODO: God this is naive
         int val;
@@ -47,10 +46,12 @@ public class StreamsUtil {
         }
     }
 
+    @Deprecated
     public static void writeFromInputToOutputSpecific(InputStream in, OutputStream out) throws InputIOException, OutputIOException {
         writeFromInputToOutput(in, out, null);
     }
 
+    @Deprecated
     public static void writeFromInputToOutput(InputStream in, OutputStream out) throws IOException {
         try {
             writeFromInputToOutput(in, out, null);
@@ -64,13 +65,9 @@ public class StreamsUtil {
     private static final int CHUNK_SIZE = 2048;
 
     /**
-     *
      * Write the byte array to the output stream
-     *
-     * @param bytes
-     * @param out
-     * @throws IOException
      */
+    @Deprecated
     public static void writeToOutput(byte[] bytes, OutputStream out, long[] tally) throws IOException {
         int offset = 0;
         int remain = bytes.length;
@@ -86,6 +83,7 @@ public class StreamsUtil {
         }
     }
 
+    @Deprecated
     public static void writeToOutput(byte[] bytes, OutputStream out) throws IOException {
         writeToOutput(bytes, out, null);
     }
@@ -97,15 +95,10 @@ public class StreamsUtil {
     }
 
     /**
-     *
      * Read bytes from an input stream into a byte array then close the input
      * stream
-     *
-     * @param in
-     * @param len
-     * @return
-     * @throws IOException
      */
+    @Deprecated
     public static byte[] readFromStream(InputStream in, int len)
             throws IOException {
 
@@ -152,11 +145,13 @@ public class StreamsUtil {
 
         IOException internal;
 
+        @Deprecated
         public DirectionalIOException(IOException internal) {
             super(internal.getMessage());
             this.internal = internal;
         }
 
+        @Deprecated
         public IOException getWrapped() {
             return internal;
         }
@@ -164,23 +159,21 @@ public class StreamsUtil {
         //TODO: Override all common methodss
     }
 
+    @Deprecated
     public class InputIOException extends DirectionalIOException{
-        /**
-         *
-         */
         private static final long serialVersionUID = 5939766950738216779L;
 
+        @Deprecated
         public InputIOException(IOException internal) {
             super(internal);
         }
     }
 
+    @Deprecated
     public class OutputIOException extends DirectionalIOException{
-        /**
-         *
-         */
         private static final long serialVersionUID = -1816322555490749440L;
 
+        @Deprecated
         public OutputIOException(IOException internal) {
             super(internal);
         }

--- a/src/org/javarosa/core/io/StreamsUtil.java
+++ b/src/org/javarosa/core/io/StreamsUtil.java
@@ -4,8 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * <b>Warning</b>: This class is unused and should remain that way. It will be removed in a future release.

--- a/src/org/javarosa/core/io/StreamsUtil.java
+++ b/src/org/javarosa/core/io/StreamsUtil.java
@@ -4,8 +4,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StreamsUtil {
+    private static final Logger logger = LoggerFactory.getLogger(StreamsUtil.class);
 
     private StreamsUtil() {
         // private constructor
@@ -156,10 +159,6 @@ public class StreamsUtil {
 
         public IOException getWrapped() {
             return internal;
-        }
-
-        public void printStackTrace()  {
-            Std.printStack(internal);
         }
 
         //TODO: Override all common methodss

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -1428,7 +1428,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 metadata.put(field, getMetaData(field));
             } catch (NullPointerException npe) {
                 if (getMetaData(field) == null) {
-                    Std.out.println("ERROR! XFORM MUST HAVE A NAME!");
+                    Std.err.println("ERROR! XFORM MUST HAVE A NAME!");
                     Std.printStack(npe);
                 }
             }

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -57,7 +57,6 @@ import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xform.parse.XFormParseException;
-import org.javarosa.xform.parse.XFormParserReporter;
 import org.javarosa.xform.util.XFormAnswerDataSerializer;
 import org.javarosa.xpath.XPathException;
 
@@ -650,10 +649,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * Report any dependency cycles based upon the triggerIndex array.
      * (Does not require that the DAG be finalized).
      *
-     * @param reporter
      */
-    public void reportDependencyCycles(XFormParserReporter reporter) {
-        dagImpl.reportDependencyCycles(reporter);
+    public void reportDependencyCycles() {
+        dagImpl.reportDependencyCycles();
     }
 
     /**

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -16,7 +16,6 @@
 
 package org.javarosa.core.model;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.model.IDag.EventNotifierAccessor;
 import org.javarosa.core.model.condition.Condition;
@@ -72,6 +71,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Definition of a form. This has some meta data about the form definition and a
@@ -80,6 +81,8 @@ import java.util.NoSuchElementException;
  * @author Daniel Kayiwa, Drew Roos
  */
 public class FormDef implements IFormElement, Localizable, Persistable, IMetaData {
+    private static final Logger logger = LoggerFactory.getLogger(FormDef.class);
+
     public static final String STORAGE_KEY = "FORMDEF";
     public static final int TEMPLATING_RECURSION_LIMIT = 10;
 
@@ -926,7 +929,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                     try {
                         ix = Integer.parseInt(argName);
                     } catch (NumberFormatException nfe) {
-                        Std.err.println("Warning: expect arguments to be numeric [" + argName + "]");
+                        logger.warn("expect arguments to be numeric [{}]", argName);
                     }
 
                     if (ix < 0 || ix >= outputFragments.size())
@@ -1033,10 +1036,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             // to chose from if the user hasn't filled them out. So I'm just going
             // to make a note of this
             // and not throw an exception.
-            Std.out
-                    .println("Dynamic select question has no choices! ["
-                            + itemset.nodesetRef
-                            + "]. If this occurs while filling out a form (and not while saving an incomplete form), the filter condition may have eliminated all the choices. Is that what you intended?\n");
+            logger.info("Dynamic select question has no choices! [{}]. If this occurs while " +
+                "filling out a form (and not while saving an incomplete form), the filter " +
+                "condition may have eliminated all the choices. Is that what you intended?"
+                , itemset.nodesetRef);
 
         }
 
@@ -1428,8 +1431,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 metadata.put(field, getMetaData(field));
             } catch (NullPointerException npe) {
                 if (getMetaData(field) == null) {
-                    Std.err.println("ERROR! XFORM MUST HAVE A NAME!");
-                    Std.printStack(npe);
+                    logger.error("ERROR! XFORM MUST HAVE A NAME!", npe);
                 }
             }
         }

--- a/src/org/javarosa/core/model/GroupDef.java
+++ b/src/org/javarosa/core/model/GroupDef.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
@@ -35,6 +34,8 @@ import org.javarosa.core.util.externalizable.ExtWrapListPoly;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** The definition of a group in a form or questionaire.
  *
@@ -42,6 +43,8 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  *
  */
 public class GroupDef implements IFormElement, Localizable {
+    private static final Logger logger = LoggerFactory.getLogger(GroupDef.class);
+
     private List<IFormElement> children;    /** A list of questions on a group. */
     private boolean repeat;  /** True if this is a "repeat", false if it is a "group" */
     private int id;    /** The group number. */
@@ -264,7 +267,7 @@ public class GroupDef implements IFormElement, Localizable {
             return;
         }
         if(DateUtils.stringContains(textID,";")){
-            Std.err.println("Warning: TextID contains ;form modifier:: \""+textID.substring(textID.indexOf(";"))+"\"... will be stripped.");
+            logger.warn("TextID contains ;form modifier:: \"{}\"... will be stripped.", textID.substring(textID.indexOf(";")));
             textID=textID.substring(0, textID.indexOf(";")); //trim away the form specifier
         }
         this.textID = textID;

--- a/src/org/javarosa/core/model/IDag.java
+++ b/src/org/javarosa/core/model/IDag.java
@@ -16,7 +16,6 @@
 
 package org.javarosa.core.model;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.FormDef.EvalBehavior;
 import org.javarosa.core.model.condition.Condition;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -30,7 +29,6 @@ import org.javarosa.debug.Event;
 import org.javarosa.debug.EventNotifier;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.model.xform.XPathReference;
-import org.javarosa.xform.parse.XFormParserReporter;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -44,6 +42,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.javarosa.xform.parse.XFormParserReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract interface of the DAG management and triggerable processing logic.
@@ -55,6 +56,7 @@ import java.util.Set;
  *
  */
 public abstract class IDag {
+    private static final Logger logger = LoggerFactory.getLogger(IDag.class);
 
     public interface EventNotifierAccessor {
         public EventNotifier getEventNotifier();
@@ -316,18 +318,18 @@ public abstract class IDag {
                 qt.t.print(w);
             }
         } catch (UnsupportedEncodingException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
         } catch (FileNotFoundException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
         } catch (IOException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
         } finally {
             if (w != null) {
                 try {
                     w.flush();
                     w.close();
                 } catch (IOException e) {
-                    Std.printStack(e);
+                    logger.error("Error", e);
                 }
             }
         }
@@ -467,9 +469,9 @@ public abstract class IDag {
             TreeReference[] edge = edges.get(i);
             b.append(edge[0].toString()).append(" => ").append(edge[1].toString()).append("\n");
          }
-         reporter.error(b.toString());
+          logger.error("XForm Parse Error: {}", b.toString());
 
-         throw new RuntimeException("Dependency cycles amongst the xpath expressions in relevant/calculate");
+          throw new RuntimeException("Dependency cycles amongst the xpath expressions in relevant/calculate");
       }
    }
 

--- a/src/org/javarosa/core/model/IDag.java
+++ b/src/org/javarosa/core/model/IDag.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.javarosa.xform.parse.XFormParserReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -403,7 +402,7 @@ public abstract class IDag {
       return recalculates;
    }
 
-   public final void reportDependencyCycles (XFormParserReporter reporter) {
+   public final void reportDependencyCycles() {
       HashSet<TreeReference> vertices = new HashSet<TreeReference>();
       ArrayList<TreeReference[]> edges = new ArrayList<TreeReference[]>();
 

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -5,7 +5,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.condition.IConditionExpr;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
@@ -21,8 +20,11 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xpath.XPathConditional;
 import org.javarosa.xpath.expr.XPathPathExpr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ItemsetBinding implements Externalizable, Localizable {
+    private static final Logger logger = LoggerFactory.getLogger(ItemsetBinding.class);
 
     /**
      * note that storing both the ref and expr for everything is kind of redundant, but we're forced
@@ -56,7 +58,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
 
     public void setChoices (List<SelectChoice> choices, Localizer localizer) {
         if (this.choices != null) {
-            Std.out.println("warning: previous choices not cleared out");
+            logger.warn("previous choices not cleared out");
             clearChoices();
         }
         this.choices = choices;

--- a/src/org/javarosa/core/model/QuestionDef.java
+++ b/src/org/javarosa/core/model/QuestionDef.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.osm.OSMTag;
@@ -34,6 +33,8 @@ import org.javarosa.core.util.externalizable.ExtWrapList;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The definition of a Question to be presented to users when
@@ -48,6 +49,8 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  *
  */
 public class QuestionDef implements IFormElement, Localizable {
+    private static final Logger logger = LoggerFactory.getLogger(QuestionDef.class);
+
     private int id;
     private IDataReference binding;    /** reference to a location in the model to store data in */
 
@@ -371,7 +374,7 @@ public class QuestionDef implements IFormElement, Localizable {
     @Override
     public void setTextID(String textID) {
         if(DateUtils.stringContains(textID,";")){
-            Std.err.println("Warning: TextID contains ;form modifier:: \""+textID.substring(textID.indexOf(";"))+"\"... will be stripped.");
+            logger.warn("TextID contains ;form modifier:: \"{}\"... will be stripped.", textID.substring(textID.indexOf(";")));
             textID=textID.substring(0, textID.indexOf(";")); //trim away the form specifier
         }
         this.textID = textID;

--- a/src/org/javarosa/core/model/condition/Constraint.java
+++ b/src/org/javarosa/core/model/condition/Constraint.java
@@ -17,7 +17,8 @@
 package org.javarosa.core.model.condition;
 
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.services.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
@@ -31,6 +32,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 public class Constraint implements Externalizable {
+    private static final Logger logger = LoggerFactory.getLogger(Constraint.class);
     public IConditionExpr constraint;
     private String constraintMsg;
     private XPathExpression xPathConstraintMsg;
@@ -59,7 +61,7 @@ public class Constraint implements Externalizable {
                 }
                 return null;
             } catch(Exception e) {
-                Logger.exception("Error evaluating a valid-looking constraint xpath ", e);
+                logger.error("Error evaluating a valid-looking constraint xpath ", e);
                 return constraintMsg;
             }
         }

--- a/src/org/javarosa/core/model/instance/utils/ModelReferencePayload.java
+++ b/src/org/javarosa/core/model/instance/utils/ModelReferencePayload.java
@@ -24,7 +24,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.utils.IInstanceSerializingVisitor;
 import org.javarosa.core.services.storage.IStorageUtility;
@@ -33,6 +32,8 @@ import org.javarosa.core.services.transport.payload.IDataPayload;
 import org.javarosa.core.services.transport.payload.IDataPayloadVisitor;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The ModelReferencePayload essentially provides a wrapper functionality
@@ -45,6 +46,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  *
  */
 public class ModelReferencePayload implements IDataPayload {
+    private static final Logger logger = LoggerFactory.getLogger(ModelReferencePayload.class);
 
     int recordId;
     IDataPayload payload;
@@ -131,7 +133,7 @@ public class ModelReferencePayload implements IDataPayload {
                 payload = serializer.createSerializedPayload(tree);
             } catch (IOException e) {
                 //Assertion, do not catch!
-                Std.printStack(e);
+                logger.error("Error", e);
                 throw new RuntimeException("ModelReferencePayload failed to retrieve its model from rms [" + e.getMessage() + "]");
             }
         }

--- a/src/org/javarosa/core/model/utils/QuestionPreloader.java
+++ b/src/org/javarosa/core/model/utils/QuestionPreloader.java
@@ -248,7 +248,7 @@ public class QuestionPreloader {
      */
     private IAnswerData preloadProperty(String preloadParams) {
         String propname = preloadParams;
-        String propval = PropertyManager._().getSingularProperty(propname);
+        String propval = PropertyManager.__().getSingularProperty(propname);
         StringData data = null;
         if (propval != null && propval.length() > 0) {
             data = new StringData(propval);
@@ -260,7 +260,7 @@ public class QuestionPreloader {
         IAnswerData answer = node.getValue();
         String value = (answer == null ? null : answer.getDisplayText());
         if (propName != null && propName.length() > 0 && value != null && value.length() > 0)
-            PropertyManager._().setProperty(propName, value);
+            PropertyManager.__().setProperty(propName, value);
     }
 
     private DateTimeData getTimestamp() {

--- a/src/org/javarosa/core/model/utils/QuestionPreloader.java
+++ b/src/org/javarosa/core/model/utils/QuestionPreloader.java
@@ -19,7 +19,6 @@ package org.javarosa.core.model.utils;
 import java.util.Date;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.IAnswerData;
@@ -28,6 +27,8 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.util.Map;
 import org.javarosa.core.util.PropertyUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Question Preloader is responsible for maintaining a set of handlers which are capable 
@@ -37,6 +38,8 @@ import org.javarosa.core.util.PropertyUtils;
  *
  */
 public class QuestionPreloader {
+    private static final Logger logger = LoggerFactory.getLogger(QuestionPreloader.class);
+
     /* String -> IPreloadHandler */
     // NOTE: this is not java.util.Map!!!
     private Map<String,IPreloadHandler> preloadHandlers;
@@ -170,7 +173,7 @@ public class QuestionPreloader {
         if(handler != null) {
             return handler.handlePreload(preloadParams);
         } else {
-            Std.err.println("Do not know how to handle preloader [" + preloadType + "]");
+            logger.error("Do not know how to handle preloader [{}]", preloadType);
             return null;
         }
     }
@@ -180,7 +183,7 @@ public class QuestionPreloader {
         if(handler != null) {
             return handler.handlePostProcess(node, params);
         } else {
-            Std.err.println("Do not know how to handle preloader [" + preloadType + "]");
+            logger.error("Do not know how to handle preloader [{}]", preloadType);
             return false;
         }
     }

--- a/src/org/javarosa/core/reference/ReferenceDataSource.java
+++ b/src/org/javarosa/core/reference/ReferenceDataSource.java
@@ -19,7 +19,6 @@
  */
 package org.javarosa.core.reference;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.services.locale.LocaleDataSource;
 import org.javarosa.core.services.locale.LocalizationUtils;
 import org.javarosa.core.util.OrderedMap;
@@ -30,6 +29,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The ReferenceDataSource is a source of locale data which
@@ -40,6 +41,7 @@ import java.io.InputStream;
  *
  */
 public class ReferenceDataSource implements LocaleDataSource {
+    private static final Logger logger = LoggerFactory.getLogger(ReferenceDataSource.class);
 
     String referenceURI;
 
@@ -71,10 +73,10 @@ public class ReferenceDataSource implements LocaleDataSource {
             InputStream is = ReferenceManager.instance().DeriveReference(referenceURI).getStream();
             return LocalizationUtils.parseLocaleInput(is);
         } catch (IOException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
             throw new RuntimeException("IOException while getting localized text at reference " + referenceURI);
         } catch (InvalidReferenceException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
             throw new RuntimeException("Invalid Reference! " + referenceURI);
         }
     }

--- a/src/org/javarosa/core/reference/ReferenceManager.java
+++ b/src/org/javarosa/core/reference/ReferenceManager.java
@@ -61,7 +61,7 @@ public class ReferenceManager {
      * @see ReferenceManager#instance
      */
     @Deprecated
-    public static ReferenceManager _() {
+    public static ReferenceManager __() {
         return instance();
     }
 

--- a/src/org/javarosa/core/services/Logger.java
+++ b/src/org/javarosa/core/services/Logger.java
@@ -1,49 +1,69 @@
 package org.javarosa.core.services;
 
 import java.util.Date;
-
 import org.javarosa.core.api.ILogger;
 import org.javarosa.core.io.Std;
 import org.javarosa.core.log.FatalException;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.services.properties.JavaRosaPropertyRules;
 
+/**
+ * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
+ *
+ * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
+ */
+@Deprecated
 public class Logger {
+    /**
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
+     */
+    @Deprecated
     public static final int MAX_MSG_LENGTH = 2048;
 
     private static ILogger logger;
 
+    /**
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
+     */
+    @Deprecated
     public static void registerLogger(ILogger theLogger) {
         logger = theLogger;
     }
 
-    public static ILogger _ () {
+    /**
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
+     */
+    @Deprecated
+    public static ILogger _() {
         return logger;
     }
 
     /**
      * Posts the given data to an existing Incident Log, if one has
      * been registered and if logging is enabled on the device.
-     *
+     * <p>
      * NOTE: This method makes a best faith attempt to log the given
      * data, but will not produce any output if such attempts fail.
      *
-     * @param type The type of incident to be logged.
+     * @param type    The type of incident to be logged.
      * @param message A message describing the incident.
+     * @deprecated Use {@link org.slf4j.Logger#info(String)} instead
      */
+    @Deprecated
     public static void log(String type, String message) {
         if (isLoggingEnabled()) {
             logForce(type, message);
         }
     }
 
+    @Deprecated
     protected static void logForce(String type, String message) {
         Std.err.println("logger> " + type + ": " + message);
         if (message.length() > MAX_MSG_LENGTH)
             Std.err.println("  (message truncated)");
 
         message = message.substring(0, Math.min(message.length(), MAX_MSG_LENGTH));
-        if(logger != null) {
+        if (logger != null) {
             try {
                 logger.log(type, message, new Date());
             } catch (RuntimeException e) {
@@ -57,7 +77,8 @@ public class Logger {
         }
     }
 
-    public static boolean isLoggingEnabled () {
+    @Deprecated
+    public static boolean isLoggingEnabled() {
         boolean enabled;
         boolean problemReadingFlag = false;
         try {
@@ -75,16 +96,25 @@ public class Logger {
         return enabled;
     }
 
-    public static void exception (Exception e) {
+    /**
+     * @deprecated Use {@link org.slf4j.Logger#error(String, Throwable)} instead
+     */
+    @Deprecated
+    public static void exception(Exception e) {
         exception(null, e);
     }
 
-    public static void exception (String info, Exception e) {
+    /**
+     * @deprecated Use {@link org.slf4j.Logger#error(String, Throwable)} instead
+     */
+    @Deprecated
+    public static void exception(String info, Exception e) {
         Std.printStack(e);
         log("exception", (info != null ? info + ": " : "") + WrappedException.printException(e));
     }
 
-    public static void die (String thread, Exception e) {
+    @Deprecated
+    public static void die(String thread, Exception e) {
         //log exception
         exception("unhandled exception at top level", e);
 
@@ -97,7 +127,7 @@ public class Logger {
         //depending on how the code was invoked, a straight 'throw' won't always reliably crash the app
         //throwing in a thread should work (at least on our nokias)
         new Thread() {
-            public void run () {
+            public void run() {
                 throw crashException;
             }
         }.start();
@@ -105,16 +135,19 @@ public class Logger {
         //still do plain throw as a fallback
         try {
             Thread.sleep(3000);
-        } catch (InterruptedException ie) { }
+        } catch (InterruptedException ie) {
+        }
         throw crashException;
     }
 
-    public static void crashTest (String msg) {
+    @Deprecated
+    public static void crashTest(String msg) {
         throw new FatalException(msg != null ? msg : "shit has hit the fan");
     }
 
+    @Deprecated
     public static void halt() {
-        if(logger != null) {
+        if (logger != null) {
             logger.halt();
         }
     }

--- a/src/org/javarosa/core/services/Logger.java
+++ b/src/org/javarosa/core/services/Logger.java
@@ -68,7 +68,7 @@ public class Logger {
         boolean enabled;
         boolean problemReadingFlag = false;
         try {
-            String flag = PropertyManager._().getSingularProperty(JavaRosaPropertyRules.LOGS_ENABLED);
+            String flag = PropertyManager.__().getSingularProperty(JavaRosaPropertyRules.LOGS_ENABLED);
             enabled = (flag == null || flag.equals(JavaRosaPropertyRules.LOGS_ENABLED_YES));
         } catch (Exception e) {
             enabled = true;    //default to true if problem

--- a/src/org/javarosa/core/services/Logger.java
+++ b/src/org/javarosa/core/services/Logger.java
@@ -1,41 +1,43 @@
 package org.javarosa.core.services;
 
-import java.util.Date;
-import org.javarosa.core.api.ILogger;
-import org.javarosa.core.io.Std;
 import org.javarosa.core.log.FatalException;
-import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.services.properties.JavaRosaPropertyRules;
+import org.slf4j.LoggerFactory;
 
 /**
  * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
  *
+ * This class depends on ILogger, which is also deprecated. We need to ignore any
+ * deprecation warnings in order to avoid making breaking changes to this class
+ * before removing it on a next release
+ *
  * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class Logger {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(Logger.class);
     /**
      * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
      */
     @Deprecated
     public static final int MAX_MSG_LENGTH = 2048;
 
-    private static ILogger logger;
 
     /**
      * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
      */
     @Deprecated
-    public static void registerLogger(ILogger theLogger) {
-        logger = theLogger;
+    public static void registerLogger(org.javarosa.core.api.ILogger theLogger) {
+        LOGGER.warn("Using deprecated ILogger class. All logs will be redirected to SLF4J. Please migrate your code to SLF4J");
     }
 
     /**
      * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
      */
     @Deprecated
-    public static ILogger _() {
-        return logger;
+    public static org.javarosa.core.api.ILogger __() {
+        return null;
     }
 
     /**
@@ -58,23 +60,7 @@ public class Logger {
 
     @Deprecated
     protected static void logForce(String type, String message) {
-        Std.err.println("logger> " + type + ": " + message);
-        if (message.length() > MAX_MSG_LENGTH)
-            Std.err.println("  (message truncated)");
-
-        message = message.substring(0, Math.min(message.length(), MAX_MSG_LENGTH));
-        if (logger != null) {
-            try {
-                logger.log(type, message, new Date());
-            } catch (RuntimeException e) {
-                //do not catch exceptions here; if this fails, we want the exception to propogate
-                Std.err.println("exception when trying to write log message! " + WrappedException.printException(e));
-                logger.panic();
-
-                //be conservative for now
-                //throw e;
-            }
-        }
+        LOGGER.error("{}: {}", type, message);
     }
 
     @Deprecated
@@ -109,17 +95,12 @@ public class Logger {
      */
     @Deprecated
     public static void exception(String info, Exception e) {
-        Std.printStack(e);
-        log("exception", (info != null ? info + ": " : "") + WrappedException.printException(e));
+        LOGGER.error(info, e);
     }
 
     @Deprecated
     public static void die(String thread, Exception e) {
-        //log exception
-        exception("unhandled exception at top level", e);
-
-        //print stacktrace
-        Std.printStack(e);
+        LOGGER.error("unhandled exception at top level", e);
 
         //crash
         final FatalException crashException = new FatalException("unhandled exception in " + thread, e);
@@ -147,9 +128,6 @@ public class Logger {
 
     @Deprecated
     public static void halt() {
-        if (logger != null) {
-            logger.halt();
-        }
     }
 }
 

--- a/src/org/javarosa/core/services/ProgramFlow.java
+++ b/src/org/javarosa/core/services/ProgramFlow.java
@@ -1,0 +1,32 @@
+package org.javarosa.core.services;
+
+import org.javarosa.core.log.FatalException;
+import org.slf4j.LoggerFactory;
+
+public final class ProgramFlow {
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(ProgramFlow.class);
+
+    public static void die(String thread, Exception e) {
+        //log exception
+        logger.error("unhandled exception at top level", e);
+
+        //crash
+        final FatalException crashException = new FatalException("unhandled exception in " + thread, e);
+
+        //depending on how the code was invoked, a straight 'throw' won't always reliably crash the app
+        //throwing in a thread should work (at least on our nokias)
+        new Thread() {
+            public void run() {
+                throw crashException;
+            }
+        }.start();
+
+        //still do plain throw as a fallback
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException ie) {
+        }
+        throw crashException;
+    }
+}
+

--- a/src/org/javarosa/core/services/PropertyManager.java
+++ b/src/org/javarosa/core/services/PropertyManager.java
@@ -20,13 +20,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.services.properties.IPropertyRules;
 import org.javarosa.core.services.properties.Property;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.StorageFullException;
 import org.javarosa.core.services.storage.StorageManager;
 import org.javarosa.core.util.externalizable.Externalizable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PropertyManager is a class that is used to set and retrieve name/value pairs
@@ -41,6 +42,7 @@ import org.javarosa.core.util.externalizable.Externalizable;
  *
  */
 public class PropertyManager implements IPropertyManager {
+    private static final Logger logger = LoggerFactory.getLogger(PropertyManager.class);
 
     ///// manage global property manager /////
 
@@ -104,7 +106,7 @@ public class PropertyManager implements IPropertyManager {
         }
         if(retVal == null) {
             //#if debug.output==verbose
-            Std.out.println("Warning: Singular property request failed for property " + propertyName);
+            logger.warn("Singular property request failed for property {}", propertyName);
             //#endif
         }
         return retVal;
@@ -172,7 +174,7 @@ public class PropertyManager implements IPropertyManager {
             }
             //#if debug.output==verbose
             else {
-                Std.out.println("Property Manager: Unable to write value (" + propertyValue + ") to " + propertyName);
+                logger.info("Property Manager: Unable to write value ({}) to {}", propertyValue, propertyName);
             }
             //#endif
         }

--- a/src/org/javarosa/core/services/PropertyManager.java
+++ b/src/org/javarosa/core/services/PropertyManager.java
@@ -105,9 +105,7 @@ public class PropertyManager implements IPropertyManager {
             }
         }
         if(retVal == null) {
-            //#if debug.output==verbose
             logger.warn("Singular property request failed for property {}", propertyName);
-            //#endif
         }
         return retVal;
     }
@@ -171,12 +169,9 @@ public class PropertyManager implements IPropertyManager {
             if(valid) {
                 writeValue(propertyName, propertyValue);
                 notifyChanges(propertyName);
-            }
-            //#if debug.output==verbose
-            else {
+            } else {
                 logger.info("Property Manager: Unable to write value ({}) to {}", propertyValue, propertyName);
             }
-            //#endif
         }
 
     }

--- a/src/org/javarosa/core/services/PropertyManager.java
+++ b/src/org/javarosa/core/services/PropertyManager.java
@@ -57,7 +57,7 @@ public class PropertyManager implements IPropertyManager {
            setPropertyManager(new PropertyManager());
     }
 
-    public static IPropertyManager _ () {
+    public static IPropertyManager __() {
            if (instance == null) {
                initDefaultPropertyManager();
            }

--- a/src/org/javarosa/core/services/locale/LocalizationUtils.java
+++ b/src/org/javarosa/core/services/locale/LocalizationUtils.java
@@ -3,18 +3,21 @@
  */
 package org.javarosa.core.services.locale;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.util.OrderedMap;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author ctsims
  *
  */
 public class LocalizationUtils {
+    private static final Logger logger = LoggerFactory.getLogger(LocalizationUtils.class);
+
     /**
      * @param is A path to a resource file provided in the current environment
      *
@@ -84,7 +87,7 @@ public class LocalizationUtils {
                 if(line.trim().equals("")) {
                     //Empty Line
                 } else {
-                    Std.out.println("Invalid line (#" + curline + ") read: " + line);
+                    logger.info("Invalid line (#{}) read: {}", curline, line);
                 }
             } else {
                 //Check to see if there's anything after the '=' first. Otherwise there
@@ -94,7 +97,7 @@ public class LocalizationUtils {
                     locale.put(line.substring(0, line.indexOf('=')), value);
                 }
                  else {
-                    Std.out.println("Invalid line (#" + curline + ") read: '" + line + "'. No value follows the '='.");
+                    logger.info("Invalid line (#{}) read: '{}'. No value follows the '='.", curline, line);
                 }
             }
         }

--- a/src/org/javarosa/core/services/locale/Localizer.java
+++ b/src/org/javarosa/core/services/locale/Localizer.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.util.CodeTimer;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.OrderedMap;
@@ -37,6 +36,8 @@ import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Localizer object maintains mappings for locale ID's and Object
@@ -46,6 +47,8 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  * @author Drew Roos/Clayton Sims
  */
 public class Localizer implements Externalizable {
+    private static final Logger logger = LoggerFactory.getLogger(Localizer.class);
+
     private List<String> locales = new ArrayList<>(0);
     private OrderedMap<String, List<LocaleDataSource>> localeResources = new OrderedMap<>();
     private OrderedMap<String, String> currentLocaleData = new OrderedMap<>();
@@ -607,7 +610,7 @@ public class Localizer implements Externalizable {
         while (i != -1) {
             int j = text.indexOf("}", i);
             if (j == -1) {
-                Std.err.println("Warning: unterminated ${...} arg");
+                logger.warn("unterminated ${...} arg");
                 break;
             }
 
@@ -626,7 +629,7 @@ public class Localizer implements Externalizable {
         while (i != -1) {
             int j = text.indexOf("}", i);
             if (j == -1) {
-                Std.err.println("Warning: unterminated ${...} arg");
+                logger.warn("unterminated ${...} arg");
                 break;
             }
 

--- a/src/org/javarosa/core/services/locale/Localizer.java
+++ b/src/org/javarosa/core/services/locale/Localizer.java
@@ -24,9 +24,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.javarosa.core.util.CodeTimer;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.OrderedMap;
+import org.javarosa.core.util.StopWatch;
 import org.javarosa.core.util.UnregisteredLocaleException;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
@@ -304,7 +304,7 @@ public class Localizer implements Externalizable {
      * @returns HashMap representing text mappings for this locale. Returns null if locale not defined or null.
      */
     public OrderedMap<String, String> getLocaleData(String locale) {
-        final CodeTimer codeTimer = new CodeTimer("getLocaleData");
+        final StopWatch codeTimer = StopWatch.start();
         if (locale == null || !this.locales.contains(locale)) {
             return null;
         }
@@ -356,7 +356,7 @@ public class Localizer implements Externalizable {
             }
         }
 
-        codeTimer.logDone();
+        logger.info(codeTimer.logLine("getLocaleData"));
         return data;
     }
 

--- a/src/org/javarosa/core/services/locale/ResourceFileDataSource.java
+++ b/src/org/javarosa/core/services/locale/ResourceFileDataSource.java
@@ -15,11 +15,10 @@
  */
 
 /**
- * 
+ *
  */
 package org.javarosa.core.services.locale;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.util.OrderedMap;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -29,13 +28,16 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Clayton Sims
- * @date Jun 1, 2009 
+ * @date Jun 1, 2009
  *
  */
 public class ResourceFileDataSource implements LocaleDataSource {
+    private static final Logger logger = LoggerFactory.getLogger(ResourceFileDataSource.class);
 
     String resourceURI;
 
@@ -139,13 +141,14 @@ public class ResourceFileDataSource implements LocaleDataSource {
             }
         } catch (IOException e) {
             // TODO Auto-generated catch block
-            Std.printStack(e);
+            logger.error("Error", e);
         } finally {
             try {
                 is.close();
             } catch (IOException e) {
-                Std.out.println("Input Stream for resource file " + resourceURI + " failed to close. This will eat up your memory! Fix Problem! [" + e.getMessage() + "]");
-                Std.printStack(e);
+                logger.info("Input Stream for resource file {} failed to close. This will eat up " +
+                    "your memory! Fix Problem! [{}]", resourceURI, e.getMessage());
+                logger.error("Error", e);
             }
         }
         return locale;
@@ -166,7 +169,7 @@ public class ResourceFileDataSource implements LocaleDataSource {
             if(line.trim().equals("")) {
                 //Empty Line
             } else {
-                Std.out.println("Invalid line (#" + curline + ") read: " + line);
+                logger.info("Invalid line (#{}) read: {}", curline, line);
             }
         } else {
             //Check to see if there's anything after the '=' first. Otherwise there
@@ -176,7 +179,7 @@ public class ResourceFileDataSource implements LocaleDataSource {
                 locale.put(line.substring(0, line.indexOf('=')), value);
             }
              else {
-                Std.out.println("Invalid line (#" + curline + ") read: '" + line + "'. No value follows the '='.");
+                logger.info("Invalid line (#{}) read: '{}'. No value follows the '='.", curline, line);
             }
         }
     }

--- a/src/org/javarosa/core/services/properties/JavaRosaPropertyRules.java
+++ b/src/org/javarosa/core/services/properties/JavaRosaPropertyRules.java
@@ -98,7 +98,7 @@ public class JavaRosaPropertyRules implements IPropertyRules {
             //Check whether this is a dynamic property
             if(prop.size() == 1 && checkPropertyAllowed(prop.get(0))) {
                 // If so, get its list of available values, and see whether the potentival value is acceptable.
-                return PropertyManager._().getProperty(prop.get(0)).contains(potentialValue);
+                return PropertyManager.__().getProperty(prop.get(0)).contains(potentialValue);
             }
             else {
                 return rules.get(propertyName).contains(potentialValue);
@@ -168,7 +168,7 @@ public class JavaRosaPropertyRules implements IPropertyRules {
      */
     public void handlePropertyChanges(String propertyName) {
         if(CURRENT_LOCALE.equals(propertyName)) {
-            String locale = PropertyManager._().getSingularProperty(propertyName);
+            String locale = PropertyManager.__().getSingularProperty(propertyName);
             Localization.setLocale(locale);
         }
     }

--- a/src/org/javarosa/core/services/properties/Property.java
+++ b/src/org/javarosa/core/services/properties/Property.java
@@ -23,10 +23,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.services.storage.IMetaData;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Property is an encapsulation of a record containing a property in the J2ME
@@ -38,6 +39,8 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  *
  */
 public class Property implements Persistable, IMetaData {
+    private static final Logger logger = LoggerFactory.getLogger(Property.class);
+
     public String name;
     public List<String> value;
     public int recordId = -1;
@@ -60,7 +63,7 @@ public class Property implements Persistable, IMetaData {
         value = new ArrayList<String>();
         if(nameindex == -1) {
             //#if debug.output==verbose
-            Std.out.println("WARNING: Property in RMS with no value:"+fullString);
+            logger.warn("Property in RMS with no value: {}", fullString);
             //#endif
             name = fullString.substring(0, fullString.length());
         }

--- a/src/org/javarosa/core/services/properties/Property.java
+++ b/src/org/javarosa/core/services/properties/Property.java
@@ -62,9 +62,7 @@ public class Property implements Persistable, IMetaData {
         int nameindex = fullString.indexOf(",");
         value = new ArrayList<String>();
         if(nameindex == -1) {
-            //#if debug.output==verbose
             logger.warn("Property in RMS with no value: {}", fullString);
-            //#endif
             name = fullString.substring(0, fullString.length());
         }
         else {

--- a/src/org/javarosa/core/services/storage/StorageManager.java
+++ b/src/org/javarosa/core/services/storage/StorageManager.java
@@ -60,8 +60,9 @@ public class StorageManager {
             storageFactory = fact;
         } else {
             if(mustWork) {
-                die("A Storage Factory had already been set when storage factory " + fact.getClass().getName()
-                                           + " attempted to become the only storage factory", new RuntimeException("Duplicate Storage Factory set"));
+                die("A Storage Factory had already been set when storage factory " +
+                    fact.getClass().getName() + " attempted to become the only storage " +
+                    "factory", new RuntimeException("Duplicate Storage Factory set"));
             } else {
                 //Not an issue
             }

--- a/src/org/javarosa/core/services/storage/StorageManager.java
+++ b/src/org/javarosa/core/services/storage/StorageManager.java
@@ -16,7 +16,8 @@
 
 package org.javarosa.core.services.storage;
 
-import org.javarosa.core.services.Logger;
+import static org.javarosa.core.services.ProgramFlow.die;
+
 import org.javarosa.core.services.storage.WrappingStorageUtility.SerializationWrapper;
 import org.javarosa.core.util.externalizable.Externalizable;
 
@@ -59,7 +60,7 @@ public class StorageManager {
             storageFactory = fact;
         } else {
             if(mustWork) {
-                Logger.die("A Storage Factory had already been set when storage factory " + fact.getClass().getName()
+                die("A Storage Factory had already been set when storage factory " + fact.getClass().getName()
                                            + " attempted to become the only storage factory", new RuntimeException("Duplicate Storage Factory set"));
             } else {
                 //Not an issue

--- a/src/org/javarosa/core/util/CacheTable.java
+++ b/src/org/javarosa/core/util/CacheTable.java
@@ -3,18 +3,20 @@
  */
 package org.javarosa.core.util;
 
-import org.javarosa.core.io.Std;
-
 import java.lang.ref.WeakReference;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author ctsims
  *
  */
 public class CacheTable<K> {
+    private static final Logger logger = LoggerFactory.getLogger(CacheTable.class);
+
     int totalAdditions = 0;
 
     // Object is actually K...
@@ -72,10 +74,10 @@ public class CacheTable<K> {
                         Thread.sleep(3000);
                     } catch (InterruptedException e) {
                         // TODO Auto-generated catch block
-                        Std.printStack(e);
+                        logger.error("Error", e);
                     }
                 } catch (Exception e) {
-                    Std.printStack(e);
+                    logger.error("Error", e);
                 }
             }
 

--- a/src/org/javarosa/core/util/CodeTimer.java
+++ b/src/org/javarosa/core/util/CodeTimer.java
@@ -17,7 +17,6 @@
 package org.javarosa.core.util;
 
 import java.io.PrintStream;
-import org.javarosa.core.io.Std;
 
 /**
  * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
@@ -50,7 +49,7 @@ public class CodeTimer {
      */
     @Deprecated
     public void logDone() {
-        logDone(Std.out);
+        logDone(System.out);
     }
 
     /**

--- a/src/org/javarosa/core/util/CodeTimer.java
+++ b/src/org/javarosa/core/util/CodeTimer.java
@@ -16,11 +16,17 @@
 
 package org.javarosa.core.util;
 
+import java.io.PrintStream;
 import org.javarosa.core.io.Std;
 
-import java.io.PrintStream;
-
-/** Helps with timing an operation and logging the time */
+/**
+ * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
+ *
+ * Helps with timing an operation and logging the time
+ *
+ * @deprecated Use {@link StopWatch} instead
+ */
+@Deprecated
 public class CodeTimer {
     private final long startTime = System.nanoTime();
     private final String operation;
@@ -28,27 +34,42 @@ public class CodeTimer {
 
     /**
      * Creates a CodeTimer for the specified operation
+     *
      * @param operation the name of the operation, such as “parsing form”
+     * @deprecated Use {@link StopWatch} instead
      */
+    @Deprecated
     public CodeTimer(String operation) {
         this.operation = operation;
     }
 
-    /** Calculates and logs the time since this object was constructed. */
+    /**
+     * Calculates and logs the time since this object was constructed.
+     *
+     * @deprecated Use {@link StopWatch} instead
+     */
+    @Deprecated
     public void logDone() {
         logDone(Std.out);
     }
 
     /**
      * Calculates and logs the time since this object was constructed.
+     *
      * @param stream the PrintStream onto which to log the message
+     * @deprecated Use {@link StopWatch} instead
      */
+    @Deprecated
     public void logDone(PrintStream stream) {
         if (enabled) {
             stream.printf("%s finished in %.3f ms\n", operation, (System.nanoTime() - startTime) / 1e6);
         }
     }
 
+    /**
+     * @deprecated Use {@link StopWatch} instead
+     */
+    @Deprecated
     public static void setEnabled(boolean enabled) {
         CodeTimer.enabled = enabled;
     }

--- a/src/org/javarosa/core/util/MemoryUtils.java
+++ b/src/org/javarosa/core/util/MemoryUtils.java
@@ -60,11 +60,7 @@ public class MemoryUtils {
         memoryHolders = new byte[MEMORY_PROFILE_SIZE][];
     }
 
-    //#if javarosa.memory.print
-    //# private static boolean MEMORY_PRINT_ENABLED = true;
-    //#else
     private static boolean MEMORY_PRINT_ENABLED = false;
-    //#endif
 
     /**
      * Prints a memory test debug statement to stdout.

--- a/src/org/javarosa/core/util/MemoryUtils.java
+++ b/src/org/javarosa/core/util/MemoryUtils.java
@@ -3,10 +3,11 @@
  */
 package org.javarosa.core.util;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.instance.TreeReferenceLevel;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.xpath.expr.XPathStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * J2ME suffers from major disparities in the effective use of memory. This
@@ -20,6 +21,7 @@ import org.javarosa.xpath.expr.XPathStep;
  *
  */
 public class MemoryUtils {
+    private static final Logger logger = LoggerFactory.getLogger(MemoryUtils.class);
 
     //These 3 are used to hold the profile of the heapspace, only relevant
     //if you are doing deep memory profiling
@@ -102,10 +104,11 @@ public class MemoryUtils {
         long total = r.totalMemory();
 
         if(tag != null) {
-            Std.out.println("=== Memory Evaluation: " + tag + " ===");
+            logger.info("=== Memory Evaluation: {} ===", tag);
         }
 
-        Std.out.println("Total: " +total + "\nFree: " + free);
+        logger.info("Total: {}", total);
+        logger.info("Free: {}", free);
 
         int chunk = 100;
         int lastSuccess = 100;
@@ -138,15 +141,16 @@ public class MemoryUtils {
 
         int availPercent = (int)Math.floor((lastSuccess * 1.0 / total) * 100);
         int fragmentation = (int)Math.floor((lastSuccess * 1.0 / free) * 100);
-        Std.out.println("Usable Memory: " +lastSuccess + "\n" + availPercent + "% of available memory");
-        Std.out.println("Fragmentation: " + fragmentation + "%");
+        logger.info("Usable Memory: {}", lastSuccess);
+        logger.info("{}% of available memory", availPercent);
+        logger.info("Fragmentation: {}%", fragmentation);
 
         if(pause != -1) {
             try {
                 Thread.sleep(pause);
             } catch (InterruptedException e) {
                 // TODO Auto-generated catch block
-                Std.printStack(e);
+                logger.error("Error", e);
             }
         }
     }
@@ -161,7 +165,7 @@ public class MemoryUtils {
      */
     public static void profileMemory() {
         if(memoryProfile == null) {
-            Std.out.println("You must initialize the memory profiler before it can be used!");
+            logger.info("You must initialize the memory profiler before it can be used!");
             return;
         }
         currentCount = 0;
@@ -180,7 +184,7 @@ public class MemoryUtils {
         //on the type of fragmentation you are concerned about.
         while(true) {
             if(currentCount >= MEMORY_PROFILE_SIZE) {
-                Std.out.println("Memory profile is too small for this device's usage!");
+                logger.info("Memory profile is too small for this device's usage!");
                 break;
             }
             if(chunkSize < threshold) { succeeded = true; break;}
@@ -202,9 +206,9 @@ public class MemoryUtils {
 
         //For now, just print out the profile. Eventually we should compress it and output it in a useful format.
         if(succeeded) {
-            Std.out.println("Acquired memory profile for " + memoryAccountedFor + " of the " + memory + " available bytes, with " + currentCount + " traces");
+            logger.info("Acquired memory profile for {} of the {} available bytes, with {} traces", memoryAccountedFor, memory, currentCount);
             for(int i = 0 ; i < currentCount * 2 ; i+=2) {
-                Std.out.println("Address: " + memoryProfile[i] + " -> " + memoryProfile[i + 1]);
+                logger.info("Address: {} -> {}", memoryProfile[i], memoryProfile[i + 1]);
             }
         }
     }

--- a/src/org/javarosa/core/util/PropertyUtils.java
+++ b/src/org/javarosa/core/util/PropertyUtils.java
@@ -20,10 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.services.PropertyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PropertyUtils {
+    private static final Logger logger = LoggerFactory.getLogger(PropertyUtils.class);
 
     //need 'addpropery' too.
     public static String initializeProperty(String propName, String defaultValue) {
@@ -33,8 +35,7 @@ public class PropertyUtils {
             propVal.add(defaultValue);
             PropertyManager._().setProperty(propName, propVal);
             //#if debug.output==verbose
-            Std.out.println("No default value for [" + propName
-                    + "]; setting to [" + defaultValue + "]"); // debug
+            logger.info("No default value for [{}]; setting to [{}]", propName, defaultValue); // debug
             //#endif
             return defaultValue;
         }

--- a/src/org/javarosa/core/util/PropertyUtils.java
+++ b/src/org/javarosa/core/util/PropertyUtils.java
@@ -29,11 +29,11 @@ public class PropertyUtils {
 
     //need 'addpropery' too.
     public static String initializeProperty(String propName, String defaultValue) {
-        List<String> propVal = PropertyManager._().getProperty(propName);
+        List<String> propVal = PropertyManager.__().getProperty(propName);
         if (propVal == null || propVal.size() == 0) {
             propVal = new ArrayList<String>(1);
             propVal.add(defaultValue);
-            PropertyManager._().setProperty(propName, propVal);
+            PropertyManager.__().setProperty(propName, propVal);
             logger.info("No default value for [{}]; setting to [{}]", propName, defaultValue); // debug
             return defaultValue;
         }

--- a/src/org/javarosa/core/util/PropertyUtils.java
+++ b/src/org/javarosa/core/util/PropertyUtils.java
@@ -34,9 +34,7 @@ public class PropertyUtils {
             propVal = new ArrayList<String>(1);
             propVal.add(defaultValue);
             PropertyManager._().setProperty(propName, propVal);
-            //#if debug.output==verbose
             logger.info("No default value for [{}]; setting to [{}]", propName, defaultValue); // debug
-            //#endif
             return defaultValue;
         }
         return propVal.get(0);

--- a/src/org/javarosa/core/util/StopWatch.java
+++ b/src/org/javarosa/core/util/StopWatch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.util;
+
+/**
+ * Helps with timing an operation and logging the time
+ */
+public class StopWatch {
+    private final long startTime;
+
+    private StopWatch(long startTime) {
+        this.startTime = startTime;
+    }
+
+    public static StopWatch start() {
+        return new StopWatch(System.nanoTime());
+    }
+
+    /**
+     * Builds a timer log line and returns it
+     *
+     * @param operation
+     * @return a string containing the log line
+     */
+    public String logLine(String operation) {
+        return String.format("%s finished in %.3f ms", operation, (System.nanoTime() - startTime) / 1e6);
+    }
+}

--- a/src/org/javarosa/core/util/StreamsUtil.java
+++ b/src/org/javarosa/core/util/StreamsUtil.java
@@ -5,22 +5,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+/**
+ * <b>Warning</b>: This class is unused and should remain that way. It will be removed in a future release.
+ *
+ * @deprecated
+ */
+@Deprecated
 public class StreamsUtil {
 
     private StreamsUtil() {
-        // private constructor
     }
 
     /**
-     *
      * Write everything from input stream to output stream, byte by byte then
      * close the streams
-     *
-     *
-     * @param in
-     * @param out
-     * @throws IOException
      */
+    @Deprecated
     public static void writeFromInputToOutput(InputStream in, OutputStream out, long[] tally) throws IOException {
         int val = in.read();
         while (val != -1) {
@@ -31,18 +31,15 @@ public class StreamsUtil {
         in.close();
     }
 
+    @Deprecated
     public static void writeFromInputToOutput(InputStream in, OutputStream out) throws IOException {
         writeFromInputToOutput(in, out, null);
     }
 
     /**
-     *
      * Write the byte array to the output stream
-     *
-     * @param bytes
-     * @param out
-     * @throws IOException
      */
+    @Deprecated
     public static void writeToOutput(byte[] bytes, OutputStream out, long[] tally) throws IOException {
 
         for (int i = 0; i < bytes.length; i++) {
@@ -52,6 +49,7 @@ public class StreamsUtil {
 
     }
 
+    @Deprecated
     public static void writeToOutput(byte[] bytes, OutputStream out) throws IOException {
         writeToOutput(bytes, out, null);
     }
@@ -63,15 +61,10 @@ public class StreamsUtil {
     }
 
     /**
-     *
      * Read bytes from an input stream into a byte array then close the input
      * stream
-     *
-     * @param in
-     * @param len
-     * @return
-     * @throws IOException
      */
+    @Deprecated
     public static byte[] readFromStream(InputStream in, int len)
             throws IOException {
 

--- a/src/org/javarosa/core/util/externalizable/PrototypeFactory.java
+++ b/src/org/javarosa/core/util/externalizable/PrototypeFactory.java
@@ -22,9 +22,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Vector;
 
-import org.javarosa.core.io.Std;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PrototypeFactory {
+    private static final Logger logger = LoggerFactory.getLogger(PrototypeFactory.class);
+
     public final static int CLASS_HASH_SIZE = 4;
 
     private final Vector<Class> classes = new Vector<>();
@@ -135,7 +138,7 @@ public class PrototypeFactory {
         System.arraycopy(md5, 0, hash, 0, hash.length);
         byte[] badHash = new byte[] {0,4,78,97};
         if(PrototypeFactory.compareHash(badHash, hash)) {
-            Std.out.println("BAD CLASS: " + type.getName());
+            logger.info("BAD CLASS: {}", type.getName());
         }
 
         return hash;

--- a/src/org/javarosa/form/api/FormEntryController.java
+++ b/src/org/javarosa/form/api/FormEntryController.java
@@ -16,18 +16,21 @@
 
 package org.javarosa.form.api;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to navigate through an xform and appropriately manipulate
  * the FormEntryModel's state.
  */
 public class FormEntryController {
+    private static final Logger logger = LoggerFactory.getLogger(FormEntryController.class);
+
     public static final int ANSWER_OK = 0;
     public static final int ANSWER_REQUIRED_BUT_EMPTY = 1;
     public static final int ANSWER_CONSTRAINT_VIOLATED = 2;
@@ -99,7 +102,7 @@ public class FormEntryController {
             try {
                 model.getForm().copyItemsetAnswer(q, element, data, midSurvey);
             } catch (InvalidReferenceException ire) {
-                Std.printStack(ire);
+                logger.error("Error", ire);
                 throw new RuntimeException("Invalid reference while copying itemset answer: " + ire.getMessage());
             }
             return ANSWER_OK;

--- a/src/org/javarosa/form/api/FormEntryModel.java
+++ b/src/org/javarosa/form/api/FormEntryModel.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -31,6 +30,8 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The data model used during form entry. Represents the current state of the
@@ -38,6 +39,8 @@ import org.javarosa.core.model.instance.TreeReference;
  * controller.
  */
 public class FormEntryModel {
+    private static final Logger logger = LoggerFactory.getLogger(FormEntryModel.class);
+
     private FormDef form;
     private FormIndex currentFormIndex;
 
@@ -461,8 +464,8 @@ public class FormEntryModel {
                               try {
                                 getForm().createNewRepeat(index);
                               } catch (InvalidReferenceException ire) {
-                                Std.printStack(ire);
-                                throw new RuntimeException("Invalid Reference while creting new repeat!" + ire.getMessage());
+                                  logger.error("Error", ire);
+                                  throw new RuntimeException("Invalid Reference while creting new repeat!" + ire.getMessage());
                               }
                             }
                         }

--- a/src/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/org/javarosa/form/api/FormEntryPrompt.java
@@ -19,7 +19,6 @@ package org.javarosa.form.api;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
@@ -36,7 +35,7 @@ import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.services.Logger;
+import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.UnregisteredLocaleException;
 import org.javarosa.formmanager.view.IQuestionWidget;
@@ -50,6 +49,7 @@ import org.javarosa.formmanager.view.IQuestionWidget;
  * @author Yaw Anokwa
  */
 public class FormEntryPrompt extends FormEntryCaption {
+    private static final Logger logger = LoggerFactory.getLogger(FormEntryPrompt.class);
 
     TreeElement mTreeElement;
     boolean dynamicChoicesPopulated = false;
@@ -306,10 +306,9 @@ public class FormEntryPrompt extends FormEntryCaption {
         }catch(NoLocalizedTextException nlt){
             //use fallback helptext
         }catch(UnregisteredLocaleException ule){
-            Std.err.println("Warning: No Locale set yet (while attempting to getHelpText())");
+            logger.warn("No Locale set yet (while attempting to getHelpText())");
         }catch(Exception e){
-            Logger.exception("FormEntryPrompt.getHelpText", e);
-            Std.printStack(e);
+            logger.error("FormEntryPrompt.getHelpText", e);
         }
 
         return helpText;

--- a/src/org/javarosa/model/xform/XPathReference.java
+++ b/src/org/javarosa/model/xform/XPathReference.java
@@ -23,7 +23,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -35,11 +34,15 @@ import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class XPathReference implements IDataReference {
+    private static final Logger logger = LoggerFactory.getLogger(XPathReference.class);
+
     private TreeReference ref;
     private String nodeset;
 
@@ -68,7 +71,7 @@ public class XPathReference implements IDataReference {
             if (validNonPathExpr) {
                 throw new XPathTypeMismatchException("Expected XPath path, got XPath expression: [" + nodeset + "]," + xse.getMessage());
             } else {
-                Std.printStack(xse);
+                logger.error("Error", xse);
                 throw new XPathException("Parse error in XPath path: [" + nodeset + "]." + (xse.getMessage() == null ? "" : "\n" + xse.getMessage()));
             }
         }

--- a/src/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/org/javarosa/xform/parse/FormInstanceParser.java
@@ -34,7 +34,6 @@ class FormInstanceParser {
 
     private final FormDef formDef;
     private final String defaultNamespace;
-    private final XFormParserReporter reporter;
     private final List<DataBinding> bindings;
     private final List<TreeReference> repeats;
     private final List<ItemsetBinding> itemsets;
@@ -44,13 +43,12 @@ class FormInstanceParser {
     /** pseudo-data model tree that describes the repeat structure of the instance; useful during instance processing and validation */
     private FormInstance repeatTree;
 
-    FormInstanceParser(FormDef formDef, String defaultNamespace, XFormParserReporter reporter,
+    FormInstanceParser(FormDef formDef, String defaultNamespace,
                        List<DataBinding> bindings, List<TreeReference> repeats, List<ItemsetBinding> itemsets,
                        List<TreeReference> selectOnes, List<TreeReference> selectMultis, List<TreeReference> actionTargets) {
         // Todo: additional refactoring should shorten this too-long argument list
         this.formDef = formDef;
         this.defaultNamespace = defaultNamespace;
-        this.reporter = reporter;
         this.bindings = bindings;
         this.repeats = repeats;
         this.itemsets = itemsets;

--- a/src/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
+++ b/src/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
@@ -23,12 +23,10 @@ import static org.javarosa.xform.parse.XFormParser.NAMESPACE_JAVAROSA;
 
 class StandardBindAttributesProcessor {
     private static final Logger logger = LoggerFactory.getLogger(StandardBindAttributesProcessor.class);
-    StandardBindAttributesProcessor(XFormParserReporter reporter, Map<String, Integer> typeMappings) {
-        this.reporter = reporter;
+    StandardBindAttributesProcessor(Map<String, Integer> typeMappings) {
         this.typeMappings = typeMappings;
     }
 
-    private XFormParserReporter reporter;
     private Map<String, Integer> typeMappings;
 
     DataBinding createBinding(IXFormParserFunctions parserFunctions, FormDef formDef,

--- a/src/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
+++ b/src/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
@@ -14,12 +14,15 @@ import org.kxml2.kdom.Element;
 
 import java.util.Collection;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
 import static org.javarosa.xform.parse.XFormParser.NAMESPACE_JAVAROSA;
 
 class StandardBindAttributesProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(StandardBindAttributesProcessor.class);
     StandardBindAttributesProcessor(XFormParserReporter reporter, Map<String, Integer> typeMappings) {
         this.reporter = reporter;
         this.typeMappings = typeMappings;
@@ -151,10 +154,9 @@ class StandardBindAttributesProcessor {
         try {
             xPathConditional = new XPathConditional(xpath);
         } catch (XPathSyntaxException xse) {
-            String errorMessage = "Encountered a problem with " + prettyType + " condition for node ["  + 
-                    contextRef.getReference().toString() + "] at line: " + xpath + ", " +  xse.getMessage();
-            reporter.error(errorMessage);
-            throw new XFormParseException(errorMessage);
+            logger.error("XForm Parse Error: Encountered a problem with {} condition for node [{}] at line: {}{}", prettyType, contextRef.getReference().toString(), xpath, xse.getMessage());
+            throw new XFormParseException("Encountered a problem with " + prettyType + " condition for node ["  +
+                    contextRef.getReference().toString() + "] at line: " + xpath + ", " +  xse.getMessage());
         }
 
         return new Condition(xPathConditional, trueAction, falseAction, FormInstance.unpackReference(contextRef));
@@ -178,7 +180,7 @@ class StandardBindAttributesProcessor {
                 dataType = typeMappings.get(type);
             } else {
                 dataType = org.javarosa.core.model.Constants.DATATYPE_UNSUPPORTED;
-                reporter.warning(XFormParserReporter.TYPE_ERROR_PRONE, "unrecognized data type [" + type + "]", null);
+                logger.warn("XForm Parse Warning: unrecognized data type [{}]", type);
             }
         }
 

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -400,8 +400,7 @@ public class XFormParser implements IXFormParserFunctions {
         try {
             reader.close();
         } catch (IOException e) {
-            logger.info("Error closing reader");
-            logger.error("Error", e);
+            logger.error("Error closing reader", e);
         }
         logger.info(ctParse.logLine("Reading XML and parsing with kXML2"));
 
@@ -1057,9 +1056,9 @@ public class XFormParser implements IXFormParserFunctions {
                     sb.append(XFormSerializer.elementToString(child));
                 } else {
                     //Otherwise, ignore it.
-                    logger.info("Unrecognized tag inside of text: <"  + child.getName() + ">. " +
-                        "Did you intend to use HTML markup? If so, ensure that the element is defined in " +
-                        "the HTML namespace.");
+                    logger.info("Unrecognized tag inside of text: <{}>. Did you intend to " +
+                        "use HTML markup? If so, ensure that the element is defined in " +
+                        "the HTML namespace.", child.getName());
                 }
             }else{
                 sb.append(e.getText(i));
@@ -1702,7 +1701,7 @@ public class XFormParser implements IXFormParserFunctions {
                 //for the other locale, but isn't super good.
                 //TODO: Clean up being able to get here
                 if(!itextKnownForms.contains(textForm)) {
-                    logger.info("adding unexpected special itext form: " + textForm + " to list of expected forms");
+                    logger.info("adding unexpected special itext form: {} to list of expected forms", textForm);
                     itextKnownForms.add(textForm);
                 }
                 return true;
@@ -1829,7 +1828,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
         if (hasElements && hasText) {
-            logger.info("Warning: instance node '" + node.getName() + "' contains both elements and text as children; text ignored");
+            logger.warn("instance node '{}' contains both elements and text as children; text ignored", node.getName());
         }
 
         //check for repeat templating
@@ -1858,7 +1857,7 @@ public class XFormParser implements IXFormParserFunctions {
             element = (TreeElement)modelPrototypes.getNewInstance(typeMappings.get(modelType).toString());
             if(element == null) {
                 element = new TreeElement(name, multiplicity);
-                logger.info("No model type prototype available for " + modelType);
+                logger.info("No model type prototype available for {}", modelType);
             } else {
                 element.setName(name);
                 element.setMult(multiplicity);

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -429,7 +429,7 @@ public class XFormParser implements IXFormParserFunctions {
         parseElement(_xmldoc.getRootElement(), _f, topLevelHandlers);
         collapseRepeatGroups(_f);
 
-        final FormInstanceParser instanceParser = new FormInstanceParser(_f, defaultNamespace, null,
+        final FormInstanceParser instanceParser = new FormInstanceParser(_f, defaultNamespace,
             bindings, repeats, itemsets, selectOnes, selectMultis, actionTargets);
 
         //parse the non-main instance nodes first
@@ -1717,7 +1717,7 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     private DataBinding processStandardBindAttributes(List<String> usedAtts, List<String> passedThroughAtts, Element element) {
-        return new StandardBindAttributesProcessor(null, typeMappings).
+        return new StandardBindAttributesProcessor(typeMappings).
             createBinding(this, _f, usedAtts, passedThroughAtts, element);
     }
 
@@ -1998,7 +1998,7 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     private void checkDependencyCycles () {
-        _f.reportDependencyCycles(null);
+        _f.reportDependencyCycles();
     }
 
     private void loadXmlInstance(FormDef f, Reader xmlReader) throws IOException {

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -189,10 +189,12 @@ public class XFormParser implements IXFormParserFunctions {
                     // These are consistently used by clients but are expected in additionalAttributes for historical
                     // reasons.
                     final List<String> passedThroughInputAtts = Collections.unmodifiableList(Arrays.asList(
-                            "rows",
-                            "query"
-                    ));p.parseControl((IFormElement) parent, e, Constants.CONTROL_INPUT,passedThroughInputAtts,
-                            passedThroughInputAtts
+                        "rows",
+                        "query"
+                    ));
+                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_INPUT,
+                        passedThroughInputAtts,
+                        passedThroughInputAtts
                     );
                 }
             });

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -405,7 +405,7 @@ public class XFormParser implements IXFormParserFunctions {
         try {
             reader.close();
         } catch (IOException e) {
-            Std.out.println("Error closing reader");
+            Std.err.println("Error closing reader");
             Std.printStack(e);
         }
         ctParse.logDone();

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -43,7 +43,7 @@ import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.core.services.locale.TableLocaleSource;
 import org.javarosa.core.util.CacheTable;
-import org.javarosa.core.util.CodeTimer;
+import org.javarosa.core.util.StopWatch;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactoryDeprecated;
 import org.javarosa.model.xform.XPathReference;
@@ -368,7 +368,7 @@ public class XFormParser implements IXFormParserFunctions {
      */
     @Deprecated public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache)
         throws IOException {
-        final CodeTimer ctParse = new CodeTimer("Reading XML and parsing with kXML2");
+        final StopWatch ctParse = StopWatch.start();
         Document doc = new Document();
 
         try{
@@ -403,17 +403,17 @@ public class XFormParser implements IXFormParserFunctions {
             logger.info("Error closing reader");
             logger.error("Error", e);
         }
-        ctParse.logDone();
+        logger.info(ctParse.logLine("Reading XML and parsing with kXML2"));
 
-        final CodeTimer ctConsolidate = new CodeTimer("Consolidating text");
+        StopWatch ctConsolidate = StopWatch.start();
         XmlTextConsolidator.consolidateText(stringCache, doc.getRootElement());
-        ctConsolidate.logDone();
+        logger.info(ctConsolidate.logLine("Consolidating text"));
 
         return doc;
     }
 
     private void parseDoc(Map<String, String> namespacePrefixesByUri) {
-        final CodeTimer codeTimer = new CodeTimer("Creating FormDef from parsed XML");
+        final StopWatch codeTimer = StopWatch.start();
         _f = new FormDef();
 
         initState();
@@ -478,7 +478,7 @@ public class XFormParser implements IXFormParserFunctions {
         _f.getMainInstance().getRoot().clearChildrenCaches();
         _f.getMainInstance().getRoot().clearCaches();
 
-        codeTimer.logDone();
+        logger.info(codeTimer.logLine("Creating FormDef from parsed XML"));
     }
 
     private final Set<String> validElementNames = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -391,10 +391,8 @@ public class XFormParser implements IXFormParserFunctions {
             //CTS - 12/09/2012 - Stop swallowing IO Exceptions
             throw e;
         } catch(Exception e){
-            //#if debug.output==verbose || debug.output==exception
             logger.error("Unhandled Exception while Parsing XForm", e);
             throw new XFormParseException("Unhandled Exception while Parsing XForm");
-            //#endif
         }
 
         try {
@@ -600,10 +598,8 @@ public class XFormParser implements IXFormParserFunctions {
                 //is set for the build. It dynamically wipes out old model nodes once they're
                 //used. This is sketchy if anything else plans on touching the nodes.
                 //This code can be removed once we're pull-parsing
-                //#if org.javarosa.xform.stingy
                 e.removeChild(i);
                 --i;
-                //#endif
             }
         }
 
@@ -1595,7 +1591,6 @@ public class XFormParser implements IXFormParserFunctions {
             //is set for the build. It dynamically wipes out old model nodes once they're
             //used. This is sketchy if anything else plans on touching the nodes.
             //This code can be removed once we're pull-parsing
-            //#if org.javarosa.xform.stingy
             removeIndexes.add(j);
         }
         ElementChildDeleter.delete(trans, removeIndexes);

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -17,7 +17,6 @@
 package org.javarosa.xform.parse;
 
 import org.javarosa.core.model.Action;
-import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.GroupDef;
@@ -72,9 +71,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,6 +79,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
+import static org.javarosa.core.model.Constants.CONTROL_INPUT;
+import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_SECRET;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
+import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
+import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
+import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
+import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
 import static org.javarosa.core.model.instance.ExternalDataInstance.getPathIfExternalDataInstance;
 import static org.javarosa.core.services.ProgramFlow.die;
 import static org.javarosa.xform.parse.Constants.ID_ATTR;
@@ -188,36 +203,30 @@ public class XFormParser implements IXFormParserFunctions {
                     // Attributes that are passed through to additionalAttributes but shouldn't lead to warnings.
                     // These are consistently used by clients but are expected in additionalAttributes for historical
                     // reasons.
-                    final List<String> passedThroughInputAtts = Collections.unmodifiableList(Arrays.asList(
-                        "rows",
-                        "query"
-                    ));
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_INPUT,
-                        passedThroughInputAtts,
-                        passedThroughInputAtts
-                    );
+                    List<String> passedThroughInputAtts = unmodifiableList(asList("rows", "query"));
+                    p.parseControl((IFormElement) parent, e, CONTROL_INPUT, passedThroughInputAtts, passedThroughInputAtts);
                 }
             });
             put("range", new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_RANGE,
-                        Arrays.asList("start", "end", "step") // Prevent warning about unexpected attributes
+                    p.parseControl((IFormElement) parent, e, CONTROL_RANGE,
+                        asList("start", "end", "step") // Prevent warning about unexpected attributes
                     );
                 }
             });
             put("secret", new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_SECRET);
+                    p.parseControl((IFormElement) parent, e, CONTROL_SECRET);
                 }
             });
             put(SELECT, new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_SELECT_MULTI);
+                    p.parseControl((IFormElement) parent, e, CONTROL_SELECT_MULTI);
                 }
             });
             put(SELECTONE, new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_SELECT_ONE);
+                    p.parseControl((IFormElement) parent, e, CONTROL_SELECT_ONE);
                 }
             });
             put("group", new IElementHandler() {
@@ -232,12 +241,12 @@ public class XFormParser implements IXFormParserFunctions {
             });
             put("trigger", new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseControl((IFormElement) parent, e, Constants.CONTROL_TRIGGER);
+                    p.parseControl((IFormElement) parent, e, CONTROL_TRIGGER);
                 }
             }); //multi-purpose now; need to dig deeper
-            put(Constants.XFTAG_UPLOAD, new IElementHandler() {
+            put(XFTAG_UPLOAD, new IElementHandler() {
                 @Override public void handle(XFormParser p, Element e, Object parent) {
-                    p.parseUpload((IFormElement) parent, e, Constants.CONTROL_UPLOAD);
+                    p.parseUpload((IFormElement) parent, e, CONTROL_UPLOAD);
                 }
             });
             put(LABEL_ELEMENT, new IElementHandler() {
@@ -480,7 +489,7 @@ public class XFormParser implements IXFormParserFunctions {
         logger.info(codeTimer.logLine("Creating FormDef from parsed XML"));
     }
 
-    private final Set<String> validElementNames = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private final Set<String> validElementNames = unmodifiableSet(new HashSet<>(asList(
         "html",
         "head",
         "body",
@@ -775,24 +784,24 @@ public class XFormParser implements IXFormParserFunctions {
         // get media type value
         String mediaType = e.getAttributeValue(null, "mediatype");
         // parse the control
-        QuestionDef question = parseControl(parent, e, controlUpload, Arrays.asList("mediatype"));
+        QuestionDef question = parseControl(parent, e, controlUpload, asList("mediatype"));
 
         // apply the media type value to the returned question def.
         if ("image/*".equals(mediaType)) {
             // NOTE: this could be further expanded.
-            question.setControlType(Constants.CONTROL_IMAGE_CHOOSE);
+            question.setControlType(CONTROL_IMAGE_CHOOSE);
         } else if("audio/*".equals(mediaType)) {
-            question.setControlType(Constants.CONTROL_AUDIO_CAPTURE);
+            question.setControlType(CONTROL_AUDIO_CAPTURE);
         } else if ("video/*".equals(mediaType)) {
-            question.setControlType(Constants.CONTROL_VIDEO_CAPTURE);
+            question.setControlType(CONTROL_VIDEO_CAPTURE);
         } else if ("osm/*".equals(mediaType)) {
-            question.setControlType(Constants.CONTROL_OSM_CAPTURE);
+            question.setControlType(CONTROL_OSM_CAPTURE);
             List<OSMTag> tags = parseOsmTags(e);
             question.setOsmTags(tags);
         } else {
             // everything else.
             // Presumably, the appearance attribute would govern how this is handled.
-            question.setControlType(Constants.CONTROL_FILE_CAPTURE);
+            question.setControlType(CONTROL_FILE_CAPTURE);
         }
         return question;
     }
@@ -893,7 +902,7 @@ public class XFormParser implements IXFormParserFunctions {
         final QuestionDef question = questionForControlType(controlType);
         question.setID(serialQuestionID++); //until we come up with a better scheme
 
-        final List<String> usedAtts = new ArrayList<>(Arrays.asList(REF_ATTR, BIND_ATTR, APPEARANCE_ATTR));
+        final List<String> usedAtts = new ArrayList<>(asList(REF_ATTR, BIND_ATTR, APPEARANCE_ATTR));
         if (additionalUsedAtts != null) {
             usedAtts.addAll(additionalUsedAtts);
         }
@@ -920,7 +929,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         } else {
             //noinspection StatementWithEmptyBody
-            if (controlType == Constants.CONTROL_TRIGGER) {
+            if (controlType == CONTROL_TRIGGER) {
                 //TODO: special handling for triggers? also, not all triggers created equal
             } else {
                 throw new XFormParseException("XForm Parse: input control with neither 'ref' nor 'bind'",e);
@@ -933,14 +942,14 @@ public class XFormParser implements IXFormParserFunctions {
             }
             question.setBind(dataRef);
 
-            if (controlType == Constants.CONTROL_SELECT_ONE) {
+            if (controlType == CONTROL_SELECT_ONE) {
                 selectOnes.add((TreeReference) dataRef.getReference());
-            } else if (controlType == Constants.CONTROL_SELECT_MULTI) {
+            } else if (controlType == CONTROL_SELECT_MULTI) {
                 selectMultis.add((TreeReference) dataRef.getReference());
             }
         }
 
-        boolean isSelect = (controlType == Constants.CONTROL_SELECT_MULTI || controlType == Constants.CONTROL_SELECT_ONE);
+        boolean isSelect = (controlType == CONTROL_SELECT_MULTI || controlType == CONTROL_SELECT_ONE);
         question.setControlType(controlType);
         question.setAppearanceAttr(e.getAttributeValue(null, APPEARANCE_ATTR));
 
@@ -979,7 +988,7 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     private QuestionDef questionForControlType(int controlType) {
-        return controlType == Constants.CONTROL_RANGE ? new RangeQuestion() : new QuestionDef();
+        return controlType == CONTROL_RANGE ? new RangeQuestion() : new QuestionDef();
     }
 
     private void parseQuestionLabel (QuestionDef q, Element e) {
@@ -1208,7 +1217,7 @@ public class XFormParser implements IXFormParserFunctions {
                         char c = value.charAt(k);
 
                         if (" \n\t\f\r\'\"`".indexOf(c) >= 0) {
-                            boolean isMultiSelect = (q.getControlType() == Constants.CONTROL_SELECT_MULTI);
+                            boolean isMultiSelect = (q.getControlType() == CONTROL_SELECT_MULTI);
                             triggerWarning(
                                 (isMultiSelect ? SELECT : SELECTONE) + " question <value>s [" + value + "] " +
                                     (isMultiSelect ? "cannot" : "should not") + " contain spaces, and are recommended not to contain apostraphes/quotation marks",
@@ -1713,7 +1722,7 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     /** Attributes that are read into DataBinding fields **/
-    private final List<String> usedAtts = Collections.unmodifiableList(Arrays.asList(
+    private final List<String> usedAtts = unmodifiableList(asList(
         ID_ATTR,
         NODESET_ATTR,
         "type",
@@ -1733,7 +1742,7 @@ public class XFormParser implements IXFormParserFunctions {
      * Attributes that are passed through to additionalAttrs but shouldn't lead to warnings.
      * These are consistently used by clients but are expected in additionalAttrs for historical reasons.
      **/
-    private final List<String> passedThroughAtts = Collections.unmodifiableList(Arrays.asList(
+    private final List<String> passedThroughAtts = unmodifiableList(asList(
             "requiredMsg",
             "saveIncomplete"
     ));
@@ -1981,7 +1990,7 @@ public class XFormParser implements IXFormParserFunctions {
 
     /** Finds a questiondef that binds to ref, if the data type is a 'select' question type */
     public static QuestionDef ghettoGetQuestionDef (int dataType, FormDef f, TreeReference ref) {
-        if (dataType == Constants.DATATYPE_CHOICE || dataType == Constants.DATATYPE_CHOICE_LIST) {
+        if (dataType == DATATYPE_CHOICE || dataType == DATATYPE_CHOICE_LIST) {
             return FormDef.findQuestionByRef(ref, f);
         } else {
             return null;

--- a/src/org/javarosa/xform/parse/XFormParserReporter.java
+++ b/src/org/javarosa/xform/parse/XFormParserReporter.java
@@ -1,39 +1,64 @@
 /**
- * 
+ *
  */
 package org.javarosa.xform.parse;
 
+import java.io.PrintStream;
 import org.javarosa.core.io.Std;
 
-import java.io.PrintStream;
-
 /**
+ * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
+ *
  * A Parser Reporter is provided to the XFormParser to receive
- * warnings and errors from the parser. 
- * 
+ * warnings and errors from the parser.
+ *
  * @author ctsims
+ * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
  */
+@Deprecated
 public class XFormParserReporter {
+    @Deprecated
     public static final String TYPE_UNKNOWN_MARKUP = "markup";
-    public static final String TYPE_INVALID_STRUCTURE ="invalid-structure";
-    public static final String TYPE_ERROR_PRONE ="dangerous";
-    public static final String TYPE_TECHNICAL ="technical";
+    @Deprecated
+    public static final String TYPE_INVALID_STRUCTURE = "invalid-structure";
+    @Deprecated
+    public static final String TYPE_ERROR_PRONE = "dangerous";
+    @Deprecated
+    public static final String TYPE_TECHNICAL = "technical";
+    @Deprecated
     protected static final String TYPE_ERROR = "error";
 
+    @Deprecated
     PrintStream errorStream;
 
+    /**
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
+     */
+    @Deprecated
     public XFormParserReporter() {
         this(Std.err);
     }
 
+    /**
+     * @deprecated Use {@link org.slf4j.LoggerFactory#getLogger(Class)} instead
+     */
+    @Deprecated
     public XFormParserReporter(PrintStream errorStream) {
         this.errorStream = errorStream;
     }
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger#warn(String)} instead
+     */
+    @Deprecated
     public void warning(String type, String message, String xmlLocation) {
         errorStream.println("XForm Parse Warning: " + message + (xmlLocation == null ? "" : xmlLocation));
     }
 
+    /**
+     * @deprecated Use {@link org.slf4j.Logger#error(String, Throwable)} instead
+     */
+    @Deprecated
     public void error(String message) {
         errorStream.println("XForm Parse Error: " + message);
     }

--- a/src/org/javarosa/xform/parse/XFormParserReporter.java
+++ b/src/org/javarosa/xform/parse/XFormParserReporter.java
@@ -4,7 +4,8 @@
 package org.javarosa.xform.parse;
 
 import java.io.PrintStream;
-import org.javarosa.core.io.Std;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <b>Warning:</b> This class is unused and should remain that way. It will be removed in a future release.
@@ -17,6 +18,7 @@ import org.javarosa.core.io.Std;
  */
 @Deprecated
 public class XFormParserReporter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(XFormParseException.class);
     @Deprecated
     public static final String TYPE_UNKNOWN_MARKUP = "markup";
     @Deprecated
@@ -36,7 +38,6 @@ public class XFormParserReporter {
      */
     @Deprecated
     public XFormParserReporter() {
-        this(Std.err);
     }
 
     /**
@@ -52,7 +53,7 @@ public class XFormParserReporter {
      */
     @Deprecated
     public void warning(String type, String message, String xmlLocation) {
-        errorStream.println("XForm Parse Warning: " + message + (xmlLocation == null ? "" : xmlLocation));
+        LOGGER.warn("XForm Parse Warning: {} {}", message, xmlLocation == null ? "" : xmlLocation);
     }
 
     /**
@@ -60,6 +61,6 @@ public class XFormParserReporter {
      */
     @Deprecated
     public void error(String message) {
-        errorStream.println("XForm Parse Error: " + message);
+        LOGGER.error("XForm Parse Error: {}", message);
     }
 }

--- a/src/org/javarosa/xform/util/XFormSerializer.java
+++ b/src/org/javarosa/xform/util/XFormSerializer.java
@@ -16,7 +16,6 @@
 
 package org.javarosa.xform.util;
 
-import org.javarosa.core.io.Std;
 import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
@@ -26,12 +25,15 @@ import java.io.DataOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /* this is just a big dump of serialization-related code */
 
 /* basically, anything that didn't belong in XFormParser */
 
 public class XFormSerializer {
+    private static final Logger logger = LoggerFactory.getLogger(XFormSerializer.class);
 
     public static ByteArrayOutputStream getStream(Document doc) {
         KXmlSerializer serializer = new KXmlSerializer();
@@ -43,7 +45,7 @@ public class XFormSerializer {
             serializer.flush();
             return bos;
         } catch (Exception e) {
-            Std.printStack(e);
+            logger.error("Error", e);
             return null;
         }
     }
@@ -61,9 +63,9 @@ public class XFormSerializer {
             s = new String(bos.toByteArray(),"UTF-8");
             return s;
         }catch (UnsupportedEncodingException uce){
-            Std.printStack(uce);
+            logger.error("Error", uce);
         } catch (Exception ex) {
-            Std.printStack(ex);
+            logger.error("Error", ex);
             return null;
         }
 
@@ -92,7 +94,7 @@ public class XFormSerializer {
             serializer.flush();
             return bos.toByteArray();
         } catch (Exception e) {
-            Std.printStack(e);
+            logger.error("Error", e);
             return null;
         }
     }

--- a/src/org/javarosa/xform/util/XFormUtils.java
+++ b/src/org/javarosa/xform/util/XFormUtils.java
@@ -24,7 +24,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
@@ -32,6 +31,8 @@ import org.javarosa.xform.parse.IXFormParserFactory;
 import org.javarosa.xform.parse.XFormParseException;
 import org.javarosa.xform.parse.XFormParserFactory;
 import org.kxml2.kdom.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Static Utility methods pertaining to XForms.
@@ -40,6 +41,8 @@ import org.kxml2.kdom.Element;
  *
  */
 public class XFormUtils {
+    private static final Logger logger = LoggerFactory.getLogger(XFormUtils.class);
+
     private static IXFormParserFactory _factory = new XFormParserFactory();
 
     public static IXFormParserFactory setXFormParserFactory(IXFormParserFactory factory) {
@@ -51,7 +54,7 @@ public class XFormUtils {
     public static FormDef getFormFromResource (String resource) {
         InputStream is = System.class.getResourceAsStream(resource);
         if (is == null) {
-            Std.err.println("Can't find form resource \"" + resource + "\". Is it in the JAR?");
+            logger.error("Can't find form resource {}. Is it in the JAR?", resource);
             return null;
         }
 
@@ -84,8 +87,7 @@ public class XFormUtils {
                     isr.close();
                 }
             } catch (IOException e) {
-                Std.err.println("IO Exception while closing stream.");
-                Std.printStack(e);
+                logger.error("IO Exception while closing stream.", e);
             }
         }
     }
@@ -100,26 +102,26 @@ public class XFormUtils {
                 returnForm = (FormDef) ExtUtil.read(dis, FormDef.class);
             } else {
                 //#if debug.output==verbose
-                Std.out.println("ResourceStream NULL");
+                logger.info("ResourceStream NULL");
                 //#endif
             }
         } catch (IOException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
         } catch (DeserializationException e) {
-            Std.printStack(e);
+            logger.error("Error", e);
         } finally {
             if (is != null) {
                 try {
                     is.close();
                 } catch (IOException e) {
-                    Std.printStack(e);
+                    logger.error("Error", e);
                 }
             }
             if (dis != null) {
                 try {
                     dis.close();
                 } catch (IOException e) {
-                    Std.printStack(e);
+                    logger.error("Error", e);
                 }
             }
         }

--- a/src/org/javarosa/xform/util/XFormUtils.java
+++ b/src/org/javarosa/xform/util/XFormUtils.java
@@ -101,9 +101,7 @@ public class XFormUtils {
                 dis = new DataInputStream(is);
                 returnForm = (FormDef) ExtUtil.read(dis, FormDef.class);
             } else {
-                //#if debug.output==verbose
                 logger.info("ResourceStream NULL");
-                //#endif
             }
         } catch (IOException e) {
             logger.error("Error", e);

--- a/src/org/javarosa/xml/ElementParser.java
+++ b/src/org/javarosa/xml/ElementParser.java
@@ -1,6 +1,7 @@
 package org.javarosa.xml;
 
-import org.javarosa.core.services.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.kxml2.io.KXmlParser;
@@ -25,6 +26,8 @@ import java.io.InputStream;
  * @author ctsims
  */
 public abstract class ElementParser<T> {
+    private static final Logger logger = LoggerFactory.getLogger(ElementParser.class);
+
     protected final KXmlParser parser;
 
     /**
@@ -63,7 +66,7 @@ public abstract class ElementParser<T> {
             return parser;
         } catch (XmlPullParserException e) {
             // TODO Auto-generated catch block
-            Logger.exception("Element Parser", e);
+            logger.error("Element Parser", e);
             throw new IOException(e.getMessage());
         } catch (IllegalArgumentException e) {
             e.printStackTrace();

--- a/src/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/org/javarosa/xpath/expr/XPathExpression.java
@@ -20,14 +20,14 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.instance.DataInstance;
-import org.javarosa.core.services.Logger;
+import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 import org.javarosa.core.util.externalizable.Externalizable;
 
 public abstract class XPathExpression implements Externalizable, Serializable {
+    private static final Logger logger = LoggerFactory.getLogger(XPathExpression.class);
 
     public Object eval (EvaluationContext evalContext) {
         return this.eval(evalContext.getMainInstance(), evalContext);
@@ -46,7 +46,7 @@ public abstract class XPathExpression implements Externalizable, Serializable {
         } catch(Exception e) {
             //Pivots aren't critical, if there was a problem getting one, log the exception
             //so we can fix it, and then just report that.
-            Logger.exception(e);
+            logger.error("Error while pivoting", e);
             throw new UnpivotableExpressionException(e.getMessage());
         }
     }
@@ -76,9 +76,10 @@ public abstract class XPathExpression implements Externalizable, Serializable {
     int indent;
 
     private void printStr (String s) {
+        StringBuilder padding = new StringBuilder();
         for (int i = 0; i < 2 * indent; i++)
-            Std.out.print(" ");
-        Std.out.println(s);
+            padding.append(" ");
+        logger.info("{}{}", padding, s);
     }
 
     public void printParseTree () {

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -410,7 +410,7 @@ public class XPathFuncExpr extends XPathExpression {
             // i.e., does not work with 'start' or 'end' property.
             assertArgsCount(name, args, 1);
             String s = toString(argVals[0]);
-            return PropertyManager._().getSingularProperty(s);
+            return PropertyManager.__().getSingularProperty(s);
         } else if (name.equals("pow") && (args.length == 2)) { //XPath 3.0
             double a = toDouble(argVals[0]);
             double b = toDouble(argVals[1]);

--- a/src/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.data.BooleanData;
@@ -55,8 +54,12 @@ import org.javarosa.xpath.XPathMissingInstanceException;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnsupportedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XPathPathExpr extends XPathExpression {
+    private static final Logger logger = LoggerFactory.getLogger(XPathPathExpr.class);
+
     public static final int INIT_CONTEXT_ROOT = 0;
     public static final int INIT_CONTEXT_RELATIVE = 1;
     public static final int INIT_CONTEXT_EXPR = 2;
@@ -319,7 +322,7 @@ public class XPathPathExpr extends XPathExpression {
             // we have no access fns that interact with GeoTrace objects (the getValue() data type)...
             return val.getDisplayText();
         } else {
-            Std.out.println("warning: unrecognized data type in xpath expr: " + val.getClass().getName());
+            logger.warn("unrecognized data type in xpath expr: " + val.getClass().getName());
             return val.getValue(); //is this a good idea?
         }
     }

--- a/src/org/javarosa/xpath/parser/ast/ASTNode.java
+++ b/src/org/javarosa/xpath/parser/ast/ASTNode.java
@@ -19,13 +19,16 @@ package org.javarosa.xpath.parser.ast;
 import java.util.Enumeration;
 import java.util.Vector;
 
-import org.javarosa.core.io.Std;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.Parser;
 import org.javarosa.xpath.parser.Token;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class ASTNode {
+    private static final Logger logger = LoggerFactory.getLogger(ASTNode.class);
+
     public abstract Vector<ASTNode> getChildren();
     public abstract XPathExpression build() throws XPathSyntaxException;
 
@@ -34,9 +37,10 @@ public abstract class ASTNode {
     int indent;
 
     private void printStr (String s) {
+        StringBuilder padding = new StringBuilder();
         for (int i = 0; i < 2 * indent; i++)
-            Std.out.print(" ");
-        Std.out.println(s);
+            padding.append(" ");
+        logger.info("{}{}", padding, s);
     }
 
     public void print () {

--- a/test/org/javarosa/core/form/api/test/TextFormTests.java
+++ b/test/org/javarosa/core/form/api/test/TextFormTests.java
@@ -17,8 +17,11 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TextFormTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(TextFormTests.class);
 
     QuestionDef q = null;
     FormEntryPrompt fep = null;
@@ -34,7 +37,7 @@ public class TextFormTests extends TestCase {
 
     public TextFormTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public void setUp(){
@@ -47,7 +50,7 @@ public class TextFormTests extends TestCase {
 
     public static Test suite() {
         TestSuite aSuite = new TestSuite();
-        System.out.println("Running TextFormTests...");
+        logger.info("Running TextFormTests...");
         for (int i = 1; i <= NUM_TESTS; i++) {
             final int testID = i;
             aSuite.addTest(new TextFormTests(doTest(testID)));

--- a/test/org/javarosa/core/io/test/BufferedInputStreamTests.java
+++ b/test/org/javarosa/core/io/test/BufferedInputStreamTests.java
@@ -27,8 +27,11 @@ import junit.framework.TestSuite;
 
 import org.javarosa.core.io.BufferedInputStream;
 import org.javarosa.core.util.ArrayUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BufferedInputStreamTests extends TestCase{
+    private static final Logger logger = LoggerFactory.getLogger(BufferedInputStreamTests.class);
 
     byte[] bytes;
 
@@ -52,7 +55,7 @@ public class BufferedInputStreamTests extends TestCase{
 
     public BufferedInputStreamTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -67,8 +70,6 @@ public class BufferedInputStreamTests extends TestCase{
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testBuffered";
         case 2: return "testIndividual";

--- a/test/org/javarosa/core/model/Safe2014DagImplTest.java
+++ b/test/org/javarosa/core/model/Safe2014DagImplTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -20,6 +22,7 @@ import static org.javarosa.xform.parse.FormParserHelper.parse;
 import static org.junit.Assert.assertThat;
 
 public class Safe2014DagImplTest {
+    private static final Logger logger = LoggerFactory.getLogger(Safe2014DagImplTest.class);
 
     private final List<Event> dagEvents = new ArrayList<>();
 
@@ -374,12 +377,12 @@ public class Safe2014DagImplTest {
             long currentIterationStart = System.nanoTime();
             formDef.deleteRepeat(firstRepeatIndex);
             double tookMs = (System.nanoTime() - currentIterationStart) / 1000000D;
-            System.out.printf("%d\t%.3f\n", i, tookMs);
+            logger.info(String.format("%d\t%.3f\n", i, tookMs));
         }
 
         // Then
         final String elapsedFormatted = LocalTime.fromMillisOfDay(System.currentTimeMillis() - startMs).toString();
-        System.out.println("Deletion of " + numberOfRepeats + " repeats took " + elapsedFormatted);
+        logger.info("Deletion of {} repeats took {}", numberOfRepeats, elapsedFormatted);
     }
 
     /**

--- a/test/org/javarosa/core/model/data/test/DateDataTests.java
+++ b/test/org/javarosa/core/model/data/test/DateDataTests.java
@@ -24,9 +24,11 @@ import java.util.Date;
 
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.utils.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DateDataTests extends TestCase {
-
+    private static final Logger logger = LoggerFactory.getLogger(DateDataTests.class);
     Date today;
     Date notToday;
 
@@ -41,7 +43,7 @@ public class DateDataTests extends TestCase {
 
     public DateDataTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -56,8 +58,6 @@ public class DateDataTests extends TestCase {
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testGetData";
         case 2: return "testSetData";

--- a/test/org/javarosa/core/model/data/test/IntegerDataTests.java
+++ b/test/org/javarosa/core/model/data/test/IntegerDataTests.java
@@ -21,8 +21,12 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import org.javarosa.core.model.data.IntegerData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IntegerDataTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(IntegerDataTests.class);
+
     Integer one;
     Integer two;
 
@@ -40,7 +44,7 @@ public class IntegerDataTests extends TestCase {
 
     public IntegerDataTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -55,8 +59,6 @@ public class IntegerDataTests extends TestCase {
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testGetData";
         case 2: return "testSetData";

--- a/test/org/javarosa/core/model/data/test/SelectMultiDataTests.java
+++ b/test/org/javarosa/core/model/data/test/SelectMultiDataTests.java
@@ -16,20 +16,21 @@
 
 package org.javarosa.core.model.data.test;
 
+import java.util.ArrayList;
+import java.util.List;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SelectMultiDataTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(SelectMultiDataTests.class);
     QuestionDef question;
 
     Selection one;
@@ -77,7 +78,7 @@ public class SelectMultiDataTests extends TestCase {
 
     public SelectMultiDataTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -91,9 +92,8 @@ public class SelectMultiDataTests extends TestCase {
 
         return aSuite;
     }
-    public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
 
+    public static String testMaster(int testID) {
         switch (testID) {
         case 1: return "testGetData";
         case 2: return "testSetData";
@@ -109,6 +109,7 @@ public class SelectMultiDataTests extends TestCase {
         assertEquals("SelectOneData's getValue returned an incorrect SelectOne", data.getValue(), one);
 
     }
+
     public void testSetData() {
         SelectMultiData data = new SelectMultiData(firstTwo);
         data.setValue(lastTwo);
@@ -121,6 +122,7 @@ public class SelectMultiDataTests extends TestCase {
         assertEquals("SelectMultiData did not properly reset value ", data.getValue(), firstTwo);
 
     }
+
     public void testNullData() {
         boolean exceptionThrown = false;
         SelectMultiData data = new SelectMultiData();

--- a/test/org/javarosa/core/model/data/test/SelectOneDataTests.java
+++ b/test/org/javarosa/core/model/data/test/SelectOneDataTests.java
@@ -24,8 +24,11 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SelectOneDataTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(SelectOneDataTests.class);
     QuestionDef question;
 
     Selection one;
@@ -54,7 +57,7 @@ public class SelectOneDataTests extends TestCase {
 
     public SelectOneDataTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -69,8 +72,6 @@ public class SelectOneDataTests extends TestCase {
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testGetData";
         case 2: return "testSetData";

--- a/test/org/javarosa/core/model/data/test/StringDataTests.java
+++ b/test/org/javarosa/core/model/data/test/StringDataTests.java
@@ -21,8 +21,11 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import org.javarosa.core.model.data.StringData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StringDataTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(StringDataTests.class);
     String stringA;
     String stringB;
 
@@ -40,7 +43,7 @@ public class StringDataTests extends TestCase {
 
     public StringDataTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -55,8 +58,6 @@ public class StringDataTests extends TestCase {
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testGetData";
         case 2: return "testSetData";

--- a/test/org/javarosa/core/model/data/test/TimeDataTests.java
+++ b/test/org/javarosa/core/model/data/test/TimeDataTests.java
@@ -23,8 +23,11 @@ import junit.framework.TestSuite;
 import java.util.Date;
 
 import org.javarosa.core.model.data.TimeData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TimeDataTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(TimeDataTests.class);
     Date now;
     Date minusOneHour;
 
@@ -39,7 +42,7 @@ public class TimeDataTests extends TestCase {
 
     public TimeDataTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -54,8 +57,6 @@ public class TimeDataTests extends TestCase {
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testGetData";
         case 2: return "testSetData";

--- a/test/org/javarosa/core/model/instance/test/QuestionDataElementTests.java
+++ b/test/org/javarosa/core/model/instance/test/QuestionDataElementTests.java
@@ -34,8 +34,11 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.utils.ITreeVisitor;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QuestionDataElementTests extends TestCase{
+    private static final Logger logger = LoggerFactory.getLogger(QuestionDataElementTests.class);
     private final String stringElementName = "String Data Element";
 
     StringData stringData;
@@ -135,7 +138,7 @@ public class QuestionDataElementTests extends TestCase{
 
     public QuestionDataElementTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -150,8 +153,6 @@ public class QuestionDataElementTests extends TestCase{
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
             case 1: return "testIsLeaf";
             case 2: return "testGetName";

--- a/test/org/javarosa/core/model/instance/test/QuestionDataGroupTests.java
+++ b/test/org/javarosa/core/model/instance/test/QuestionDataGroupTests.java
@@ -33,8 +33,11 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.utils.ITreeVisitor;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QuestionDataGroupTests extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(QuestionDataGroupTests.class);
     private final String stringElementName = "String Data Element";
     private final String groupName = "TestGroup";
 
@@ -138,7 +141,7 @@ public class QuestionDataGroupTests extends TestCase {
 
     public QuestionDataGroupTests(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -153,8 +156,6 @@ public class QuestionDataGroupTests extends TestCase {
         return aSuite;
     }
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
             case 1: return "testIsLeaf";
             case 2: return "testGetName";

--- a/test/org/javarosa/core/model/test/FormDefTest.java
+++ b/test/org/javarosa/core/model/test/FormDefTest.java
@@ -29,6 +29,8 @@ import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * See testAnswerConstraint() for an example of how to write the 
@@ -37,13 +39,14 @@ import org.javarosa.form.api.FormEntryPrompt;
  *
  */
 public class FormDefTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(FormDefTest.class);
     QuestionDef q = null;
     FormEntryPrompt fep = null;
     FormParseInit fpi = null;
 
     public FormDefTest(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public void setUp(){

--- a/test/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/test/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -30,9 +30,11 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DateUtilsTests extends TestCase {
-
+    private static final Logger logger = LoggerFactory.getLogger(DateUtilsTests.class);
     private static int NUM_TESTS = 8;
 
     Date currentTime;
@@ -40,7 +42,7 @@ public class DateUtilsTests extends TestCase {
 
     public DateUtilsTests(String name){
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public void setUp() throws Exception{

--- a/test/org/javarosa/core/model/utils/test/LocalizerTest.java
+++ b/test/org/javarosa/core/model/utils/test/LocalizerTest.java
@@ -30,12 +30,15 @@ import org.javarosa.core.util.OrderedMap;
 import org.javarosa.core.util.UnregisteredLocaleException;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.core.util.test.ExternalizableTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LocalizerTest extends TestCase  {
+    private static final Logger logger = LoggerFactory.getLogger(LocalizerTest.class);
 
     public LocalizerTest(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -53,8 +56,6 @@ public class LocalizerTest extends TestCase  {
     public static final int NUM_TESTS = 31;
 
     public static String testMaster (int testID) {
-        //System.out.println("running " + testID);
-
         switch (testID) {
         case 1: return "testEmpty";
         case 2: return "testAddLocale";
@@ -511,8 +512,6 @@ public class LocalizerTest extends TestCase  {
     }
 
     public void testGetText (int i, int j, int k, String ourLocale, String otherLocale, String textID, int localeCase, int formCase) {
-        //System.out.println("testing getText: "+localeCase+","+formCase+","+i+","+j+","+k);
-
         Localizer l = buildLocalizer(i, j, k, ourLocale, otherLocale);
         String expected = expectedText(textID, l);
         String text, text2;

--- a/test/org/javarosa/core/model/utils/test/LocalizerTest.java
+++ b/test/org/javarosa/core/model/utils/test/LocalizerTest.java
@@ -884,7 +884,6 @@ public class LocalizerTest extends TestCase  {
 
         }
         if(t.isAlive()) {
-            t.stop();
             throw new RuntimeException("Failed to return from recursive argument processing");
         }
     }

--- a/test/org/javarosa/core/test/FormParseInit.java
+++ b/test/org/javarosa/core/test/FormParseInit.java
@@ -15,6 +15,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /* TODO
  * Priority: Top priority is getting the localizations tested so that test coverage isn't lost
@@ -26,8 +28,8 @@ import java.util.List;
  * This class sets up everything you need to perform tests on the models and form elements found in JR (such
  * as QuestionDef, FormDef, Selections, etc).  It exposes hooks to the FormEntryController,FormEntryModel and
  * FormDef (all the toys you need to test IFormElements, provide answers to questions and test constraints, etc)
- * 
- * REMEMBER to set the 
+ *
+ * REMEMBER to set the
  */
 
 
@@ -36,6 +38,7 @@ import java.util.List;
 
 
 public class FormParseInit {
+    private static final Logger logger = LoggerFactory.getLogger(FormParseInit.class);
     private String FORM_NAME = (new File(PathConst.getTestResourcePath(), "ImageSelectTester.xhtml")).getAbsolutePath();
     private FormDef xform;
     private FormEntryController fec;
@@ -63,10 +66,8 @@ public class FormParseInit {
         try {
             is = new FileInputStream(xf_name);
         } catch (FileNotFoundException e) {
-            System.err.println("Error: the file '" + xf_name
-                    + "' could not be found!");
-            throw new RuntimeException("Error: the file '" + xf_name
-                    + "' could not be found!");
+            logger.error("Error: the file '{}' could not be found!", xf_name);
+            throw new RuntimeException("Error: the file '" + xf_name + "' could not be found!");
         }
 
         // Parse the form
@@ -76,8 +77,7 @@ public class FormParseInit {
         fec = new FormEntryController(femodel);
 
         if( xform == null ) {
-            System.out.println("\n\n==================================\nERROR: XForm has failed validation!!");
-        } else {
+            logger.error("ERROR: XForm has failed validation!!");
         }
     }
 

--- a/test/org/javarosa/core/util/GeoShapeAreaTest.java
+++ b/test/org/javarosa/core/util/GeoShapeAreaTest.java
@@ -19,16 +19,16 @@ package org.javarosa.core.util;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
 import org.javarosa.core.PathConst;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.xform.util.XFormUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Author: Meletis Margaritis
@@ -36,10 +36,11 @@ import org.javarosa.xform.util.XFormUtils;
  * Time: 3:40 PM
  */
 public class GeoShapeAreaTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(GeoShapeAreaTest.class);
 
   public GeoShapeAreaTest(String name) {
     super(name);
-    System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+    logger.info("Running {} test: {}...", this.getClass().getName(), name);
   }
 
   public static Test suite() {

--- a/test/org/javarosa/core/util/GeoUtilsTest.java
+++ b/test/org/javarosa/core/util/GeoUtilsTest.java
@@ -16,19 +16,21 @@
 
 package org.javarosa.core.util;
 
+import java.util.ArrayList;
+import java.util.List;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class GeoUtilsTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(GeoUtilsTest.class);
 
   public GeoUtilsTest(String name) {
     super(name);
-    System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+    logger.info("Running {} test: {}...", this.getClass().getName(), name);
   }
 
   public static Test suite() {
@@ -139,7 +141,7 @@ public class GeoUtilsTest extends TestCase {
 
     double area = GeoUtils.calculateAreaOfGPSPolygonOnEarthInSquareMeters(gpsCoordinatesList);
 
-    System.out.println("Area in m2: " + area);
+    logger.info("Area in m2: {}", area);
 
     assertTrue((int)Math.rint(area) == expectedArea);
   }

--- a/test/org/javarosa/core/util/test/ExternalizableTest.java
+++ b/test/org/javarosa/core/util/test/ExternalizableTest.java
@@ -16,6 +16,13 @@
 
 package org.javarosa.core.util.test;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -31,20 +38,15 @@ import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.ExternalizableWrapper;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExternalizableTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(ExternalizableTest.class);
 
     public ExternalizableTest(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -293,7 +295,7 @@ public class ExternalizableTest extends TestCase {
 
     private static void print (String s) {
         //#if javarosa.dev.serializationtest.verbose
-        System.out.println(s);
+        logger.info(s);
         //#endif
     }
 }

--- a/test/org/javarosa/core/util/test/ExternalizableTest.java
+++ b/test/org/javarosa/core/util/test/ExternalizableTest.java
@@ -294,8 +294,6 @@ public class ExternalizableTest extends TestCase {
     }
 
     private static void print (String s) {
-        //#if javarosa.dev.serializationtest.verbose
         logger.info(s);
-        //#endif
     }
 }

--- a/test/org/javarosa/core/util/test/NumericEncodingTest.java
+++ b/test/org/javarosa/core/util/test/NumericEncodingTest.java
@@ -19,16 +19,18 @@ package org.javarosa.core.util.test;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
 import org.javarosa.core.util.externalizable.ExtWrapIntEncoding;
 import org.javarosa.core.util.externalizable.ExtWrapIntEncodingSmall;
 import org.javarosa.core.util.externalizable.ExtWrapIntEncodingUniform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class NumericEncodingTest extends TestCase  {
+public class NumericEncodingTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(NumericEncodingTest.class);
 
     public NumericEncodingTest(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {

--- a/test/org/javarosa/xform/parse/FormParserHelper.java
+++ b/test/org/javarosa/xform/parse/FormParserHelper.java
@@ -16,20 +16,18 @@ public final class FormParserHelper {
     public static ParseResult parse(Path formName) throws IOException {
         XFormParser parser = new XFormParser(new FileReader(formName.toString()));
         final List<String> errorMessages = new ArrayList<>();
-        parser.attachReporter(new XFormParserReporter() {
+        parser.onWarning(new XFormParser.WarningCallback() {
             @Override
-            public void warning(String type, String message, String xmlLocation) {
+            public void accept(String message, String xmlLocation) {
                 errorMessages.add(message);
-                super.warning(type, message, xmlLocation);
-            }
-
-            @Override
-            public void error(String message) {
-                errorMessages.add(message);
-                super.error(message);
             }
         });
-
+        parser.onError(new XFormParser.ErrorCallback() {
+            @Override
+            public void accept(String message) {
+                errorMessages.add(message);
+            }
+        });
         return new ParseResult(parser.parse(), errorMessages);
     }
 

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -19,7 +19,6 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
-import org.javarosa.core.util.CodeTimer;
 import org.javarosa.core.util.JavaRosaCoreModule;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.model.xform.XFormSerializingVisitor;
@@ -29,7 +28,6 @@ import org.javarosa.xform.parse.FormParserHelper.ParseResult;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.kxml2.kdom.Element;
 
@@ -44,6 +42,8 @@ import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.file.Files.copy;
 import static java.nio.file.Files.readAllBytes;
@@ -61,6 +61,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class XFormParserTest {
+    private static final Logger logger = LoggerFactory.getLogger(XFormParserTest.class);
 
     private static final Path FORM_INSTANCE_XML_FILE_NAME           = r("instance.xml");
     private static final Path SECONDARY_INSTANCE_XML                = r("secondary-instance.xml");
@@ -79,11 +80,6 @@ public class XFormParserTest {
 
     private static final String ORX_2_NAMESPACE_PREFIX = "orx2";
     private static final String ORX_2_NAMESPACE_URI = "http://openrosa.org/xforms";
-
-    @Before
-    public void setUp() {
-        CodeTimer.setEnabled(true);
-    }
 
     @After
     public void tearDown() throws Exception {
@@ -165,7 +161,7 @@ public class XFormParserTest {
             }
         }
         for (String line : results) {
-            System.out.println(line);
+            logger.info(line);
         }
         Files.delete(largeDataFilename);
     }

--- a/test/org/javarosa/xform/util/test/XFormAnswerDataSerializerTest.java
+++ b/test/org/javarosa/xform/util/test/XFormAnswerDataSerializerTest.java
@@ -29,6 +29,8 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.data.TimeData;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xform.util.XFormAnswerDataSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Note that this is just a start and doesn't cover direct comparisons
@@ -38,6 +40,8 @@ import org.javarosa.xform.util.XFormAnswerDataSerializer;
  *
  */
 public class XFormAnswerDataSerializerTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(XFormAnswerDataSerializerTest.class);
+
     final String stringDataValue = "String Data Value";
     final Integer integerDataValue = new Integer(5);
     final Date dateDataValue = new Date();
@@ -78,7 +82,7 @@ public class XFormAnswerDataSerializerTest extends TestCase {
 
     public XFormAnswerDataSerializerTest(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -43,6 +43,8 @@ import org.javarosa.xpath.XPathUnsupportedException;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -51,6 +53,7 @@ import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 
 public class XPathEvalTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(XPathEvalTest.class);
 
     public XPathEvalTest(String name) {
         super(name);
@@ -79,7 +82,7 @@ public class XPathEvalTest extends TestCase {
         try {
             xpe = XPathParseTool.parseXPath(expr);
         } catch (XPathSyntaxException xpse) {
-            System.out.println("Parsing " + expr + " failed with " + xpse.toString());
+            logger.info("Parsing {} failed with {}", expr, xpse.toString());
         }
 
         if (xpe == null) {
@@ -93,7 +96,7 @@ public class XPathEvalTest extends TestCase {
                 fail("Expected exception, expression : " + expr);
             } else if ((result instanceof Double && expected instanceof Double)) {
                 if (! expected.equals(result)) {
-                    System.out.println(String.format("%s result %s differed from expected %s",
+                    logger.info(String.format("%s result %s differed from expected %s",
                             expr, result, expected));
                 }
                 assertEquals((Double) expected, (Double) result, 1e-12);
@@ -612,7 +615,7 @@ public class XPathEvalTest extends TestCase {
     }
     
     private void logTestCategory(String message) {
-        System.out.println("Running " + this.getClass().getName() + " test: " + message);
+        logger.info("Running {} test: {}", this.getClass().getName(), message);
     } 
 
     private EvaluationContext getFunctionHandlers () {
@@ -648,9 +651,9 @@ public class XPathEvalTest extends TestCase {
             public String getName() { return "regex";    }
             @Override
             public Object eval(Object[] args, EvaluationContext ec) {
-                System.out.println("EVAL REGEX TESTS:");
+                logger.info("EVAL REGEX TESTS:");
                 for (Object arg : args) {
-                    System.out.println("REGEX ARGS: " + arg.toString());
+                    logger.info("REGEX ARGS: {}", arg.toString());
                 }
 
 

--- a/test/org/javarosa/xpath/test/XPathParseTest.java
+++ b/test/org/javarosa/xpath/test/XPathParseTest.java
@@ -28,9 +28,12 @@ import org.javarosa.core.util.test.ExternalizableTest;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class XPathParseTest extends TestCase {
+    private static final Logger logger = LoggerFactory.getLogger(XPathParseTest.class);
     public static String[][] parseTestCases = {
         /* no null expressions */
         {"", null},
@@ -210,7 +213,7 @@ public class XPathParseTest extends TestCase {
 
     public XPathParseTest(String name) {
         super(name);
-        System.out.println("Running " + this.getClass().getName() + " test: " + name + "...");
+        logger.info("Running {} test: {}...", this.getClass().getName(), name);
     }
 
     public static Test suite() {
@@ -225,21 +228,15 @@ public class XPathParseTest extends TestCase {
             final String expr = parseTestCases[i][0];
             final String expected = parseTestCases[i][1];
 
-            System.out.print("XPath Parsing Test [" + expr + "]");
+            logger.info("XPath Parsing Test [{}]", expr);
             testParse(expr, expected);
         }
     }
 
     private void testXPathValid (String expr, String expected) {
-        //debug
-        //System.out.println("+[ " + expr + " ]");
-
         try {
             XPathExpression xpe = XPathParseTool.parseXPath(expr);
             String result = (xpe != null ? xpe.toString() : null);
-
-            //debug
-            //System.out.println("[ " + result + " ]");
 
             if (result == null || !result.equals(expected)) {
                 fail("XPath Parse Failed! Incorrect parse tree." +
@@ -257,9 +254,6 @@ public class XPathParseTest extends TestCase {
     }
 
     private void testXPathInvalid (String expr) {
-        //debug
-        //System.out.println("+[ " + expr + " ]");
-
         try {
             XPathExpression xpe = XPathParseTool.parseXPath(expr);
             String result = (xpe != null ? xpe.toString() : null);


### PR DESCRIPTION
Closes #152 

This PR adds SLF4J API to the project and Logback binding only for the tests.

All the code that was directly or indirectly using `System.out` and `System.err` has been migrated to SLF4J.

As a consequence, first, deprecation flags have been added to some public artifacts. Then any unused deprecated artifact has been removed. This is also discussed in #52:
- `org.javarosa.core.api.ILogger`
- `org.javarosa.core.io.Std`
- `org.javarosa.core.io.StreamsUtil`
- `org.javarosa.core.services.Logger`
- `org.javarosa.core.util.CodeTimer`
- `org.javarosa.xform.parse.XFormParserReporter`
  - There's a coupling issue with this class. It's used by `FormParserHelper` for logging **and** error handling:

    ```java
    public static ParseResult parse(Path formName) throws IOException {
        XFormParser parser = new XFormParser(new FileReader(formName.toString()));
        final List<String> errorMessages = new ArrayList<>();
        parser.attachReporter(new XFormParserReporter() {
            @Override
            public void warning(String type, String message, String xmlLocation) {
                errorMessages.add(message);
                super.warning(type, message, xmlLocation);
            }
    
            @Override
            public void error(String message) {
                errorMessages.add(message);
                super.error(message);
            }
        });
    
        return new ParseResult(parser.parse(), errorMessages);
    }
    ```

    This is the only special use of `XFormParserReporter` that requires a change on the API. The solution I propose is to add into `XFormParser` a pair of `onWarning` and `onError` methods:

    ```java
    public static ParseResult parse(Path formName) throws IOException {
        XFormParser parser = new XFormParser(new FileReader(formName.toString()));
        final List<String> errorMessages = new ArrayList<>();
        parser.onWarning(new XFormParser.WarningCallback() {
            @Override
            public void accept(String type, String message, String xmlLocation) {
                errorMessages.add(message);
            }
        });
        parser.onError(new XFormParser.ErrorCallback() {
            @Override
            public void accept(String message) {
                errorMessages.add(message);
            }
        });
        return new ParseResult(parser.parse(), errorMessages);
    }
    ```
#### What has been done to verify that this works as intended?
Compiled project and ran automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I tried to do the minimum amount of changes to do a meaningful migration to slf4j

#### Are there any risks to merging this code? If so, what are they?
Removal of public artifacts has to be explicitly documented on any release note of a JR release that includes this PR

Any error introduced by migrating manual log message variable interpolation to SLF4J's `{}` placeholder syntax. I manually reviewed this three times but there's a risk here of losing information on logs or getting unexpected changes on current log lines.