### PR TITLE
Restore failing test

### DIFF
--- a/test/org/javarosa/xpath/expr/ToDateTest.java
+++ b/test/org/javarosa/xpath/expr/ToDateTest.java
@@ -51,14 +51,13 @@ public class ToDateTest {
     assertEquals(expectedDate.withTimeAtStartOfDay().toDate(), toDate(days, true));
   }
 
-  // Test fails on some machines and succeeds on others. Needs investigation.
-  // @Test
-  // public void datesGoUnchanged() {
-  //   // We need to account for the offset, because this test could be affected by other tests manipulating the Calendar
-  //   DateTime testDate = new DateTime(2018, 1, 1, 10, 20, 30, 400, UTC);
-  //   assertEquals(testDate.withTimeAtStartOfDay().toDate(), toDate(testDate.toDate(), false));
-  //   assertEquals(testDate.toDate(), toDate(testDate.toDate(), true));
-  // }
+  @Test
+  public void datesGoUnchanged() {
+    // We need to account for the offset, because this test could be affected by other tests manipulating the Calendar
+    DateTime testDate = new DateTime(2018, 1, 1, 10, 20, 30, 400, UTC);
+    assertEquals(testDate.withTimeAtStartOfDay().toDate(), toDate(testDate.toDate(), false));
+    assertEquals(testDate.toDate(), toDate(testDate.toDate(), true));
+  }
 
   @Test
   public void emptyStringsGoUnchanged() {

--- a/test/org/javarosa/xpath/expr/ToDateTest.java
+++ b/test/org/javarosa/xpath/expr/ToDateTest.java
@@ -7,6 +7,7 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Date;
+import java.util.Calendar;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -54,7 +55,7 @@ public class ToDateTest {
   @Test
   public void datesGoUnchanged() {
     // We need to account for the offset, because this test could be affected by other tests manipulating the Calendar
-    DateTime testDate = new DateTime(2018, 1, 1, 10, 20, 30, 400, UTC);
+    DateTime testDate = new DateTime(2018, 1, 1, 10, 20, 30, 400, DateTimeZone.forTimeZone(Calendar.getInstance().getTimeZone()));
     assertEquals(testDate.withTimeAtStartOfDay().toDate(), toDate(testDate.toDate(), false));
     assertEquals(testDate.toDate(), toDate(testDate.toDate(), true));
   }


### PR DESCRIPTION
This test is unreliable. It passes on CircleCI, but fails on my machine. The command I am using in both places is `mvn clean test`.

The output I get is
```Failed tests:   datesGoUnchanged(org.javarosa.xpath.expr.ToDateTest): expected:<Sun Dec 31 16:00:00 PST 2017> but was:<Mon Jan 01 00:00:00 PST 2018>```

When I run `mvn -version` this is what I get.

**macOS (passes)**
Apache Maven 3.5.2 (138edd61fd100ec658bfa2d307c43b76940a5d7d; 2017-10-18T00:58:13-07:00)
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_162, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"

**CircleCI (fails)**
Apache Maven 3.5.2 (138edd61fd100ec658bfa2d307c43b76940a5d7d; 2017-10-18T07:58:13Z)
Maven home: /opt/apache-maven
Java version: 1.8.0_151, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "4.4.0-111-generic", arch: "amd64", family: "unix"

This might be an ordering issue, but `mvn -Dsurefire.runOrder=random clean test` doesn't help.