### PR TITLE
Improved the comment regarding #279

### DIFF
--- a/src/org/javarosa/form/api/FormEntryModel.java
+++ b/src/org/javarosa/form/api/FormEntryModel.java
@@ -739,7 +739,7 @@ public class FormEntryModel {
         if (node == null || node.isRepeatable()) { // node == null if there are no instances of the repeat
             IFormElement lastElement = elements.get(elements.size() - 1);
             if (lastElement instanceof GroupDef && !((GroupDef) lastElement).getRepeat()) {
-                return false; // it's a regular group inside a repeatable group
+                return false; // It's a regular group inside a repeatable group. This case takes place when the nested group doesn't have the ref attribute.
             }
             int mult;
             if (node == null) {


### PR DESCRIPTION
@lognaturel 

I just would like to add a better comment here since after fixing #279 I discovered one thing. That problem takes places only when ref attributes are not specified. It's the same problem like here: https://github.com/opendatakit/javarosa/issues/218

and it's a problem wit ODKBuild because, if we build a form using xls everything is ok.

[nestedGroupsBuildUsingXLS.xml.txt](https://github.com/opendatakit/javarosa/files/1871749/nestedGroupsBuildUsingXLS.xml.txt)
[nestedGroupsBuildUsingODKBuild.xml.txt](https://github.com/opendatakit/javarosa/files/1871750/nestedGroupsBuildUsingODKBuild.xml.txt)

So just a short explanation of what the root cause is.