### PR TITLE
Pass through known bind attributes

### DIFF
--- a/resources/whitelisted-attributes.xml
+++ b/resources/whitelisted-attributes.xml
@@ -17,7 +17,7 @@
 
     <h:body>
         <group appearance="field-list">
-            <input ref="/data/meta/instanceID" rows="2">
+            <input ref="/data/meta/instanceID" rows="2" query="instance('fake')/root/item[fake2 = /data/meta/instanceID">
                 <label>Instance ID:</label>
             </input>
         </group>

--- a/src/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
+++ b/src/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
@@ -29,7 +29,8 @@ class StandardBindAttributesProcessor {
     private Map<String, Integer> typeMappings;
 
     DataBinding createBinding(IXFormParserFunctions parserFunctions, FormDef formDef,
-                              Collection<String> usedAttributes, Element element) {
+                              Collection<String> usedAttributes, Collection<String> passedThroughAttributes,
+                              Element element) {
         final DataBinding binding = new DataBinding();
 
         binding.setId(element.getAttributeValue("", ID_ATTR));
@@ -116,7 +117,7 @@ class StandardBindAttributesProcessor {
         binding.setPreload(element.getAttributeValue(NAMESPACE_JAVAROSA, "preload"));
         binding.setPreloadParams(element.getAttributeValue(NAMESPACE_JAVAROSA, "preloadParams"));
 
-        saveUnusedAttributes(binding, element, usedAttributes);
+        saveUnusedAttributes(binding, element, usedAttributes, passedThroughAttributes);
 
         return binding;
     }
@@ -184,10 +185,11 @@ class StandardBindAttributesProcessor {
         return dataType;
     }
 
-    private void saveUnusedAttributes(DataBinding binding, Element element, Collection<String> usedAttributes) {
+    private void saveUnusedAttributes(DataBinding binding, Element element, Collection<String> usedAttributes,
+                                      Collection<String> passedThroughAttributes) {
         for (int i = 0; i < element.getAttributeCount(); i++) {
             String name = element.getAttributeName(i);
-            if (! usedAttributes.contains(name)) {
+            if (!usedAttributes.contains(name) || passedThroughAttributes.contains(name)) {
                 binding.setAdditionalAttribute(element.getAttributeNamespace(i), name, element.getAttributeValue(i));
             }
         }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -1692,11 +1692,12 @@ public class XFormParser implements IXFormParserFunctions {
         return false;
     }
 
-    protected DataBinding processStandardBindAttributes(List<String> usedAtts, Element element) {
+    private DataBinding processStandardBindAttributes(List<String> usedAtts, List<String> passedThroughAtts, Element element) {
         return new StandardBindAttributesProcessor(reporter, typeMappings).
-                createBinding(this, _f, usedAtts, element);
+                createBinding(this, _f, usedAtts, passedThroughAtts, element);
     }
 
+    /** Attributes that are read into DataBinding fields **/
     private final List<String> usedAtts = Collections.unmodifiableList(Arrays.asList(
             ID_ATTR,
             NODESET_ATTR,
@@ -1713,8 +1714,17 @@ public class XFormParser implements IXFormParserFunctions {
             "saveIncomplete"
     ));
 
-    protected void parseBind(Element element) {
-        final DataBinding binding = processStandardBindAttributes(usedAtts, element);
+    /**
+     * Attributes that are passed through to additionalAttrs but shouldn't lead to warnings.
+     * These are consistently used by clients but are expected in additionalAttrs for historical reasons.
+     **/
+    private final List<String> passedThroughAtts = Collections.unmodifiableList(Arrays.asList(
+            "requiredMsg",
+            "saveIncomplete"
+    ));
+
+    private void parseBind(Element element) {
+        final DataBinding binding = processStandardBindAttributes(usedAtts, passedThroughAtts, element);
 
         // Warn of unused attributes of parent element
         if (XFormUtils.showUnusedAttributeWarning(element, usedAtts)) {
@@ -1725,7 +1735,7 @@ public class XFormParser implements IXFormParserFunctions {
         addBinding(binding);
     }
 
-    protected void addBinding(DataBinding binding) {
+    private void addBinding(DataBinding binding) {
         bindings.add(binding);
 
         if (binding.getId() != null) {

--- a/src/org/javarosa/xform/util/XFormUtils.java
+++ b/src/org/javarosa/xform/util/XFormUtils.java
@@ -30,7 +30,6 @@ import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.xform.parse.IXFormParserFactory;
 import org.javarosa.xform.parse.XFormParseException;
-import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.parse.XFormParserFactory;
 import org.kxml2.kdom.Element;
 
@@ -150,17 +149,17 @@ public class XFormUtils {
         return unusedAtts;
     }
 
-    public static String unusedAttWarning(Element e, List<String> usedAtts){
+    public static String unusedAttWarning(Element e, List<String> usedAtts) {
         String warning = "Warning: ";
-      List<String> ua = getUnusedAttributes(e,usedAtts);
-        warning+=ua.size()+" Unrecognized attributes found in Element ["+e.getName()+"] and will be ignored: ";
-        warning+="[";
-        for(int i=0;i<ua.size();i++){
-            warning+=ua.get(i);
-            if(i!=ua.size()-1) warning+=",";
+        List<String> unusedAttributes = getUnusedAttributes(e, usedAtts);
+        warning += unusedAttributes.size() + " Unrecognized attributes found in Element [" + e.getName() +
+                "] and will be ignored: ";
+        warning += "[";
+        for (int i=0; i < unusedAttributes.size(); i++) {
+            warning += unusedAttributes.get(i);
+            if (i != unusedAttributes.size() - 1) warning += ",";
         }
-        warning+="] ";
-        warning+="Location:\n"+XFormParser.getVagueLocation(e);
+        warning += "] ";
 
         return warning;
     }

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -386,9 +386,38 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
+    /** No warnings should be produced when bind attributes known to clients are used. **/
     @Test public void parsesWithWhitelistedAttributes() throws IOException {
       ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
       assertThat(parseResult.errorMessages.size(), is(0));
+    }
+
+    /**
+     * Attributes that started being used by clients without being added as fields to DataBinding should be passed
+     * through and made available in the bindAttributes list.
+     */
+    @Test public void passedThroughAttributesHaveExpectedValues() throws IOException {
+        ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
+
+        TreeElement instanceIDElement = parseResult.formDef
+                .getMainInstance()
+                .getRoot()
+                .getChildAt(0)
+                .getChildAt(0);
+
+        String requiredMsg = instanceIDElement
+                .getBindAttribute("", "requiredMsg")
+                .getValue()
+                .getDisplayText();
+
+        assertEquals(requiredMsg, "this is required");
+
+        String saveIncomplete = instanceIDElement
+                .getBindAttribute("", "saveIncomplete")
+                .getValue()
+                .getDisplayText();
+
+        assertEquals(saveIncomplete, "false");
     }
 
     private TreeElement findDepthFirst(TreeElement parent, String name) {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -386,12 +386,6 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
-    /** No warnings should be produced when bind attributes known to clients are used. **/
-    @Test public void parsesWithWhitelistedAttributes() throws IOException {
-      ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
-      assertThat(parseResult.errorMessages.size(), is(0));
-    }
-
     /**
      * Attributes that started being used by clients without being added as fields to DataBinding should be passed
      * through and made available in the bindAttributes list.

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -6,6 +6,7 @@ import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.IFormElement;
+import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.RangeQuestion;
 import org.javarosa.core.model.SubmissionProfile;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -387,8 +388,8 @@ public class XFormParserTest {
     }
 
     /**
-     * Attributes that started being used by clients without being added as fields to DataBinding should be passed
-     * through and made available in the bindAttributes list.
+     * Attributes that started being used by clients without being added as fields to DataBinding or QuestionDef should
+     * be passed through and made available in the bindAttributes or additionalAttributes list.
      */
     @Test public void passedThroughAttributesHaveExpectedValues() throws IOException {
         ParseResult parseResult = parse(r("whitelisted-attributes.xml"));
@@ -399,6 +400,7 @@ public class XFormParserTest {
                 .getChildAt(0)
                 .getChildAt(0);
 
+        // Bind attributes
         String requiredMsg = instanceIDElement
                 .getBindAttribute("", "requiredMsg")
                 .getValue()
@@ -412,6 +414,16 @@ public class XFormParserTest {
                 .getDisplayText();
 
         assertEquals(saveIncomplete, "false");
+
+        // Attributes specific to input form controls
+        QuestionDef question = FormDef.findQuestionByRef(instanceIDElement.getRef(), parseResult.formDef);
+        String rows = question
+                .getAdditionalAttribute("", "rows");
+        assertEquals(rows, "2");
+
+        String query = question
+                .getAdditionalAttribute("", "query");
+        assertEquals(query, "instance('fake')/root/item[fake2 = /data/meta/instanceID");
     }
 
     private TreeElement findDepthFirst(TreeElement parent, String name) {


### PR DESCRIPTION
Closes #275

#### What has been done to verify that this works as intended?
Automated test.

#### Why is this the best possible solution? Were any other approaches considered?
This makes it explicit why these attributes have special status and follows the original code structure. No changes are made to public interfaces. @grzesiek2010 has an alternative at grzesiek2010/javarosa@59ae8c5. I think that would also be ok but it buries the passed through attributes.

For `rows`, I don't think it's common/important enough to warrant invasive changes.

I removed a test that would never fail because it was checking for errors rather than warnings. Warnings go to the output stream so they can't easily be captured. I think that's ok.

#### Are there any risks to merging this code? If so, what are they?
This could further affect binding code or not actually fix the problem with `requiredMsg`.