### PR TITLE
Select ones with spaces are not loaded on edit

### DIFF
--- a/src/org/javarosa/xform/util/XFormAnswerDataParser.java
+++ b/src/org/javarosa/xform/util/XFormAnswerDataParser.java
@@ -106,8 +106,8 @@ public class XFormAnswerDataParser {
 
         case Constants.DATATYPE_CHOICE:
 
-            List<Selection> selections = getSelections(text, q);
-            return (selections.size() == 0 ? null : new SelectOneData(selections.get(0)));
+            Selection selection = getSelection(text, q);
+            return (selection == null ? null : new SelectOneData(selection));
 
         case Constants.DATATYPE_CHOICE_LIST:
 


### PR DESCRIPTION
Closes #263 

#### What has been done to verify that this works as intended?
I've tested a form with blank space: 
[selectSpace.xml.txt](https://github.com/opendatakit/javarosa/files/1777548/selectSpace.xml.txt)
and also other `SelectOneWidgets` from the `AllWidgets` form.

#### Why is this the best possible solution? Were any other approaches considered?
We don't need to check for separators (spaces) if we use `SelectOneWidget` because then only one answer is possible.

#### Are there any risks to merging this code? If so, what are they?
It might be a little bit confusing why we allow spaces in `SelectOne` and not in `SelectMultiple` but overall I can't see any risk.
