### PR TITLE
#227 Add support for xforms-value-changed event

### DIFF
--- a/resources/org/javarosa/core/model/actions/nested-setvalue-action-with-repeats.xml
+++ b/resources/org/javarosa/core/model/actions/nested-setvalue-action-with-repeats.xml
@@ -1,0 +1,32 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Nested setvalue action</h:title>
+        <model>
+            <instance>
+                <data id="data-id">
+                    <repeat>
+                        <cost/>
+                        <cost_timestamp/>
+                    </repeat>
+                    <repeat>
+                        <cost/>
+                        <cost_timestamp/>
+                    </repeat>
+                    <repeat>
+                        <cost/>
+                        <cost_timestamp/>
+                    </repeat>
+                </data>
+            </instance>
+            <bind nodeset="/data/repeat/cost" type="decimal" />
+            <bind nodeset="/data/repeat/cost_timestamp" type="dateTime" />
+        </model>
+    </h:head>
+    <h:body>
+        <repeat nodeset="/data/repeat">
+            <input ref="/data/repeat/cost">
+                <setvalue event="xforms-value-changed" ref="/data/repeat/cost_timestamp" value="now()" />
+            </input>
+        </repeat>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/actions/nested-setvalue-action.xml
+++ b/resources/org/javarosa/core/model/actions/nested-setvalue-action.xml
@@ -1,0 +1,21 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Nested setvalue action</h:title>
+        <model>
+            <instance>
+                <data id="data-id">
+                    <cost/>
+                    <cost_timestamp/>
+                    <cost_calculation/>
+                </data>
+            </instance>
+            <bind nodeset="/data/cost" type="decimal" />
+            <bind nodeset="/data/cost_timestamp" type="dateTime" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/cost">
+            <setvalue event="xforms-value-changed" ref="/data/cost_timestamp" value="now()" />
+        </input>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/Action.java
+++ b/src/org/javarosa/core/model/Action.java
@@ -23,7 +23,10 @@ public class Action implements Externalizable {
 
     public static final String EVENT_XFORMS_REVALIDATE = "xforms-revalidate";
 
+    public static final String EVENT_XFORMS_VALUE_CHANGED = "xforms-value-changed";
+
     public static final String EVENT_JR_INSERT = "jr-insert";
+
     private String name;
 
     public Action() {

--- a/src/org/javarosa/xform/parse/Constants.java
+++ b/src/org/javarosa/xform/parse/Constants.java
@@ -5,4 +5,5 @@ public class Constants {
     static final String NODESET_ATTR = "nodeset";
     static final String SELECTONE = "select1";
     static final String SELECT = "select";
+    public static final String SETVALUE = "setvalue";
 }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -87,6 +87,7 @@ import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
 import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.Constants.SETVALUE;
 import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 
@@ -285,7 +286,7 @@ public class XFormParser implements IXFormParserFunctions {
 
 
         structuredActions = new HashMap<>();
-        structuredActions.put("setvalue", new IElementHandler() {
+        structuredActions.put(SETVALUE, new IElementHandler() {
                 public void handle (XFormParser p, Element e, Object parent) { p.parseSetValueAction((FormDef)parent, e);}
         });
     }
@@ -627,6 +628,10 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     private void parseSetValueAction(FormDef form, Element e) {
+        parseSetValueAction(form, e, null);
+    }
+
+    private void parseSetValueAction(FormDef form, Element e, TreeReference trigger) {
         String ref = e.getAttributeValue(null, REF_ATTR);
         String bind = e.getAttributeValue(null, BIND_ATTR);
 
@@ -661,15 +666,16 @@ public class XFormParser implements IXFormParserFunctions {
         TreeReference treeref = FormInstance.unpackReference(dataRef);
 
         actionTargets.add(treeref);
+
         if(valueRef == null) {
             if(e.getChildCount() == 0 || !e.isText(0)) {
                 throw new XFormParseException("No 'value' attribute and no inner value set in <setvalue> associated with: " + treeref, e);
             }
             //Set expression
-            action = new SetValueAction(treeref, e.getText(0));
+            action = new SetValueAction(treeref, trigger, e.getText(0));
         } else {
             try {
-                action = new SetValueAction(treeref, XPathParseTool.parseXPath(valueRef));
+                action = new SetValueAction(treeref, trigger, XPathParseTool.parseXPath(valueRef));
             } catch (XPathSyntaxException e1) {
                 Std.printStack(e1);
                 throw new XFormParseException("Invalid XPath in value set action declaration: '" + valueRef + "'", e);
@@ -941,6 +947,8 @@ public class XFormParser implements IXFormParserFunctions {
                 parseItem(question, child);
             } else if (isSelect && "itemset".equals(childName)) {
                 parseItemset(question, child, parent);
+            } else if (SETVALUE.equals(childName)) {
+                parseSetValueAction(_f, child, FormInstance.unpackReference(dataRef));
             }
         }
         if (isSelect) {

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -39,6 +39,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
+import org.joda.time.DateTime;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -332,7 +333,7 @@ public class XPathFuncExpr extends XPathExpression {
             return DateUtils.roundDate(new Date());
         } else if (name.equals("now")) {
             assertArgsCount(name, args, 0);
-            return new Date();
+            return new DateTime().toDate();
         } else if (name.equals("concat")) {
             if (args.length == 1 && argVals[0] instanceof XPathNodeset) {
                 return join("", ((XPathNodeset) argVals[0]).toArgList());

--- a/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
+++ b/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
@@ -1,0 +1,98 @@
+package org.javarosa.core.model.actions;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.data.DateTimeData;
+import org.javarosa.core.model.data.DecimalData;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.instance.TreeReference;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.javarosa.xform.parse.FormParserHelper.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class NestedSetValueActionTest {
+
+    private static final long DATE_NOW = 1_500_000_000_000L;
+    private static final long DAY_OFFSET = 86_400_000L;
+
+    @Before
+    public void before() {
+        DateTimeUtils.setCurrentMillisFixed(DATE_NOW);
+    }
+
+    @After
+    public void after() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void when_triggerNodeIsUpdated_targetNodeCalculation_isEvaluated() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action.xml")).formDef;
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost_timestamp", 0);
+
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        assertNull(targetValue);
+
+        // When
+        formDef.setValue(new DecimalData(22.0), triggerRef, true);
+
+        // Then
+        targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW));
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
+
+    @Test
+    public void when_triggerNodeIsUpdatedWithTheSameValue_targetNodeCalculation_isNotEvaluated() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action.xml")).formDef;
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost_timestamp", 0);
+
+        DecimalData decimalValue = new DecimalData(22.0);
+        formDef.getMainInstance().resolveReference(targetRef).setValue(new DateTimeData(new Date(DATE_NOW)));
+        formDef.getMainInstance().resolveReference(triggerRef).setValue(decimalValue);
+
+        // When
+        DateTimeUtils.setCurrentMillisFixed(DATE_NOW + DAY_OFFSET); // shift the current time so we can test whether the setvalue action was re-fired
+        formDef.setValue(decimalValue, triggerRef, true);
+
+        // Then
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW));
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
+
+}

--- a/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
+++ b/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
@@ -65,6 +65,46 @@ public class NestedSetValueActionTest {
     }
 
     @Test
+    public void when_triggerNodeIsUpdatedWithinRepeat_targetNodeCalculation_isEvaluated() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action-with-repeats.xml")).formDef;
+
+        TreeReference[] triggerRefs = new TreeReference[3];
+        TreeReference[] targetRefs = new TreeReference[3];
+
+        for (int i = 0; i < 3; i++) {
+            TreeReference triggerRef = new TreeReference();
+            triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+            triggerRef.add("data", 0);
+            triggerRef.add("repeat", i);
+            triggerRef.add("cost", 0);
+
+            TreeReference targetRef = new TreeReference();
+            targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+            targetRef.add("data", 0);
+            targetRef.add("repeat", i);
+            targetRef.add("cost_timestamp", 0);
+
+            triggerRefs[i] = triggerRef;
+            targetRefs[i] = targetRef;
+        }
+
+        // When
+        for (int i = 0; i < 3; i++) {
+            DateTimeUtils.setCurrentMillisFixed(DATE_NOW + i * DAY_OFFSET);
+            formDef.setValue(new DecimalData(i+1), triggerRefs[i], true);
+        }
+
+        // Then
+        for (int i = 0; i < 3; i++) {
+            IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRefs[i]).getValue();
+            IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW + i * DAY_OFFSET));
+            assertEquals(expectedValue.getValue(), targetValue.getValue());
+        }
+    }
+
+    @Test
     public void when_triggerNodeIsUpdatedWithTheSameValue_targetNodeCalculation_isNotEvaluated() throws IOException {
         // Given
         final FormDef formDef =


### PR DESCRIPTION
Closes #227 

#### What has been done to verify that this works as intended?
Manual testing + unit tests.

#### Why is this the best possible solution? Were any other approaches considered?
This approach leverages existing `setvalue` action related code. 
As a different approach, the existing Observer Pattern code (`FormElementStateListener`) could be considered. However it seems to me to be too low level since it operates on `TreeElement` instances.

#### Are there any risks to merging this code? If so, what are they?
Existing code in `SetValueAction` uses `FormDef#setValue` to update the value of a node. Since now `FormDef#setValue` fires the `xforms-value-changed` event, it's possible to create a form that has dependency cycles. For example the following code:
```
<bind nodeset="/data/cost" type="decimal" />
<bind nodeset="/data/cost2" type="decimal" />
<bind nodeset="/data/cost3" type="decimal" />
...
<input ref="/data/cost">
  <setvalue event="xforms-value-changed" ref="/data/cost2" value="pow(/data/cost, 2)" />
</input>
<input ref="/data/cost2">
  <setvalue event="xforms-value-changed" ref="/data/cost3" value="pow(/data/cost2, 2)" />
</input>
<input ref="/data/cost3">
  <setvalue event="xforms-value-changed" ref="/data/cost" value="pow(/data/cost3, 2)" />
</input>
```
will keep looping till each node has the [infinity value](https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#POSITIVE_INFINITY). In other scenarios it may loop till `StackOverflowException` is thrown.

Thoughts on fixing this so far:
* use `FormDef#setAnswer` instead of `setValue` - this method however won't fire recalculation of triggerables so it may not be a feasible solution
* simply don't fire the event (but fire triggerables) if a value is updated from `SetValueAction` - would require some ugly code to handle it and wouldn't be consistent
* validate against dependency cycle and don't allow such forms

