### PR TITLE
#227 Add support for xforms-value-changed event

### DIFF
--- a/resources/org/javarosa/core/model/actions/nested-setvalue-action-dependency-cycles-between-actions-and-instance.xml
+++ b/resources/org/javarosa/core/model/actions/nested-setvalue-action-dependency-cycles-between-actions-and-instance.xml
@@ -1,0 +1,21 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Nested setvalue action</h:title>
+        <model>
+            <instance>
+                <data id="data-id">
+                    <cost/>
+                    <cost2/>
+                </data>
+            </instance>
+            <bind nodeset="/data/cost" type="decimal" calculate="pow(/data/cost2,2)"/>
+            <bind nodeset="/data/cost2" type="decimal" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/cost"/>
+        <input ref="/data/cost2">
+            <setvalue event="xforms-value-changed" ref="/data/cost3" value="pow(/data/cost2, 2)" />
+        </input>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/actions/nested-setvalue-action-dependency-cycles.xml
+++ b/resources/org/javarosa/core/model/actions/nested-setvalue-action-dependency-cycles.xml
@@ -1,0 +1,23 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Nested setvalue action</h:title>
+        <model>
+            <instance>
+                <data id="data-id">
+                    <cost/>
+                    <cost2/>
+                </data>
+            </instance>
+            <bind nodeset="/data/cost" type="decimal" />
+            <bind nodeset="/data/cost2" type="decimal" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/cost">
+            <setvalue event="xforms-value-changed" ref="/data/cost2" value="pow(/data/cost, 2)" />
+        </input>
+        <input ref="/data/cost2">
+            <setvalue event="xforms-value-changed" ref="/data/cost" value="pow(/data/cost2, 2)" />
+        </input>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/actions/nested-setvalue-action-with-repeats.xml
+++ b/resources/org/javarosa/core/model/actions/nested-setvalue-action-with-repeats.xml
@@ -1,0 +1,32 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Nested setvalue action</h:title>
+        <model>
+            <instance>
+                <data id="data-id">
+                    <repeat>
+                        <cost/>
+                        <cost_timestamp/>
+                    </repeat>
+                    <repeat>
+                        <cost/>
+                        <cost_timestamp/>
+                    </repeat>
+                    <repeat>
+                        <cost/>
+                        <cost_timestamp/>
+                    </repeat>
+                </data>
+            </instance>
+            <bind nodeset="/data/repeat/cost" type="decimal" />
+            <bind nodeset="/data/repeat/cost_timestamp" type="dateTime" />
+        </model>
+    </h:head>
+    <h:body>
+        <repeat nodeset="/data/repeat">
+            <input ref="/data/repeat/cost">
+                <setvalue event="xforms-value-changed" ref="/data/repeat/cost_timestamp" value="now()" />
+            </input>
+        </repeat>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/core/model/actions/nested-setvalue-action.xml
+++ b/resources/org/javarosa/core/model/actions/nested-setvalue-action.xml
@@ -1,0 +1,21 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Nested setvalue action</h:title>
+        <model>
+            <instance>
+                <data id="data-id">
+                    <cost/>
+                    <cost_timestamp/>
+                    <cost_calculation/>
+                </data>
+            </instance>
+            <bind nodeset="/data/cost" type="decimal" />
+            <bind nodeset="/data/cost_timestamp" type="dateTime" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/cost">
+            <setvalue event="xforms-value-changed" ref="/data/cost_timestamp" value="now()" />
+        </input>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/Action.java
+++ b/src/org/javarosa/core/model/Action.java
@@ -23,7 +23,10 @@ public class Action implements Externalizable {
 
     public static final String EVENT_XFORMS_REVALIDATE = "xforms-revalidate";
 
+    public static final String EVENT_XFORMS_VALUE_CHANGED = "xforms-value-changed";
+
     public static final String EVENT_JR_INSERT = "jr-insert";
+
     private String name;
 
     public Action() {

--- a/src/org/javarosa/core/model/CoreModelModule.java
+++ b/src/org/javarosa/core/model/CoreModelModule.java
@@ -48,7 +48,8 @@ public class CoreModelModule implements IModule {
             "org.javarosa.core.model.data.UncastData",
             "org.javarosa.core.model.data.helper.BasicDataPointer",
             "org.javarosa.core.model.Action",
-            "org.javarosa.core.model.actions.SetValueAction"
+            "org.javarosa.core.model.actions.SetValueAction",
+            "org.javarosa.core.model.actions.NestedSetValueAction"
     };
 
     @Override

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -19,6 +19,7 @@ package org.javarosa.core.model;
 import org.javarosa.core.io.Std;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.model.IDag.EventNotifierAccessor;
+import org.javarosa.core.model.actions.NestedSetValueAction;
 import org.javarosa.core.model.condition.Condition;
 import org.javarosa.core.model.condition.Constraint;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -655,6 +656,37 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      */
     public void reportDependencyCycles(XFormParserReporter reporter) {
         dagImpl.reportDependencyCycles(reporter);
+    }
+
+
+    public void reportDependencyCycles() {
+        final EventNotifierAccessor ia = new EventNotifierAccessor() {
+
+            @Override
+            public EventNotifier getEventNotifier() {
+                return FormDef.this.getEventNotifier();
+            }
+        };
+        final IDag dag = new Safe2014DagImpl(ia);
+
+        for (final String event : eventListeners.keySet()) {
+            for (final Action action : getEventListeners(event)) {
+                if (!(action instanceof NestedSetValueAction)) {
+                    // Ignore;
+                    continue;
+                }
+
+                final NestedSetValueAction nestedAction = (NestedSetValueAction) action;
+
+                if (nestedAction.getValue() == null) {
+                    // No XPath expression, ignore
+                    continue;
+                }
+
+//                dag.addTriggerable(new Recalculate(nestedAction.getValue(), nestedAction.getTarget()));
+            }
+        }
+//        for (final Action action : getEventListeners())
     }
 
     /**

--- a/src/org/javarosa/core/model/actions/NestedSetValueAction.java
+++ b/src/org/javarosa/core/model/actions/NestedSetValueAction.java
@@ -89,6 +89,23 @@ public class NestedSetValueAction extends Action {
         model.setValue(val == null ? null: AnswerDataFactory.templateByDataType(dataType).cast(val.uncast()), qualifiedReference, true);
     }
 
+    public TreeReference getTarget() {
+        return target;
+    }
+
+    public TreeReference getTrigger() {
+        return trigger;
+    }
+
+    public XPathExpression getValue() {
+        return value;
+    }
+
+    public String getExplicitValue() {
+        return explicitValue;
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         target = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
         trigger = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
@@ -99,6 +116,7 @@ public class NestedSetValueAction extends Action {
 
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, target);
         ExtUtil.write(out, trigger);

--- a/src/org/javarosa/core/model/actions/NestedSetValueAction.java
+++ b/src/org/javarosa/core/model/actions/NestedSetValueAction.java
@@ -1,11 +1,4 @@
-/**
- *
- */
 package org.javarosa.core.model.actions;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
 
 import org.javarosa.core.model.Action;
 import org.javarosa.core.model.FormDef;
@@ -22,32 +15,40 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 
-/**
- * @author ctsims
- *
- */
-public class SetValueAction extends Action {
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class NestedSetValueAction extends Action {
     private TreeReference target;
+    private TreeReference trigger;
     private XPathExpression value;
     private String explicitValue;
 
-    public SetValueAction() {
+    public NestedSetValueAction() {
 
     }
 
-    public SetValueAction(TreeReference target, XPathExpression value) {
+    public NestedSetValueAction(TreeReference target,  TreeReference trigger, XPathExpression value) {
         super("setvalue");
         this.target = target;
         this.value = value;
+        this.trigger = trigger;
     }
 
-    public SetValueAction(TreeReference target, String explicitValue) {
+    public NestedSetValueAction(TreeReference target, TreeReference trigger, String explicitValue) {
         super("setvalue");
         this.target = target;
         this.explicitValue = explicitValue;
+        this.trigger = trigger;
     }
 
     public void processAction(FormDef model, TreeReference contextRef) {
+
+        // If the trigger was specified then check if the context ref is not null and actually equals the trigger.
+        if (trigger != null && (contextRef == null || !trigger.equals(contextRef.genericize()))) {
+            return;
+        }
 
         //Qualify the reference if necessary
         TreeReference qualifiedReference = contextRef == null ? target : target.contextualize(contextRef);
@@ -55,7 +56,10 @@ public class SetValueAction extends Action {
         //For now we only process setValue actions which are within the
         //context if a context is provided. This happens for repeats where
         //insert events should only trigger on the right nodes
-        if(contextRef != null){
+        //If the trigger is specified then it means it's Action.EVENT_XFORMS_VALUE_CHANGED and thus
+        //it's not important if the target is withing the context. Context points to the node which value has changed and the target
+        //to be updated may be at any position within the form (instance).
+        if(contextRef != null && trigger == null) {
 
             //Note: right now we're qualifying then testing parentage to see wheter
             //there was a conflict, but it's not super clear whether this is a perfect
@@ -86,7 +90,8 @@ public class SetValueAction extends Action {
     }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        target = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
+        target = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
+        trigger = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
         explicitValue = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         if(explicitValue == null) {
             value = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
@@ -96,7 +101,7 @@ public class SetValueAction extends Action {
 
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, target);
-
+        ExtUtil.write(out, trigger);
         ExtUtil.write(out, ExtUtil.emptyIfNull(explicitValue));
         if(explicitValue == null) {
             ExtUtil.write(out, new ExtWrapTagged(value));

--- a/src/org/javarosa/xform/parse/Constants.java
+++ b/src/org/javarosa/xform/parse/Constants.java
@@ -5,4 +5,5 @@ public class Constants {
     static final String NODESET_ATTR = "nodeset";
     static final String SELECTONE = "select1";
     static final String SELECT = "select";
+    public static final String SETVALUE = "setvalue";
 }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -29,6 +29,7 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.RangeQuestion;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.SubmissionProfile;
+import org.javarosa.core.model.actions.NestedSetValueAction;
 import org.javarosa.core.model.actions.SetValueAction;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -672,10 +673,14 @@ public class XFormParser implements IXFormParserFunctions {
                 throw new XFormParseException("No 'value' attribute and no inner value set in <setvalue> associated with: " + treeref, e);
             }
             //Set expression
-            action = new SetValueAction(treeref, trigger, e.getText(0));
+            action = trigger != null ?
+                    new NestedSetValueAction(treeref, trigger, e.getText(0)) :
+                    new SetValueAction(treeref, e.getText(0));
         } else {
             try {
-                action = new SetValueAction(treeref, trigger, XPathParseTool.parseXPath(valueRef));
+                action = trigger != null ?
+                        new NestedSetValueAction(treeref, trigger, XPathParseTool.parseXPath(valueRef)) :
+                        new SetValueAction(treeref, XPathParseTool.parseXPath(valueRef));
             } catch (XPathSyntaxException e1) {
                 Std.printStack(e1);
                 throw new XFormParseException("Invalid XPath in value set action declaration: '" + valueRef + "'", e);

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -87,6 +87,7 @@ import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
 import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.Constants.SETVALUE;
 import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 
@@ -285,7 +286,7 @@ public class XFormParser implements IXFormParserFunctions {
 
 
         structuredActions = new HashMap<>();
-        structuredActions.put("setvalue", new IElementHandler() {
+        structuredActions.put(SETVALUE, new IElementHandler() {
                 public void handle (XFormParser p, Element e, Object parent) { p.parseSetValueAction((FormDef)parent, e);}
         });
     }
@@ -627,6 +628,10 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     private void parseSetValueAction(FormDef form, Element e) {
+        parseSetValueAction(form, e, null);
+    }
+
+    private void parseSetValueAction(FormDef form, Element e, TreeReference trigger) {
         String ref = e.getAttributeValue(null, REF_ATTR);
         String bind = e.getAttributeValue(null, BIND_ATTR);
 
@@ -661,15 +666,16 @@ public class XFormParser implements IXFormParserFunctions {
         TreeReference treeref = FormInstance.unpackReference(dataRef);
 
         actionTargets.add(treeref);
+
         if(valueRef == null) {
             if(e.getChildCount() == 0 || !e.isText(0)) {
                 throw new XFormParseException("No 'value' attribute and no inner value set in <setvalue> associated with: " + treeref, e);
             }
             //Set expression
-            action = new SetValueAction(treeref, e.getText(0));
+            action = new SetValueAction(treeref, trigger, e.getText(0));
         } else {
             try {
-                action = new SetValueAction(treeref, XPathParseTool.parseXPath(valueRef));
+                action = new SetValueAction(treeref, trigger, XPathParseTool.parseXPath(valueRef));
             } catch (XPathSyntaxException e1) {
                 Std.printStack(e1);
                 throw new XFormParseException("Invalid XPath in value set action declaration: '" + valueRef + "'", e);
@@ -941,6 +947,8 @@ public class XFormParser implements IXFormParserFunctions {
                 parseItem(question, child);
             } else if (isSelect && "itemset".equals(childName)) {
                 parseItemset(question, child, parent);
+            } else if (SETVALUE.equals(childName)) {
+                parseSetValueAction(_f, child, FormInstance.unpackReference(dataRef));
             }
         }
         if (isSelect) {

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -39,6 +39,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
+import org.joda.time.DateTime;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -332,7 +333,7 @@ public class XPathFuncExpr extends XPathExpression {
             return DateUtils.roundDate(new Date());
         } else if (name.equals("now")) {
             assertArgsCount(name, args, 0);
-            return new Date();
+            return new DateTime().toDate();
         } else if (name.equals("concat")) {
             if (args.length == 1 && argVals[0] instanceof XPathNodeset) {
                 return join("", ((XPathNodeset) argVals[0]).toArgList());

--- a/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
+++ b/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
@@ -63,6 +63,46 @@ public class NestedSetValueActionTest {
     }
 
     @Test
+    public void when_triggerNodeIsUpdatedWithinRepeat_targetNodeCalculation_isEvaluated() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action-with-repeats.xml")).formDef;
+
+        TreeReference[] triggerRefs = new TreeReference[3];
+        TreeReference[] targetRefs = new TreeReference[3];
+
+        for (int i = 0; i < 3; i++) {
+            TreeReference triggerRef = new TreeReference();
+            triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+            triggerRef.add("data", 0);
+            triggerRef.add("repeat", i);
+            triggerRef.add("cost", 0);
+
+            TreeReference targetRef = new TreeReference();
+            targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+            targetRef.add("data", 0);
+            targetRef.add("repeat", i);
+            targetRef.add("cost_timestamp", 0);
+
+            triggerRefs[i] = triggerRef;
+            targetRefs[i] = targetRef;
+        }
+
+        // When
+        for (int i = 0; i < 3; i++) {
+            DateTimeUtils.setCurrentMillisFixed(DATE_NOW + i * DAY_OFFSET);
+            formDef.setValue(new DecimalData(i+1), triggerRefs[i], true);
+        }
+
+        // Then
+        for (int i = 0; i < 3; i++) {
+            IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRefs[i]).getValue();
+            IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW + i * DAY_OFFSET));
+            assertEquals(expectedValue.getValue(), targetValue.getValue());
+        }
+    }
+
+    @Test
     public void when_triggerNodeIsUpdatedWithTheSameValue_targetNodeCalculation_isNotEvaluated() throws IOException {
         // Given
         final FormDef formDef =

--- a/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
+++ b/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
@@ -1,0 +1,96 @@
+package org.javarosa.core.model.actions;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.data.DateTimeData;
+import org.javarosa.core.model.data.DecimalData;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.instance.TreeReference;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.javarosa.xform.parse.FormParserHelper.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class NestedSetValueActionTest {
+
+    private static final long DATE_NOW = 1_500_000_000_000L;
+    private static final long DAY_OFFSET = 86_400_000L;
+
+    @Before
+    public void before() {
+        DateTimeUtils.setCurrentMillisFixed(DATE_NOW);
+    }
+
+    @After
+    public void after() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void when_triggerNodeIsUpdated_targetNodeCalculation_isEvaluated() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action.xml")).formDef;
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost_timestamp", 0);
+
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        assertNull(targetValue);
+
+        // When
+        formDef.setValue(new DecimalData(22.0), triggerRef, true);
+
+        // Then
+        targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW));
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
+
+    @Test
+    public void when_triggerNodeIsUpdatedWithTheSameValue_targetNodeCalculation_isNotEvaluated() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action.xml")).formDef;
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost_timestamp", 0);
+
+        DecimalData decimalValue = new DecimalData(22.0);
+        formDef.getMainInstance().resolveReference(targetRef).setValue(new DateTimeData(new Date(DATE_NOW)));
+        formDef.getMainInstance().resolveReference(triggerRef).setValue(decimalValue);
+
+        // When
+        DateTimeUtils.setCurrentMillisFixed(DATE_NOW + DAY_OFFSET); // shift the current time so we can test whether the setvalue action was re-fired
+        formDef.setValue(decimalValue, triggerRef, true);
+
+        // Then
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW));
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
+
+}

--- a/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
+++ b/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
@@ -1,18 +1,28 @@
 package org.javarosa.core.model.actions;
 
+import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.PrototypeManager;
+import org.javarosa.core.util.JavaRosaCoreModule;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.model.xform.XFormsModule;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 
+import static org.javarosa.core.util.externalizable.ExtUtil.defaultPrototypes;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.javarosa.xform.parse.FormParserHelper.parse;
 import static org.junit.Assert.assertEquals;
@@ -133,4 +143,45 @@ public class NestedSetValueActionTest {
         assertEquals(expectedValue.getValue(), targetValue.getValue());
     }
 
+    @Test
+    public void testSerializationAndDeserialization() throws IOException, DeserializationException {
+        PrototypeManager.registerPrototypes(JavaRosaCoreModule.classNames);
+        PrototypeManager.registerPrototypes(CoreModelModule.classNames);
+        new XFormsModule().registerModule();
+
+        FormDef formDef = parse(r("nested-setvalue-action.xml")).formDef;
+        Path p = Files.createTempFile("serialized-form", null);
+
+        final DataOutputStream dos = new DataOutputStream(Files.newOutputStream(p));
+        formDef.writeExternal(dos);
+        dos.close();
+
+        final DataInputStream dis = new DataInputStream(Files.newInputStream(p));
+        formDef.readExternal(dis, defaultPrototypes());
+        dis.close();
+
+        Files.delete(p);
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost_timestamp", 0);
+
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        assertNull(targetValue);
+
+        // When
+        formDef.setValue(new DecimalData(22.0), triggerRef, true);
+
+        // Then
+        targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DateTimeData(new Date(DATE_NOW));
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
 }

--- a/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
+++ b/test/org/javarosa/core/model/actions/NestedSetValueActionTest.java
@@ -144,6 +144,58 @@ public class NestedSetValueActionTest {
     }
 
     @Test
+    public void when_thereAreDependencyCyclesBetweenSetValueActionExpressions_returnError() throws IOException {
+        // Given
+        final FormDef formDef =
+        parse(r("nested-setvalue-action-dependency-cycles.xml")).formDef;
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        // When
+        DecimalData decimalValue = new DecimalData(6.0);
+        formDef.setValue(decimalValue, triggerRef, true);
+
+        // Then
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost2", 0);
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DecimalData(36.0);
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
+
+    @Test
+    public void when_thereAreDependencyCyclesBetweenExpressionsInSetValueActionsAndInstance_returnError() throws IOException {
+        // Given
+        final FormDef formDef =
+                parse(r("nested-setvalue-action-dependency-cycles.xml")).formDef;
+
+        TreeReference triggerRef = new TreeReference();
+        triggerRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        triggerRef.add("data", 0);
+        triggerRef.add("cost", 0);
+
+        // When
+        DecimalData decimalValue = new DecimalData(6.0);
+        formDef.setValue(decimalValue, triggerRef, true);
+
+        // Then
+        TreeReference targetRef = new TreeReference();
+        targetRef.setRefLevel(TreeReference.REF_ABSOLUTE);
+        targetRef.add("data", 0);
+        targetRef.add("cost2", 0);
+        IAnswerData targetValue = formDef.getMainInstance().resolveReference(targetRef).getValue();
+        IAnswerData expectedValue = new DecimalData(36.0);
+
+        assertEquals(expectedValue.getValue(), targetValue.getValue());
+    }
+
+    @Test
     public void testSerializationAndDeserialization() throws IOException, DeserializationException {
         PrototypeManager.registerPrototypes(JavaRosaCoreModule.classNames);
         PrototypeManager.registerPrototypes(CoreModelModule.classNames);


### PR DESCRIPTION
Closes #227 

#### What has been done to verify that this works as intended?
Manual testing + unit tests.

#### Why is this the best possible solution? Were any other approaches considered?
This approach leverages existing `setvalue` action related code. 
As a different approach, the existing Observer Pattern code (`FormElementStateListener`) could be considered. However it seems to me to be too low level since it operates on `TreeElement` instances.

#### Are there any risks to merging this code? If so, what are they?
Existing code in `SetValueAction` uses `FormDef#setValue` to update the value of a node. Since now `FormDef#setValue` fires the `xforms-value-changed` event, it's possible to create a form that has dependency cycles. For example the following code:
```
<bind nodeset="/data/cost" type="decimal" />
<bind nodeset="/data/cost2" type="decimal" />
<bind nodeset="/data/cost3" type="decimal" />
...
<input ref="/data/cost">
  <setvalue event="xforms-value-changed" ref="/data/cost2" value="pow(/data/cost, 2)" />
</input>
<input ref="/data/cost2">
  <setvalue event="xforms-value-changed" ref="/data/cost3" value="pow(/data/cost2, 2)" />
</input>
<input ref="/data/cost3">
  <setvalue event="xforms-value-changed" ref="/data/cost" value="pow(/data/cost3, 2)" />
</input>
```
will keep looping till each node has the [infinity value](https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#POSITIVE_INFINITY). In other scenarios it may loop till `StackOverflowException` is thrown.

Thoughts on fixing this so far:
* use `FormDef#setAnswer` instead of `setValue` - this method however won't fire recalculation of triggerables so it may not be a feasible solution
* simply don't fire the event (but fire triggerables) if a value is updated from `SetValueAction` - would require some ugly code to handle it and wouldn't be consistent
* validate against dependency cycle and don't allow such forms

