### PR TITLE
Issue 273 randomize nodeset

### DIFF
--- a/resources/org/javarosa/xpath/expr/randomize.xml
+++ b/resources/org/javarosa/xpath/expr/randomize.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Randomize Test</h:title>
+        <model>
+            <instance>
+                <randomize id="randomize">
+                    <fruit1/>
+                    <fruit2/>
+                    <seededFruit1/>
+                    <seededFruit2/>
+                    <randomValue/>
+                    <seededRandomValue/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </randomize>
+            </instance>
+
+            <instance id="fruit">
+                <root>
+                    <item>
+                        <label>Apple</label>
+                        <name>apple</name>
+                    </item>
+                    <item>
+                        <label>Banana</label>
+                        <name>banana</name>
+                    </item>
+                    <item>
+                        <label>Cherimoya</label>
+                        <name>cherimoya</name>
+                    </item>
+                    <item>
+                        <label>Durian</label>
+                        <name>durian</name>
+                    </item>
+                    <item>
+                        <label>Elderberry</label>
+                        <name>elderberry</name>
+                    </item>
+                    <item>
+                        <label>Fig</label>
+                        <name>fig</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="numbers">
+                <root>
+                    <item>1</item>
+                    <item>2</item>
+                    <item>3</item>
+                    <item>4</item>
+                    <item>5</item>
+                    <item>6</item>
+                </root>
+            </instance>
+            <bind nodeset="/randomize/fruit1" type="select1"/>
+            <bind nodeset="/randomize/fruit2" type="select1"/>
+            <bind nodeset="/randomize/seededFruit1" type="select1"/>
+            <bind nodeset="/randomize/seededFruit2" type="select1"/>
+            <bind nodeset="/randomize/randomValue" calculate="max(randomize(instance('numbers')/root/value))"/>
+            <bind nodeset="/randomize/seededRandomValue" calculate="max(randomize(instance('numbers')/root/value, 42))"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/randomize/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/randomize/fruit1">
+            <label>Fruit #1</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/randomize/fruit2">
+            <label>Fruit #2</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/randomize/seededFruit1">
+            <label>Seeded fruit #1</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item, 42)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/randomize/seededFruit2">
+            <label>Seeded fruit #2</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item, 42)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <input ref="/randomize/randomValue"/>
+        <input ref="/randomize/seededRandomValue"/>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -1,5 +1,7 @@
 package org.javarosa.core.model;
 
+import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -52,6 +54,9 @@ public class ItemsetBinding implements Externalizable, Localizable {
                                    //not serialized -- set by QuestionDef.setDynamicChoices()
     private List<SelectChoice> choices; //dynamic choices -- not serialized, obviously
 
+    public boolean randomize = false;
+    public Long randomSeed = null;
+
     public List<SelectChoice> getChoices () {
         return choices;
     }
@@ -61,7 +66,13 @@ public class ItemsetBinding implements Externalizable, Localizable {
             logger.warn("previous choices not cleared out");
             clearChoices();
         }
-        this.choices = choices;
+        this.choices = randomize ? shuffle(choices, randomSeed) : choices;
+
+        if (randomize) {
+            // Match indices to new positions
+            for (int i = 0; i < choices.size(); i++)
+                choices.get(i).setIndex(i);
+        }
 
         //init localization
         if (localizer != null) {

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -148,6 +148,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
         copyExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         labelIsItext = ExtUtil.readBool(in);
         copyMode = ExtUtil.readBool(in);
+        randomize = ExtUtil.readBool(in);
+        randomSeed = (Long)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()));
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {
@@ -158,6 +160,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
         ExtUtil.write(out, new ExtWrapNullable(copyExpr == null ? null : new ExtWrapTagged(copyExpr)));
         ExtUtil.writeBool(out, labelIsItext);
         ExtUtil.writeBool(out, copyMode);
+        ExtUtil.writeBool(out, randomize);
+        ExtUtil.write(out, new ExtWrapNullable(randomSeed == null ? null : new ExtWrapTagged(randomSeed)));
     }
 
 }

--- a/src/org/javarosa/xform/parse/FisherYates.java
+++ b/src/org/javarosa/xform/parse/FisherYates.java
@@ -1,0 +1,29 @@
+package org.javarosa.xform.parse;
+
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Random;
+
+public class FisherYates {
+    @SuppressWarnings("unchecked")
+    public static void shuffle(List<?> list, Random random) {
+        int size = list.size();
+        Object[] array = list.toArray();
+        Object[] result = new Object[size];
+
+        for (int i = 0; i < size; ++i) {
+            int j = Double.valueOf(random.nextDouble() * (i + 1)).intValue();
+
+            if (j != i)
+                result[i] = result[j];
+
+            result[j] = array[i];
+        }
+
+        ListIterator it = list.listIterator();
+        for (Object e : result) {
+            it.next();
+            it.set(e);
+        }
+    }
+}

--- a/src/org/javarosa/xform/parse/FisherYates.java
+++ b/src/org/javarosa/xform/parse/FisherYates.java
@@ -1,29 +1,113 @@
 package org.javarosa.xform.parse;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Random;
 
+/**
+ * This class implements the <a href=" * This class implements the out-of-place
+ * <a href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle">Fisher-Yates</a>
+ * list shuffling algorithm.
+ * <p>
+ * Combined with the {@link ParkMiller} Random Number Generator
+ * implementation on this library, cross-platform reproducible results
+ * can be guaranteed.
+ * <p>
+ * Verified compatible libraries are:
+ * <ul>
+ * <li><a href="https://www.npmjs.com/package/fisher-yates">Javascript - fisher-yates npm module</a></li>
+ * <li><a href="https://www.npmjs.com/package/park-miller">Javascript - park-miller npm module</a></li>
+ * </ul>
+ * <p>
+ * Using other libraries won't guarantee reproducible results.
+ * <p>
+ * The main difference between this implementation and the native
+ * {@link java.util.Collections#shuffle} consist on the way this one
+ * selects which elements to swap on each iteration. See inlined comments
+ * for more information.
+ */
 public class FisherYates {
+
+    /**
+     * Shuffle the input list of elements using a {@link Random} Random
+     * Number Generator instance to decide which positions get swapped
+     * on each iteration.
+     *
+     * @param input {@link List} of elements to be shuffled
+     * @param <T>   Type parameter of the input {@link List} of elements
+     * @return A new {@link List} of elements, containing the same elements
+     *     as in the input {@link List}, but in a different order.
+     */
     @SuppressWarnings("unchecked")
-    public static void shuffle(List<?> list, Random random) {
-        int size = list.size();
-        Object[] array = list.toArray();
-        Object[] result = new Object[size];
+    public static <T> List<T> shuffle(List<T> input) {
+        return shuffle(input, new Random());
+    }
+
+    /**
+     * Shuffle the input list of elements using a {@link ParkMiller} Random
+     * Number Generator instance to decide which positions get swapped
+     * on each iteration.
+     * <p>
+     * Use the same seed for the RNGs when reproducible results are required.
+     *
+     * @param input {@link List} of elements to be shuffled
+     * @param seed  {@link Long} number to use as seed of the RNG
+     * @param <T>   Type parameter of the input {@link List} of elements
+     * @return A new {@link List} of elements, containing the same elements
+     *     as in the input {@link List}, but in a different order.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> shuffle(List<T> input, long seed) {
+        return shuffle(input, new ParkMiller(seed));
+    }
+
+    /**
+     * Shuffle the input list of elements using a {@link Random} Random
+     * Number Generator instance to decide which positions get swapped
+     * on each iteration.
+     * <p>
+     * Use the same seed for the RNGs when reproducible results are required.
+     *
+     * <b>Warning:</b> It's recommended to use {@link #shuffle(List, long)}
+     * instead, to ensure you are using a cross-platform RNG like {@link ParkMiller}.
+     *
+     * @param input  {@link List} of elements to be shuffled
+     * @param random {@link Random} instance with the RNG to be used
+     * @param <T>    Type parameter of the input {@link List} of elements
+     * @return A new {@link List} of elements, containing the same elements
+     *     as in the input {@link List}, but in a different order.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> shuffle(List<T> input, Random random) {
+        // The algorithm creates an output array with the shuffled elements
+        int size = input.size();
+        Object[] inputArr = input.toArray();
+        Object[] outputArr = new Object[size];
 
         for (int i = 0; i < size; ++i) {
+            // This is the main difference with Collections.shuffle()
+            // To make this version cross-platform, we need to decide the
+            // target index using the next double in our PRNG to let
+            // languages like JavaScript, where numbers are always represented
+            // with IEE754 double precission floating point decimals.
             int j = Double.valueOf(random.nextDouble() * (i + 1)).intValue();
-
             if (j != i)
-                result[i] = result[j];
-
-            result[j] = array[i];
+                // Make room for input[i] at output[j]
+                outputArr[i] = outputArr[j];
+            // Take input[i]
+            outputArr[j] = inputArr[i];
         }
 
-        ListIterator it = list.listIterator();
-        for (Object e : result) {
+        // Once the output array is created, we set the output list
+        // iterator with the elements in the order they appear
+        List<T> output = new ArrayList<>(input);
+        ListIterator it = output.listIterator();
+        for (Object e : outputArr) {
             it.next();
             it.set(e);
         }
+
+        return output;
     }
 }

--- a/src/org/javarosa/xform/parse/ParkMiller.java
+++ b/src/org/javarosa/xform/parse/ParkMiller.java
@@ -2,6 +2,17 @@ package org.javarosa.xform.parse;
 
 import java.util.Random;
 
+/**
+ * This class implements a cross-platform version of the
+ * <a href="https://en.wikipedia.org/wiki/Lehmer_random_number_generator">Park-Miller</a>
+ * Pseudo-Random Number Generator.
+ * <p>
+ * Verified compatible libraries are:
+ * <ul>
+ * <li><a href="https://www.npmjs.com/package/park-miller">Javascript - park-miller npm module</a></li>
+ * </ul>
+ * <p>
+ */
 class ParkMiller extends Random {
     private static final long MODULUS = 2147483647;
     private static final long MULTIPLIER = 16807;

--- a/src/org/javarosa/xform/parse/ParkMiller.java
+++ b/src/org/javarosa/xform/parse/ParkMiller.java
@@ -1,0 +1,27 @@
+package org.javarosa.xform.parse;
+
+import java.util.Random;
+
+class ParkMiller extends Random {
+    private static final long MODULUS = 2147483647;
+    private static final long MULTIPLIER = 16807;
+
+    private double seed;
+
+    ParkMiller(long seed) {
+        this.seed = Long.valueOf(seed).doubleValue() % MODULUS;
+        if (this.seed <= 0)
+            this.seed += (MODULUS - 1);
+    }
+
+    @Override
+    protected int next(int bits) {
+        seed = seed * MULTIPLIER % MODULUS;
+        return Double.valueOf(seed).intValue();
+    }
+
+    @Override
+    public double nextDouble() {
+        return ((double) (this.nextInt() - 1)) / (MODULUS - 1);
+    }
+}

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -15,10 +15,7 @@
  */
 package org.javarosa.xform.parse;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 /**
  * This class contains all the code needed to implement the xform randomize()
@@ -68,7 +65,7 @@ public final class RandomizeHelper {
      * @return a new {@link List} with the same input elements reordered
      */
     public static <T> List<T> shuffle(List<T> elements) {
-        return shuffle(elements, null);
+        return FisherYates.shuffle(elements);
     }
 
     /**
@@ -81,9 +78,7 @@ public final class RandomizeHelper {
      * @return a new {@link List} with the same input elements reordered
      */
     public static <T> List<T> shuffle(List<T> elements, Long seed) {
-        List<T> output = new ArrayList<>(elements);
-        FisherYates.shuffle(output, seed != null ? new ParkMiller(seed) : new Random());
-        return output;
+        return seed == null ? FisherYates.shuffle(elements) : FisherYates.shuffle(elements, seed);
     }
 
     private static String[] getArgs(String nodesetStr) {

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -81,10 +81,8 @@ public final class RandomizeHelper {
      * @return a new {@link List} with the same input elements reordered
      */
     public static <T> List<T> shuffle(List<T> elements, Long seed) {
-        List<T> output = new ArrayList<>(elements.size());
-        output.addAll(elements);
-
-        Collections.shuffle(output, seed != null ? new Random(seed) : new Random());
+        List<T> output = new ArrayList<>(elements);
+        FisherYates.shuffle(output, seed != null ? new ParkMiller(seed) : new Random());
         return output;
     }
 

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -15,22 +15,82 @@
  */
 package org.javarosa.xform.parse;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
-public class RandomizeHelper {
-    public static Long parseSeed(String nodesetStr) {
-        return null;
+/**
+ * This class contains all the code needed to implement the xform randomize()
+ * function.
+ */
+public final class RandomizeHelper {
+    /**
+     * Looks for a seed in an xform randomize() expression. If it is present and
+     * it can be parsed into a {@link Long}, it returns it. If it is not present,
+     * returns null.
+     * <p>
+     * Can throw an {@link IllegalArgumentException} if the expression doesn't conform
+     * to an xform randomize() call.
+     * Can throw a {@link NumberFormatException} if it can't parse the seed into a {@link Long}
+     *
+     * @param nodesetStr an xform randomize() expression
+     * @return a {@link Long} seed or null if it is not found inside the expression
+     */
+    static Long parseSeed(String nodesetStr) {
+        String[] args = getArgs(nodesetStr);
+        return args.length == 2
+            ? Long.parseLong(args[1].trim())
+            : null;
     }
 
-    public static String cleanNodesetDefinition(String nodesetStr) {
-        return nodesetStr;
+    /**
+     * Cleans an xform randomize() expression to leave only its first argument, which
+     * should be an xpath expression.
+     * <p>
+     * Can throw an {@link IllegalArgumentException} if the expression doesn't conform
+     * to an xform randomize() call.
+     *
+     * @param nodesetStr an xform randomize() expression
+     * @return a {@link String} with the first argument of the xform randomize() expression
+     */
+    static String cleanNodesetDefinition(String nodesetStr) {
+        return getArgs(nodesetStr)[0].trim();
     }
 
+    /**
+     * This method will return a new list with the same elements, randomly reordered.
+     * Every call to this method will produce a different random seed, which will
+     * potentially produce a different ordering each time.
+     *
+     * @param elements {@link List} of elements of type T to be shuffled
+     * @param <T>      Type of the elements in the list
+     * @return a new {@link List} with the same input elements reordered
+     */
     public static <T> List<T> shuffle(List<T> elements) {
         return shuffle(elements, null);
     }
 
+    /**
+     * This method will return a new list with the same elements, randomly reordered.
+     * Given the same seed, calls to this method will produce exactly the same output.
+     *
+     * @param elements {@link List} of elements of type T to be shuffled
+     * @param seed     {@link Long} seed for the Random number generator
+     * @param <T>      Type of the elements in the list
+     * @return a new {@link List} with the same input elements reordered
+     */
     public static <T> List<T> shuffle(List<T> elements, Long seed) {
-        return elements;
+        List<T> output = new ArrayList<>(elements.size());
+        output.addAll(elements);
+
+        Collections.shuffle(output, seed != null ? new Random(seed) : new Random());
+        return output;
+    }
+
+    private static String[] getArgs(String nodesetStr) {
+        if (!nodesetStr.startsWith("randomize(") || !nodesetStr.endsWith(")"))
+            throw new IllegalArgumentException("Nodeset definition must use randomize(path, seed?) function");
+        return nodesetStr.substring(10, nodesetStr.length() - 1).split(",");
     }
 }

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xform.parse;
+
+import java.util.List;
+
+public class RandomizeHelper {
+    public static Long parseSeed(String nodesetStr) {
+        return null;
+    }
+
+    public static String cleanNodesetDefinition(String nodesetStr) {
+        return nodesetStr;
+    }
+
+    public static <T> List<T> shuffle(List<T> elements) {
+        return shuffle(elements, null);
+    }
+
+    public static <T> List<T> shuffle(List<T> elements, Long seed) {
+        return elements;
+    }
+}

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -40,6 +40,8 @@ import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
 import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.parseSeed;
 import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 import java.io.ByteArrayInputStream;
@@ -1297,6 +1299,13 @@ public class XFormParser implements IXFormParserFunctions {
         String nodesetStr = e.getAttributeValue("", NODESET_ATTR);
         if (nodesetStr == null)
             throw new RuntimeException("No nodeset attribute in element: [" + e.getName() + "]. This is required. (Element Printout:" + XFormSerializer.elementToString(e) + ")");
+
+        if (nodesetStr.startsWith("randomize(")) {
+            itemset.randomize = true;
+            itemset.randomSeed = parseSeed(nodesetStr);
+            nodesetStr = cleanNodesetDefinition(nodesetStr);
+        }
+
         XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
         itemset.nodesetExpr = new XPathConditional(path);
         itemset.contextRef = getFormElementRef(qparent);

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -16,6 +16,45 @@
 
 package org.javarosa.xform.parse;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
+import static org.javarosa.core.model.Constants.CONTROL_INPUT;
+import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_SECRET;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
+import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
+import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
+import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
+import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
+import static org.javarosa.core.model.instance.ExternalDataInstance.getPathIfExternalDataInstance;
+import static org.javarosa.core.services.ProgramFlow.die;
+import static org.javarosa.xform.parse.Constants.ID_ATTR;
+import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
+import static org.javarosa.xform.parse.Constants.SELECT;
+import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.javarosa.core.model.Action;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
@@ -65,46 +104,6 @@ import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
-import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
-import static org.javarosa.core.model.Constants.CONTROL_INPUT;
-import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_RANGE;
-import static org.javarosa.core.model.Constants.CONTROL_SECRET;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
-import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
-import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
-import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
-import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
-import static org.javarosa.core.model.instance.ExternalDataInstance.getPathIfExternalDataInstance;
-import static org.javarosa.core.services.ProgramFlow.die;
-import static org.javarosa.xform.parse.Constants.ID_ATTR;
-import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
-import static org.javarosa.xform.parse.Constants.SELECT;
-import static org.javarosa.xform.parse.Constants.SELECTONE;
-import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
-
 
 /* droos: i think we need to start storing the contents of the <bind>s in the formdef again */
 
@@ -113,7 +112,6 @@ import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttr
  *
  * @author Daniel Kayiwa
  * @author Drew Roos
- *
  */
 public class XFormParser implements IXFormParserFunctions {
     private static final Logger logger = LoggerFactory.getLogger(XFormParser.class);
@@ -199,7 +197,8 @@ public class XFormParser implements IXFormParserFunctions {
     private static void initProcessingRules() {
         groupLevelHandlers = new HashMap<String, IElementHandler>() {{
             put("input", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     // Attributes that are passed through to additionalAttributes but shouldn't lead to warnings.
                     // These are consistently used by clients but are expected in additionalAttributes for historical
                     // reasons.
@@ -208,69 +207,82 @@ public class XFormParser implements IXFormParserFunctions {
                 }
             });
             put("range", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_RANGE,
                         asList("start", "end", "step") // Prevent warning about unexpected attributes
                     );
                 }
             });
             put("secret", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_SECRET);
                 }
             });
             put(SELECT, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_SELECT_MULTI);
                 }
             });
             put(SELECTONE, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_SELECT_ONE);
                 }
             });
             put("group", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseGroup((IFormElement) parent, e, CONTAINER_GROUP);
                 }
             });
             put("repeat", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseGroup((IFormElement) parent, e, CONTAINER_REPEAT);
                 }
             });
             put("trigger", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_TRIGGER);
                 }
             }); //multi-purpose now; need to dig deeper
             put(XFTAG_UPLOAD, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseUpload((IFormElement) parent, e, CONTROL_UPLOAD);
                 }
             });
             put(LABEL_ELEMENT, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     if (parent instanceof GroupDef) {
                         p.parseGroupLabel((GroupDef) parent, e);
-                    } else throw new XFormParseException("parent of element is not a group", e);
+                    } else
+                        throw new XFormParseException("parent of element is not a group", e);
                 }
             });
         }};
 
         topLevelHandlers = new HashMap<String, IElementHandler>() {{
             put("model", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseModel(e);
                 }
             });
             put("title", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseTitle(e);
                 }
             });
             put("meta", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseMeta(e);
                 }
             });
@@ -278,7 +290,7 @@ public class XFormParser implements IXFormParserFunctions {
         topLevelHandlers.putAll(groupLevelHandlers);
     }
 
-    private void initState () {
+    private void initState() {
         modelFound = false;
         bindingsByID = new HashMap<>();
         bindings = new ArrayList<>();
@@ -308,7 +320,9 @@ public class XFormParser implements IXFormParserFunctions {
 
         structuredActions = new HashMap<>();
         structuredActions.put("setvalue", new IElementHandler() {
-            public void handle (XFormParser p, Element e, Object parent) { p.parseSetValueAction((FormDef)parent, e);}
+            public void handle(XFormParser p, Element e, Object parent) {
+                p.parseSetValueAction((FormDef) parent, e);
+            }
         });
     }
 
@@ -352,7 +366,9 @@ public class XFormParser implements IXFormParserFunctions {
         return _f;
     }
 
-    /** Extracts the namespaces from the given element and creates a map of URI to prefix */
+    /**
+     * Extracts the namespaces from the given element and creates a map of URI to prefix
+     */
     private static Map<String, String> buildNamespacesMap(Element el) {
         final Map<String, String> namespacePrefixesByURI = new HashMap<>();
 
@@ -363,7 +379,7 @@ public class XFormParser implements IXFormParserFunctions {
         return namespacePrefixesByURI;
     }
 
-    public static Document getXMLDocument(Reader reader) throws IOException  {
+    public static Document getXMLDocument(Reader reader) throws IOException {
         return getXMLDocument(reader, null);
     }
 
@@ -377,15 +393,16 @@ public class XFormParser implements IXFormParserFunctions {
      * @throws IOException
      * @deprecated The InterningKXmlParser is not used.
      */
-    @Deprecated public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache)
+    @Deprecated
+    public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache)
         throws IOException {
         final StopWatch ctParse = StopWatch.start();
         Document doc = new Document();
 
-        try{
+        try {
             KXmlParser parser;
 
-            if(stringCache != null) {
+            if (stringCache != null) {
                 parser = new InterningKXmlParser(stringCache);
             } else {
                 parser = new KXmlParser();
@@ -394,14 +411,14 @@ public class XFormParser implements IXFormParserFunctions {
             parser.setInput(reader);
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
             doc.parse(parser);
-        }  catch (XmlPullParserException e) {
-            String errorMsg = "XML Syntax Error at Line: " + e.getLineNumber() +", Column: "+ e.getColumnNumber()+ "!";
+        } catch (XmlPullParserException e) {
+            String errorMsg = "XML Syntax Error at Line: " + e.getLineNumber() + ", Column: " + e.getColumnNumber() + "!";
             logger.error(errorMsg, e);
             throw new XFormParseException(errorMsg);
-        } catch(IOException e){
+        } catch (IOException e) {
             //CTS - 12/09/2012 - Stop swallowing IO Exceptions
             throw e;
-        } catch(Exception e){
+        } catch (Exception e) {
             logger.error("Unhandled Exception while Parsing XForm", e);
             throw new XFormParseException("Unhandled Exception while Parsing XForm");
         }
@@ -458,7 +475,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
         //now parse the main instance
-        if(mainInstanceNode != null) {
+        if (mainInstanceNode != null) {
             FormInstance fi = instanceParser.parseInstance(mainInstanceNode, true,
                 instanceNodeIdStrs.get(instanceNodes.indexOf(mainInstanceNode)), namespacePrefixesByUri);
             /*
@@ -475,7 +492,7 @@ public class XFormParser implements IXFormParserFunctions {
         // Clear the caches, as these may not have been initialized
         // entirely correctly during the validation steps.
         Enumeration<DataInstance> e = _f.getNonMainInstances();
-        while ( e.hasMoreElements() ) {
+        while (e.hasMoreElements()) {
             DataInstance instance = e.nextElement();
             final AbstractTreeElement treeElement = instance.getRoot();
             if (treeElement instanceof TreeElement) {
@@ -505,7 +522,7 @@ public class XFormParser implements IXFormParserFunctions {
         "delHeader"
     )));
 
-    private void parseElement (Element e, Object parent, HashMap<String, IElementHandler> handlers) {
+    private void parseElement(Element e, Object parent, HashMap<String, IElementHandler> handlers) {
         String name = e.getName();
 
         IElementHandler eh = handlers.get(name);
@@ -514,7 +531,7 @@ public class XFormParser implements IXFormParserFunctions {
         } else {
             if (!validElementNames.contains(name)) {
                 triggerWarning(
-                    "Unrecognized element [" + name    + "]. Ignoring and processing children...",
+                    "Unrecognized element [" + name + "]. Ignoring and processing children...",
                     getVagueLocation(e));
             }
             for (int i = 0; i < e.getChildCount(); i++) {
@@ -525,12 +542,12 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void parseTitle (Element e) {
+    private void parseTitle(Element e) {
         List<String> usedAtts = new ArrayList<>(); //no attributes parsed in title.
         String title = getXMLText(e, true);
         logger.info("Title: \"" + title + "\"");
         _f.setTitle(title);
-        if(_f.getName() == null) {
+        if (_f.getName() == null) {
             //Jan 9, 2009 - ctsims
             //We don't really want to allow for forms without
             //some unique ID, so if a title is available, use
@@ -539,31 +556,31 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseMeta (Element e) {
+    private void parseMeta(Element e) {
         List<String> usedAtts = new ArrayList<>();
         int attributes = e.getAttributeCount();
-        for(int i = 0 ; i < attributes ; ++i) {
+        for (int i = 0; i < attributes; ++i) {
             String name = e.getAttributeName(i);
             String value = e.getAttributeValue(i);
-            if("name".equals(name)) {
+            if ("name".equals(name)) {
                 _f.setName(value);
             }
         }
 
 
         usedAtts.add("name");
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
     //for ease of parsing, we assume a model comes before the controls, which isn't necessarily mandated by the xforms spec
-    private void parseModel (Element e) {
+    private void parseModel(Element e) {
         List<String> usedAtts = new ArrayList<>(); //no attributes parsed in title.
         List<Element> delayedParseElements = new ArrayList<>();
 
@@ -574,8 +591,8 @@ public class XFormParser implements IXFormParserFunctions {
         }
         modelFound = true;
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
         for (int i = 0; i < e.getChildCount(); i++) {
@@ -592,19 +609,19 @@ public class XFormParser implements IXFormParserFunctions {
                 saveInstanceNode(child);
             } else if (BIND_ATTR.equals(childName)) { //<instance> must come before <bind>s
                 parseBind(child);
-            } else if("submission".equals(childName)) {
+            } else if ("submission".equals(childName)) {
                 delayedParseElements.add(child);
-            } else if(namedActions.contains(childName) || (childName != null && structuredActions.containsKey(childName))) {
+            } else if (namedActions.contains(childName) || (childName != null && structuredActions.containsKey(childName))) {
                 delayedParseElements.add(child);
             } else { //invalid model content
                 if (type == Node.ELEMENT) {
-                    throw new XFormParseException("Unrecognized top-level tag [" + childName + "] found within <model>",child);
+                    throw new XFormParseException("Unrecognized top-level tag [" + childName + "] found within <model>", child);
                 } else if (type == Node.TEXT && getXMLText(e, i, true).length() != 0) {
-                    throw new XFormParseException("Unrecognized text content found within <model>: \"" + getXMLText(e, i, true) + "\"",child == null ? e : child);
+                    throw new XFormParseException("Unrecognized text content found within <model>: \"" + getXMLText(e, i, true) + "\"", child == null ? e : child);
                 }
             }
 
-            if(child == null || BIND_ATTR.equals(childName) || "itext".equals(childName)) {
+            if (child == null || BIND_ATTR.equals(childName) || "itext".equals(childName)) {
                 //Clayton Sims - Jun 17, 2009 - This code is used when the stinginess flag
                 //is set for the build. It dynamically wipes out old model nodes once they're
                 //used. This is sketchy if anything else plans on touching the nodes.
@@ -615,13 +632,13 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         //Now parse out the submission/action blocks (we needed the binds to all be set before we could)
-        for(Element child : delayedParseElements) {
+        for (Element child : delayedParseElements) {
             String name = child.getName();
-            if(name.equals("submission")) {
+            if (name.equals("submission")) {
                 parseSubmission(child);
             } else {
                 //For now, anything that isn't a submission is an action
-                if(namedActions.contains(name)) {
+                if (namedActions.contains(name)) {
                     parseNamedAction(child);
                 } else {
                     structuredActions.get(name).handle(this, child, _f);
@@ -669,8 +686,8 @@ public class XFormParser implements IXFormParserFunctions {
         TreeReference treeref = FormInstance.unpackReference(dataRef);
 
         actionTargets.add(treeref);
-        if(valueRef == null) {
-            if(e.getChildCount() == 0 || !e.isText(0)) {
+        if (valueRef == null) {
+            if (e.getChildCount() == 0 || !e.isText(0)) {
                 throw new XFormParseException("No 'value' attribute and no inner value set in <setvalue> associated with: " + treeref, e);
             }
             //Set expression
@@ -695,8 +712,8 @@ public class XFormParser implements IXFormParserFunctions {
         String action = submission.getAttributeValue(null, "action");
 
         SubmissionParser parser = new SubmissionParser();
-        for(SubmissionParser p : submissionParsers) {
-            if(p.matchesCustomMethod(method)) {
+        for (SubmissionParser p : submissionParsers) {
+            if (p.matchesCustomMethod(method)) {
                 parser = p;
             }
         }
@@ -728,9 +745,9 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        SubmissionProfile profile = parser.parseSubmission(method, action, dataRef, submission );
+        SubmissionProfile profile = parser.parseSubmission(method, action, dataRef, submission);
 
-        if(id == null) {
+        if (id == null) {
             //default submission profile
             _f.setDefaultSubmission(profile);
         } else {
@@ -739,7 +756,7 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void saveInstanceNode (Element instance) {
+    private void saveInstanceNode(Element instance) {
         Element instanceNode = null;
         String instanceId = instance.getAttributeValue("", "id");
 
@@ -753,7 +770,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        if(instanceNode == null) {
+        if (instanceNode == null) {
             //no kids
             instanceNode = instance;
         }
@@ -790,7 +807,7 @@ public class XFormParser implements IXFormParserFunctions {
         if ("image/*".equals(mediaType)) {
             // NOTE: this could be further expanded.
             question.setControlType(CONTROL_IMAGE_CHOOSE);
-        } else if("audio/*".equals(mediaType)) {
+        } else if ("audio/*".equals(mediaType)) {
             question.setControlType(CONTROL_AUDIO_CAPTURE);
         } else if ("video/*".equals(mediaType)) {
             question.setControlType(CONTROL_VIDEO_CAPTURE);
@@ -807,8 +824,8 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     /**
-     *  Parses the OSM Tag Elements when we are parsing
-     *  an OSM Upload element. 
+     * Parses the OSM Tag Elements when we are parsing
+     * an OSM Upload element.
      */
     private List<OSMTag> parseOsmTags(Element e) {
         List<OSMTag> tags = new ArrayList<>();
@@ -889,13 +906,13 @@ public class XFormParser implements IXFormParserFunctions {
     /**
      * Parses a form control element into a {@link org.javarosa.core.model.QuestionDef} and attaches it to its parent.
      *
-     * @param parent                the form control element's parent
-     * @param e                     the form control element to parse
-     * @param controlType           one of the control types defined in {@link org.javarosa.core.model.Constants}
-     * @param additionalUsedAtts    attributes specific to the control type
-     * @param passedThroughAtts     attributes specific to the control type that should be passed through to
-     *                              additionalAttributes for historical reasons
-     * @return                      a {@link org.javarosa.core.model.QuestionDef} representing the form control element
+     * @param parent             the form control element's parent
+     * @param e                  the form control element to parse
+     * @param controlType        one of the control types defined in {@link org.javarosa.core.model.Constants}
+     * @param additionalUsedAtts attributes specific to the control type
+     * @param passedThroughAtts  attributes specific to the control type that should be passed through to
+     *                           additionalAttributes for historical reasons
+     * @return a {@link org.javarosa.core.model.QuestionDef} representing the form control element
      */
     private QuestionDef parseControl(IFormElement parent, Element e, int controlType, List<String> additionalUsedAtts,
                                      List<String> passedThroughAtts) {
@@ -923,7 +940,7 @@ public class XFormParser implements IXFormParserFunctions {
         } else if (ref != null) {
             try {
                 dataRef = new XPathReference(ref);
-            } catch(RuntimeException el) {
+            } catch (RuntimeException el) {
                 logger.info(XFormParser.getVagueLocation(e));
                 throw el;
             }
@@ -932,7 +949,7 @@ public class XFormParser implements IXFormParserFunctions {
             if (controlType == CONTROL_TRIGGER) {
                 //TODO: special handling for triggers? also, not all triggers created equal
             } else {
-                throw new XFormParseException("XForm Parse: input control with neither 'ref' nor 'bind'",e);
+                throw new XFormParseException("XForm Parse: input control with neither 'ref' nor 'bind'", e);
             }
         }
 
@@ -991,7 +1008,7 @@ public class XFormParser implements IXFormParserFunctions {
         return controlType == CONTROL_RANGE ? new RangeQuestion() : new QuestionDef();
     }
 
-    private void parseQuestionLabel (QuestionDef q, Element e) {
+    private void parseQuestionLabel(QuestionDef q, Element e) {
         String label = getLabel(e);
         String ref = e.getAttributeValue("", REF_ATTR);
 
@@ -1012,12 +1029,12 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseGroupLabel (GroupDef g, Element e) {
+    private void parseGroupLabel(GroupDef g, Element e) {
         if (g.getRepeat())
             return; //ignore child <label>s for <repeat>; the appropriate <label> must be in the wrapping <group>
 
@@ -1042,24 +1059,25 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private String getLabel (Element e){
-        if(e.getChildCount() == 0) return null;
+    private String getLabel(Element e) {
+        if (e.getChildCount() == 0)
+            return null;
 
         recurseForOutput(e);
 
         StringBuilder sb = new StringBuilder();
-        for(int i = 0; i<e.getChildCount();i++){
-            if(e.getType(i)!=Node.TEXT && !(e.getChild(i) instanceof String)){
+        for (int i = 0; i < e.getChildCount(); i++) {
+            if (e.getType(i) != Node.TEXT && !(e.getChild(i) instanceof String)) {
                 Object b = e.getChild(i);
-                Element child = (Element)b;
+                Element child = (Element) b;
 
                 //If the child is in the HTML namespace, retain it.
-                if(NAMESPACE_HTML.equals(child.getNamespace())) {
+                if (NAMESPACE_HTML.equals(child.getNamespace())) {
                     sb.append(XFormSerializer.elementToString(child));
                 } else {
                     //Otherwise, ignore it.
@@ -1067,7 +1085,7 @@ public class XFormParser implements IXFormParserFunctions {
                         "use HTML markup? If so, ensure that the element is defined in " +
                         "the HTML namespace.", child.getName());
                 }
-            }else{
+            } else {
                 sb.append(e.getText(i));
             }
         }
@@ -1075,30 +1093,35 @@ public class XFormParser implements IXFormParserFunctions {
         return sb.toString().trim();
     }
 
-    private void recurseForOutput(Element e){
-        if(e.getChildCount() == 0) return;
+    private void recurseForOutput(Element e) {
+        if (e.getChildCount() == 0)
+            return;
 
-        for(int i=0;i<e.getChildCount();i++){
+        for (int i = 0; i < e.getChildCount(); i++) {
             int kidType = e.getType(i);
-            if(kidType == Node.TEXT) { continue; }
-            if(e.getChild(i) instanceof String) { continue; }
-            Element kid = (Element)e.getChild(i);
+            if (kidType == Node.TEXT) {
+                continue;
+            }
+            if (e.getChild(i) instanceof String) {
+                continue;
+            }
+            Element kid = (Element) e.getChild(i);
 
             //is just text
-            if(kidType == Node.ELEMENT && XFormUtils.isOutput(kid)){
-                String s = "${"+parseOutput(kid)+"}";
+            if (kidType == Node.ELEMENT && XFormUtils.isOutput(kid)) {
+                String s = "${" + parseOutput(kid) + "}";
                 e.removeChild(i);
                 e.addChild(i, Node.TEXT, s);
 
                 //has kids? Recurse through them and swap output tag for parsed version
-            }else if(kid.getChildCount() !=0){
+            } else if (kid.getChildCount() != 0) {
                 recurseForOutput(kid);
                 //is something else
             }
         }
     }
 
-    private String parseOutput (Element e) {
+    private String parseOutput(Element e) {
         List<String> usedAtts = new ArrayList<>();
         usedAtts.add(REF_ATTR);
         usedAtts.add(VALUE);
@@ -1108,7 +1131,7 @@ public class XFormParser implements IXFormParserFunctions {
             xpath = e.getAttributeValue(null, VALUE);
         }
         if (xpath == null) {
-            throw new XFormParseException("XForm Parse: <output> without 'ref' or 'value'",e);
+            throw new XFormParseException("XForm Parse: <output> without 'ref' or 'value'", e);
         }
 
         XPathConditional expr = null;
@@ -1127,14 +1150,14 @@ public class XFormParser implements IXFormParserFunctions {
             _f.getOutputFragments().add(expr);
         }
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
         return String.valueOf(index);
     }
 
-    private void parseHint (QuestionDef q, Element e) {
+    private void parseHint(QuestionDef q, Element e) {
         List<String> usedAtts = new ArrayList<>();
         usedAtts.add(REF_ATTR);
         String hint = getXMLText(e, true);
@@ -1155,12 +1178,12 @@ public class XFormParser implements IXFormParserFunctions {
             q.setHelpText(hint);
         }
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseItem (QuestionDef q, Element e) {
+    private void parseItem(QuestionDef q, Element e) {
         final int MAX_VALUE_LEN = 32;
 
         //catalogue of used attributes in this method/element
@@ -1182,8 +1205,8 @@ public class XFormParser implements IXFormParserFunctions {
             if (LABEL_ELEMENT.equals(childName)) {
 
                 //print attribute warning for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, labelUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, labelUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
                 }
                 labelInnerText = getLabel(child);
                 String ref = child.getAttributeValue("", REF_ATTR);
@@ -1194,18 +1217,18 @@ public class XFormParser implements IXFormParserFunctions {
 
                         verifyTextMappings(textRef, "Item <label>", true);
                     } else {
-                        throw new XFormParseException("malformed ref [" + ref + "] for <item>",child);
+                        throw new XFormParseException("malformed ref [" + ref + "] for <item>", child);
                     }
                 }
             } else if (VALUE.equals(childName)) {
                 value = getXMLText(child, true);
 
                 //print attribute warning for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, valueUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, valueUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
                 }
 
-                if (value != null)  {
+                if (value != null) {
                     if (value.length() > MAX_VALUE_LEN) {
                         triggerWarning(
                             "choice value [" + value + "] is too long; max. suggested length " + MAX_VALUE_LEN + " chars",
@@ -1230,25 +1253,25 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         if (textRef == null && labelInnerText == null) {
-            throw new XFormParseException("<item> without proper <label>",e);
+            throw new XFormParseException("<item> without proper <label>", e);
         }
         if (value == null) {
-            throw new XFormParseException("<item> without proper <value>",e);
+            throw new XFormParseException("<item> without proper <value>", e);
         }
 
         if (textRef != null) {
             q.addSelectChoice(new SelectChoice(textRef, value));
         } else {
-            q.addSelectChoice(new SelectChoice(null,labelInnerText, value, false));
+            q.addSelectChoice(new SelectChoice(null, labelInnerText, value, false));
         }
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
             triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseItemset (QuestionDef q, Element e, IFormElement qparent) {
+    private void parseItemset(QuestionDef q, Element e, IFormElement qparent) {
         ItemsetBinding itemset = new ItemsetBinding();
 
         ////////////////USED FOR PARSER WARNING OUTPUT ONLY
@@ -1272,7 +1295,8 @@ public class XFormParser implements IXFormParserFunctions {
          * We will patch this all up in the verifyItemsetBindings() method.
          */
         String nodesetStr = e.getAttributeValue("", NODESET_ATTR);
-        if(nodesetStr == null ) throw new RuntimeException("No nodeset attribute in element: ["+e.getName()+"]. This is required. (Element Printout:"+XFormSerializer.elementToString(e)+")");
+        if (nodesetStr == null)
+            throw new RuntimeException("No nodeset attribute in element: [" + e.getName() + "]. This is required. (Element Printout:" + XFormSerializer.elementToString(e) + ")");
         XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
         itemset.nodesetExpr = new XPathConditional(path);
         itemset.contextRef = getFormElementRef(qparent);
@@ -1291,8 +1315,8 @@ public class XFormParser implements IXFormParserFunctions {
                 boolean labelItext = false;
 
                 //print unused attribute warning message for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, labelUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, labelUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
                 }
                 /////////////////////////////////////////////////////////////
 
@@ -1314,8 +1338,8 @@ public class XFormParser implements IXFormParserFunctions {
                 String copyXpath = child.getAttributeValue("", REF_ATTR);
 
                 //print unused attribute warning message for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, copyUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, copyUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, copyUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, copyUA), getVagueLocation(child));
                 }
 
                 if (copyXpath == null) {
@@ -1331,8 +1355,8 @@ public class XFormParser implements IXFormParserFunctions {
                 String valueXpath = child.getAttributeValue("", REF_ATTR);
 
                 //print unused attribute warning message for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, valueUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, valueUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
                 }
 
                 if (valueXpath == null) {
@@ -1354,7 +1378,7 @@ public class XFormParser implements IXFormParserFunctions {
 
         if (itemset.copyExpr != null) {
             if (itemset.valueExpr == null) {
-                triggerWarning( "<itemset>s with <copy> are STRONGLY recommended to have <value> as well; pre-selecting, default answers, and display of answers will not work properly otherwise",getVagueLocation(e));
+                triggerWarning("<itemset>s with <copy> are STRONGLY recommended to have <value> as well; pre-selecting, default answers, and display of answers will not work properly otherwise", getVagueLocation(e));
             }
         }
 
@@ -1362,13 +1386,13 @@ public class XFormParser implements IXFormParserFunctions {
         q.setDynamicChoices(itemset);
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
             triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
     }
 
-    private void parseGroup (IFormElement parent, Element e, int groupType) {
+    private void parseGroup(IFormElement parent, Element e, int groupType) {
         GroupDef group = new GroupDef();
         group.setID(serialQuestionID++); //until we come up with a better scheme
         IDataReference dataRef = null;
@@ -1394,7 +1418,7 @@ public class XFormParser implements IXFormParserFunctions {
         if (bind != null) {
             DataBinding binding = bindingsByID.get(bind);
             if (binding == null) {
-                throw new XFormParseException("XForm Parse: invalid binding ID [" + bind + "]",e);
+                throw new XFormParseException("XForm Parse: invalid binding ID [" + bind + "]", e);
             }
             dataRef = binding.getReference();
             refFromBind = true;
@@ -1403,7 +1427,7 @@ public class XFormParser implements IXFormParserFunctions {
                 if (nodeset != null) {
                     dataRef = new XPathReference(nodeset);
                 } else {
-                    throw new XFormParseException("XForm Parse: <repeat> with no binding ('bind' or 'nodeset')",e);
+                    throw new XFormParseException("XForm Parse: <repeat> with no binding ('bind' or 'nodeset')", e);
                 }
             } else {
                 if (ref != null) {
@@ -1470,27 +1494,28 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         // save all the unused attributes verbatim...
-        for(int i=0;i<e.getAttributeCount();i++){
+        for (int i = 0; i < e.getAttributeCount(); i++) {
             String name = e.getAttributeName(i);
-            if ( usedAtts.contains(name) ) continue;
+            if (usedAtts.contains(name))
+                continue;
             group.setAdditionalAttribute(e.getAttributeNamespace(i), name, e.getAttributeValue(i));
         }
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
         parent.addChild(group);
     }
 
-    private TreeReference getFormElementRef (IFormElement fe) {
+    private TreeReference getFormElementRef(IFormElement fe) {
         if (fe instanceof FormDef) {
             TreeReference ref = TreeReference.rootRef();
             ref.add(mainInstanceNode.getName(), 0);
             return ref;
         } else {
-            return (TreeReference)fe.getBind().getReference();
+            return (TreeReference) fe.getBind().getReference();
         }
     }
 
@@ -1499,8 +1524,10 @@ public class XFormParser implements IXFormParserFunctions {
         return FormDef.getAbsRef(ref, getFormElementRef(parent));
     }
 
-    /** Collapses groups whose only child is a repeat into a single repeat that uses the label of the wrapping group */
-    private static void collapseRepeatGroups (IFormElement fe) {
+    /**
+     * Collapses groups whose only child is a repeat into a single repeat that uses the label of the wrapping group
+     */
+    private static void collapseRepeatGroups(IFormElement fe) {
         if (fe.getChildren() == null)
             return;
 
@@ -1508,14 +1535,14 @@ public class XFormParser implements IXFormParserFunctions {
             IFormElement child = fe.getChild(i);
             GroupDef group = null;
             if (child instanceof GroupDef)
-                group = (GroupDef)child;
+                group = (GroupDef) child;
 
             if (group != null) {
                 if (!group.getRepeat() && group.getChildren().size() == 1) {
                     IFormElement grandchild = group.getChildren().get(0);
                     GroupDef repeat = null;
                     if (grandchild instanceof GroupDef)
-                        repeat = (GroupDef)grandchild;
+                        repeat = (GroupDef) grandchild;
 
                     if (repeat != null && repeat.getRepeat()) {
                         //collapse the wrapping group
@@ -1538,7 +1565,7 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void parseIText (Element itext) {
+    private void parseIText(Element itext) {
         Localizer l = new Localizer(true, true);
 
         ArrayList<String> usedAtts = new ArrayList<>(); //used for warning message
@@ -1552,20 +1579,20 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         if (l.getAvailableLocales().length == 0)
-            throw new XFormParseException("no <translation>s defined",itext);
+            throw new XFormParseException("no <translation>s defined", itext);
 
         if (l.getDefaultLocale() == null)
             l.setDefaultLocale(l.getAvailableLocales()[0]);
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(itext, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(itext, usedAtts), getVagueLocation(itext));
+        if (XFormUtils.showUnusedAttributeWarning(itext, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(itext, usedAtts), getVagueLocation(itext));
         }
 
         localizer = l;
     }
 
-    private void parseTranslation (Localizer l, Element trans) {
+    private void parseTranslation(Localizer l, Element trans) {
         /////for warning message
         List<String> usedAtts = new ArrayList<>();
         usedAtts.add("lang");
@@ -1574,17 +1601,17 @@ public class XFormParser implements IXFormParserFunctions {
 
         String lang = trans.getAttributeValue("", "lang");
         if (lang == null || lang.length() == 0) {
-            throw new XFormParseException("no language specified for <translation>",trans);
+            throw new XFormParseException("no language specified for <translation>", trans);
         }
         String isDefault = trans.getAttributeValue("", "default");
 
         if (!l.addAvailableLocale(lang)) {
-            throw new XFormParseException("duplicate <translation> for language '" + lang + "'",trans);
+            throw new XFormParseException("duplicate <translation> for language '" + lang + "'", trans);
         }
 
         if (isDefault != null) {
             if (l.getDefaultLocale() != null)
-                throw new XFormParseException("more than one <translation> set as default",trans);
+                throw new XFormParseException("more than one <translation> set as default", trans);
             l.setDefaultLocale(lang);
         }
 
@@ -1607,14 +1634,14 @@ public class XFormParser implements IXFormParserFunctions {
         ElementChildDeleter.delete(trans, removeIndexes);
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(trans, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(trans, usedAtts), getVagueLocation(trans));
+        if (XFormUtils.showUnusedAttributeWarning(trans, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(trans, usedAtts), getVagueLocation(trans));
         }
 
         l.registerLocaleResource(lang, source);
     }
 
-    private void parseTextHandle (TableLocaleSource l, Element text) {
+    private void parseTextHandle(TableLocaleSource l, Element text) {
         String id = text.getAttributeValue("", ID_ATTR);
 
         //used for parser warnings...
@@ -1627,14 +1654,15 @@ public class XFormParser implements IXFormParserFunctions {
         //////////
 
         if (id == null || id.length() == 0) {
-            throw new XFormParseException("no id defined for <text>",text);
+            throw new XFormParseException("no id defined for <text>", text);
         }
 
         for (int k = 0; k < text.getChildCount(); k++) {
             Element value = text.getElement(k);
-            if (value == null) continue;
-            if(!value.getName().equals(VALUE)){
-                throw new XFormParseException("Unrecognized element ["+value.getName()+"] in Itext->translation->text");
+            if (value == null)
+                continue;
+            if (!value.getName().equals(VALUE)) {
+                throw new XFormParseException("Unrecognized element [" + value.getName() + "] in Itext->translation->text");
             }
 
             String form = value.getAttributeValue("", FORM_ATTR);
@@ -1648,27 +1676,27 @@ public class XFormParser implements IXFormParserFunctions {
 
             String textID = (form == null ? id : id + ";" + form);  //kind of a hack
             if (l.hasMapping(textID)) {
-                throw new XFormParseException("duplicate definition for text ID \"" + id + "\" and form \"" + form + "\""+". Can only have one definition for each text form.",text);
+                throw new XFormParseException("duplicate definition for text ID \"" + id + "\" and form \"" + form + "\"" + ". Can only have one definition for each text form.", text);
             }
             l.setLocaleMapping(textID, data);
 
             //print unused attribute warning message for child element
-            if(XFormUtils.showUnusedAttributeWarning(value, childUsedAtts)){
-                triggerWarning( XFormUtils.unusedAttWarning(value, childUsedAtts), getVagueLocation(value));
+            if (XFormUtils.showUnusedAttributeWarning(value, childUsedAtts)) {
+                triggerWarning(XFormUtils.unusedAttWarning(value, childUsedAtts), getVagueLocation(value));
             }
         }
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(text, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(text, usedAtts), getVagueLocation(text));
+        if (XFormUtils.showUnusedAttributeWarning(text, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(text, usedAtts), getVagueLocation(text));
         }
     }
 
-    private boolean hasITextMapping (String textID, String locale) {
+    private boolean hasITextMapping(String textID, String locale) {
         return localizer.hasMapping(locale == null ? localizer.getDefaultLocale() : locale, textID);
     }
 
-    private void verifyTextMappings (String textID, String type, boolean allowSubforms) {
+    private void verifyTextMappings(String textID, String type, boolean allowSubforms) {
         String[] locales = localizer.getAvailableLocales();
 
         for (String locale : locales) {
@@ -1679,7 +1707,7 @@ public class XFormParser implements IXFormParserFunctions {
                         "': text is not localizable for default locale [" + localizer.getDefaultLocale() + "]!");
                 }
 
-                triggerWarning( type + " '" +
+                triggerWarning(type + " '" +
                     textID + "': text is not localizable for locale " + locale + ".", null);
             }
         }
@@ -1693,20 +1721,20 @@ public class XFormParser implements IXFormParserFunctions {
      */
     private boolean hasSpecialFormMapping(String textID, String locale) {
         //First check our guesses
-        for(String guess : itextKnownForms) {
-            if(hasITextMapping(textID + ";" + guess, locale)) {
+        for (String guess : itextKnownForms) {
+            if (hasITextMapping(textID + ";" + guess, locale)) {
                 return true;
             }
         }
         //Otherwise this sucks and we have to test the keys
         for (String key : localizer.getLocaleData(locale).keySet()) {
-            if(key.startsWith(textID + ";")) {
+            if (key.startsWith(textID + ";")) {
                 //A key is found, pull it out, add it to the list of guesses, and return positive
                 String textForm = key.substring(key.indexOf(";") + 1, key.length());
                 //Kind of a long story how we can end up getting here. It involves the default locale loading values
                 //for the other locale, but isn't super good.
                 //TODO: Clean up being able to get here
-                if(!itextKnownForms.contains(textForm)) {
+                if (!itextKnownForms.contains(textForm)) {
                     logger.info("adding unexpected special itext form: {} to list of expected forms", textForm);
                     itextKnownForms.add(textForm);
                 }
@@ -1721,7 +1749,9 @@ public class XFormParser implements IXFormParserFunctions {
             createBinding(this, _f, usedAtts, passedThroughAtts, element);
     }
 
-    /** Attributes that are read into DataBinding fields **/
+    /**
+     * Attributes that are read into DataBinding fields
+     **/
     private final List<String> usedAtts = unmodifiableList(asList(
         ID_ATTR,
         NODESET_ATTR,
@@ -1743,8 +1773,8 @@ public class XFormParser implements IXFormParserFunctions {
      * These are consistently used by clients but are expected in additionalAttrs for historical reasons.
      **/
     private final List<String> passedThroughAtts = unmodifiableList(asList(
-            "requiredMsg",
-            "saveIncomplete"
+        "requiredMsg",
+        "saveIncomplete"
     ));
 
     private void parseBind(Element element) {
@@ -1769,7 +1799,9 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    /** e is the top-level _data_ node of the instance (immediate (and only) child of <instance>) */
+    /**
+     * e is the top-level _data_ node of the instance (immediate (and only) child of <instance>)
+     */
     private void addMainInstanceToFormDef(Element e, FormInstance instanceModel) {
         loadInstanceData(e, instanceModel.getRoot(), _f);
 
@@ -1779,24 +1811,24 @@ public class XFormParser implements IXFormParserFunctions {
 
         try {
             _f.finalizeTriggerables();
-        } catch(IllegalStateException ise) {
+        } catch (IllegalStateException ise) {
             throw new XFormParseException(ise.getMessage() == null ? "Form has an illegal cycle in its calculate and relevancy expressions!" : ise.getMessage());
         }
     }
 
     static HashMap<String, String> loadNamespaces(Element e, FormInstance tree) {
         HashMap<String, String> prefixes = new HashMap<>();
-        for(int i = 0 ; i < e.getNamespaceCount(); ++i ) {
+        for (int i = 0; i < e.getNamespaceCount(); ++i) {
             String uri = e.getNamespaceUri(i);
             String prefix = e.getNamespacePrefix(i);
-            if(uri != null && prefix != null) {
+            if (uri != null && prefix != null) {
                 tree.addNamespace(prefix, uri);
             }
         }
         return prefixes;
     }
 
-    public static TreeElement buildInstanceStructure (Element node, TreeElement parent, Map<String,
+    public static TreeElement buildInstanceStructure(Element node, TreeElement parent, Map<String,
         String> namespacePrefixesByUri, Integer multiplicityFromGroup) {
         return buildInstanceStructure(node, parent, null, node.getNamespace(), namespacePrefixesByUri, multiplicityFromGroup);
     }
@@ -1814,9 +1846,9 @@ public class XFormParser implements IXFormParserFunctions {
      *                               expensive search can be avoided.
      * @return a new TreeElement
      */
-    public static TreeElement buildInstanceStructure (Element node, TreeElement parent,
-                                                      String instanceName, String docnamespace, Map<String, String> namespacePrefixesByUri,
-                                                      Integer multiplicityFromGroup) {
+    public static TreeElement buildInstanceStructure(Element node, TreeElement parent,
+                                                     String instanceName, String docnamespace, Map<String, String> namespacePrefixesByUri,
+                                                     Integer multiplicityFromGroup) {
         TreeElement element;
 
         //catch when text content is mixed with children
@@ -1826,7 +1858,8 @@ public class XFormParser implements IXFormParserFunctions {
         for (int i = 0; i < numChildren; i++) {
             switch (node.getType(i)) {
                 case Node.ELEMENT:
-                    hasElements = true; break;
+                    hasElements = true;
+                    break;
                 case Node.TEXT:
                     if (node.getText(i).trim().length() > 0)
                         hasText = true;
@@ -1843,7 +1876,7 @@ public class XFormParser implements IXFormParserFunctions {
         if (isTemplate(node)) {
             multiplicity = TreeReference.INDEX_TEMPLATE;
             if (parent != null && parent.getChild(name, TreeReference.INDEX_TEMPLATE) != null) {
-                throw new XFormParseException("More than one node declared as the template for the same repeated set [" + name + "]",node);
+                throw new XFormParseException("More than one node declared as the template for the same repeated set [" + name + "]", node);
             }
         } else {
             multiplicity = multiplicityFromGroup != null ? multiplicityFromGroup :
@@ -1853,15 +1886,15 @@ public class XFormParser implements IXFormParserFunctions {
 
         String modelType = node.getAttributeValue(NAMESPACE_JAVAROSA, "modeltype");
         //create node; handle children
-        if(modelType == null) {
+        if (modelType == null) {
             element = new TreeElement(name, multiplicity);
             element.setInstanceName(instanceName);
         } else {
-            if( typeMappings.get(modelType) == null ){
-                throw new XFormParseException("ModelType " + modelType + " is not recognized.",node);
+            if (typeMappings.get(modelType) == null) {
+                throw new XFormParseException("ModelType " + modelType + " is not recognized.", node);
             }
-            element = (TreeElement)modelPrototypes.getNewInstance(typeMappings.get(modelType).toString());
-            if(element == null) {
+            element = (TreeElement) modelPrototypes.getNewInstance(typeMappings.get(modelType).toString());
+            if (element == null) {
                 element = new TreeElement(name, multiplicity);
                 logger.info("No model type prototype available for {}", modelType);
             } else {
@@ -1869,8 +1902,8 @@ public class XFormParser implements IXFormParserFunctions {
                 element.setMult(multiplicity);
             }
         }
-        if(node.getNamespace() != null) {
-            if(!node.getNamespace().equals(docnamespace)) {
+        if (node.getNamespace() != null) {
+            if (!node.getNamespace().equals(docnamespace)) {
                 element.setNamespace(node.getNamespace());
             }
             if (namespacePrefixesByUri.containsKey(node.getNamespace())) {
@@ -1947,7 +1980,7 @@ public class XFormParser implements IXFormParserFunctions {
     //FIXME: the 'ref' and FormDef parameters (along with the helper function above that initializes them) are only needed so that we
     //can fetch QuestionDefs bound to the given node, as the QuestionDef reference is needed to properly represent answers
     //to select questions. obviously, we want to fix this.
-    private static void loadInstanceData (Element node, TreeElement cur, FormDef f) {
+    private static void loadInstanceData(Element node, TreeElement cur, FormDef f) {
         int numChildren = node.getChildCount();
         boolean hasElements = false;
         for (int i = 0; i < numChildren; i++) {
@@ -1988,8 +2021,10 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    /** Finds a questiondef that binds to ref, if the data type is a 'select' question type */
-    public static QuestionDef ghettoGetQuestionDef (int dataType, FormDef f, TreeReference ref) {
+    /**
+     * Finds a questiondef that binds to ref, if the data type is a 'select' question type
+     */
+    public static QuestionDef ghettoGetQuestionDef(int dataType, FormDef f, TreeReference ref) {
         if (dataType == DATATYPE_CHOICE || dataType == DATATYPE_CHOICE_LIST) {
             return FormDef.findQuestionByRef(ref, f);
         } else {
@@ -1997,7 +2032,7 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void checkDependencyCycles () {
+    private void checkDependencyCycles() {
         _f.reportDependencyCycles();
     }
 
@@ -2007,7 +2042,7 @@ public class XFormParser implements IXFormParserFunctions {
 
     /**
      * Loads a compatible xml instance into FormDef f
-     *
+     * <p>
      * call before f.initialize()!
      */
     private static void loadXmlInstance(FormDef f, Document xmlInst) {
@@ -2036,7 +2071,7 @@ public class XFormParser implements IXFormParserFunctions {
         //     }
     }
 
-    public static String getXMLText (Node n, boolean trim) {
+    public static String getXMLText(Node n, boolean trim) {
         return (n.getChildCount() == 0 ? null : getXMLText(n, 0, trim));
     }
 
@@ -2045,7 +2080,7 @@ public class XFormParser implements IXFormParserFunctions {
      * needed because escape sequences are parsed into consecutive text nodes
      * e.g. "abc&amp;123" --> (abc)(&)(123)
      **/
-    public static String getXMLText (Node node, int i, boolean trim) {
+    public static String getXMLText(Node node, int i, boolean trim) {
         StringBuilder strBuff = null;
 
         String text = node.getText(i);
@@ -2067,7 +2102,7 @@ public class XFormParser implements IXFormParserFunctions {
         return text;
     }
 
-    public static FormInstance restoreDataModel (InputStream input, Class restorableType) throws IOException {
+    public static FormInstance restoreDataModel(InputStream input, Class restorableType) throws IOException {
         Document doc = getXMLDocument(new InputStreamReader(input, "UTF-8"));
         if (doc == null) {
             throw new RuntimeException("syntax error in XML instance; could not parse");
@@ -2075,8 +2110,8 @@ public class XFormParser implements IXFormParserFunctions {
         return restoreDataModel(doc, restorableType);
     }
 
-    public static FormInstance restoreDataModel (Document doc, Class restorableType) {
-        Restorable r = (restorableType != null ? (Restorable)PrototypeFactory.getInstance(restorableType) : null);
+    public static FormInstance restoreDataModel(Document doc, Class restorableType) {
+        Restorable r = (restorableType != null ? (Restorable) PrototypeFactory.getInstance(restorableType) : null);
 
         Element e = doc.getRootElement();
 
@@ -2091,7 +2126,7 @@ public class XFormParser implements IXFormParserFunctions {
         return dm;
     }
 
-    public static FormInstance restoreDataModel (byte[] data, Class restorableType) {
+    public static FormInstance restoreDataModel(byte[] data, Class restorableType) {
         try {
             return restoreDataModel(new ByteArrayInputStream(data), restorableType);
         } catch (IOException e) {
@@ -2103,13 +2138,13 @@ public class XFormParser implements IXFormParserFunctions {
     public static String getVagueLocation(Element e) {
         String path = e.getName();
         Element walker = e;
-        while(walker != null) {
+        while (walker != null) {
             Node n = walker.getParent();
-            if(n instanceof Element) {
-                walker = (Element)n;
+            if (n instanceof Element) {
+                walker = (Element) n;
                 String step = walker.getName();
-                for(int i = 0; i <  walker.getAttributeCount() ; ++i) {
-                    step += "[@" +walker.getAttributeName(i) + "=";
+                for (int i = 0; i < walker.getAttributeCount(); ++i) {
+                    step += "[@" + walker.getAttributeName(i) + "=";
                     step += walker.getAttributeValue(i) + "]";
                 }
                 path = step + "/" + path;
@@ -2128,15 +2163,15 @@ public class XFormParser implements IXFormParserFunctions {
 
     private static String getVagueElementPrintout(Element e, int maxDepth) {
         String elementString = "<" + e.getName();
-        for(int i = 0; i <  e.getAttributeCount() ; ++i) {
+        for (int i = 0; i < e.getAttributeCount(); ++i) {
             elementString += " " + e.getAttributeName(i) + "=\"";
             elementString += e.getAttributeValue(i) + "\"";
         }
-        if(e.getChildCount() > 0) {
+        if (e.getChildCount() > 0) {
             elementString += ">";
-            if(e.getType(0) ==Element.ELEMENT) {
-                if(maxDepth > 0) {
-                    elementString += getVagueElementPrintout((Element)e.getChild(0),maxDepth -1);
+            if (e.getType(0) == Element.ELEMENT) {
+                if (maxDepth > 0) {
+                    elementString += getVagueElementPrintout((Element) e.getChild(0), maxDepth - 1);
                 } else {
                     elementString += "...";
                 }

--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -6,7 +6,9 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.xpath.expr.XPathPathExpr;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Represents a set of XPath nodes returned from a path or other operation which acts on multiple
@@ -75,6 +77,41 @@ public class XPathNodeset {
         nodeset.pathEvaluated = pathEvaluated;
         nodeset.originalPath = originalPath;
         return nodeset;
+    }
+
+    /**
+     * Builds and returns a copy of a XPathNodeset with nodes in a randomized order.
+     *
+     * @return      a copy of this nodeset with nodes in a randomized order
+     */
+    public static XPathNodeset shuffle(XPathNodeset input) {
+        return shuffle(input, new Random());
+    }
+
+    /**
+     * Builds and returns a copy of a XPathNodeset with nodes in a randomized order.
+     *
+     * @param seed  the seed used when building a Random object to get reproducible results. If null, no seed is used
+     * @return      a copy of this nodeset with nodes in a randomized order
+     */
+    public static XPathNodeset shuffle(XPathNodeset input, long seed) {
+        return shuffle(input, new Random(seed));
+    }
+
+    private static XPathNodeset shuffle(XPathNodeset input, Random r) {
+        List<TreeReference> nodesCopy = new ArrayList<>(input.nodes);
+
+        XPathNodeset result = new XPathNodeset(nodesCopy, input.instance, input.ec);
+
+        for (int i = result.nodes.size() - 1; i > 0; i--) {
+            int randomIndex = r.nextInt(i + 1);
+
+            TreeReference current = result.nodes.remove(i);
+            result.nodes.add(i, result.nodes.get(randomIndex));
+            result.nodes.set(randomIndex, current);
+        }
+
+        return result;
     }
 
     protected void setReferences(List<TreeReference> nodes) {

--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -4,11 +4,10 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xform.parse.RandomizeHelper;
 import org.javarosa.xpath.expr.XPathPathExpr;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Represents a set of XPath nodes returned from a path or other operation which acts on multiple
@@ -85,7 +84,11 @@ public class XPathNodeset {
      * @return      a copy of this nodeset with nodes in a randomized order
      */
     public static XPathNodeset shuffle(XPathNodeset input) {
-        return shuffle(input, new Random());
+        return new XPathNodeset(
+            RandomizeHelper.shuffle(input.nodes),
+            input.instance,
+            input.ec
+        );
     }
 
     /**
@@ -95,23 +98,11 @@ public class XPathNodeset {
      * @return      a copy of this nodeset with nodes in a randomized order
      */
     public static XPathNodeset shuffle(XPathNodeset input, long seed) {
-        return shuffle(input, new Random(seed));
-    }
-
-    private static XPathNodeset shuffle(XPathNodeset input, Random r) {
-        List<TreeReference> nodesCopy = new ArrayList<>(input.nodes);
-
-        XPathNodeset result = new XPathNodeset(nodesCopy, input.instance, input.ec);
-
-        for (int i = result.nodes.size() - 1; i > 0; i--) {
-            int randomIndex = r.nextInt(i + 1);
-
-            TreeReference current = result.nodes.remove(i);
-            result.nodes.add(i, result.nodes.get(randomIndex));
-            result.nodes.set(randomIndex, current);
-        }
-
-        return result;
+        return new XPathNodeset(
+            RandomizeHelper.shuffle(input.nodes, seed),
+            input.instance,
+            input.ec
+        );
     }
 
     protected void setReferences(List<TreeReference> nodes) {

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -424,6 +424,17 @@ public class XPathFuncExpr extends XPathExpression {
                 (String) argVals[0],
                 args.length == 3 ? Encoding.from((String)argVals[2]) : Encoding.BASE64
             );
+        } else if (name.equals("randomize")) {
+            if (!(argVals[0] instanceof XPathNodeset))
+                throw new XPathTypeMismatchException("First argument to randomize must be a nodeset");
+
+            if (args.length == 1)
+                return XPathNodeset.shuffle((XPathNodeset) argVals[0]);
+
+            if (args.length == 2)
+                return XPathNodeset.shuffle((XPathNodeset) argVals[0], toNumeric(argVals[1]).longValue());
+
+            throw new XPathUnhandledException("function \'randomize\' requires 1 or 2 arguments. " + args.length + " provided.");
         } else {
             //check for custom handler
             IFunctionHandler handler = funcHandlers.get(name);

--- a/test/org/javarosa/core/model/condition/RecalculateTest.java
+++ b/test/org/javarosa/core/model/condition/RecalculateTest.java
@@ -16,8 +16,7 @@ public class RecalculateTest {
 
     @Before
     public void setUp() {
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(r("calculate-now.xml").toString());
+        FormParseInit fpi = new FormParseInit(r("calculate-now.xml"));
         formDef = fpi.getFormDef();
         formDef.initialize(true, new InstanceInitializationFactory());
     }

--- a/test/org/javarosa/core/model/instance/test/TreeElementTests.java
+++ b/test/org/javarosa/core/model/instance/test/TreeElementTests.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -22,9 +23,7 @@ public class TreeElementTests {
     @Test
     public void testPopulate_withNodesAttributes() {
         // Given
-        FormParseInit formParseInit = new FormParseInit();
-        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(),
-                "populate-nodes-attributes.xml").toString());
+        FormParseInit formParseInit = new FormParseInit(r("populate-nodes-attributes.xml"));
 
         FormEntryController formEntryController = formParseInit.getFormEntryController();
 

--- a/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
+++ b/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
@@ -6,15 +6,14 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.nio.file.Paths;
 
-import org.javarosa.core.PathConst;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryController;
 import org.junit.Test;
 
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 
 public class FormIndexSerializationTest {
@@ -54,8 +53,7 @@ public class FormIndexSerializationTest {
 
     @Test
     public void testOnFormController() throws IOException, ClassNotFoundException {
-        FormParseInit formParseInit = new FormParseInit();
-        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "formindex-serialization.xml").toString());
+        FormParseInit formParseInit = new FormParseInit(r("formindex-serialization.xml"));
         FormEntryController formEntryController = formParseInit.getFormEntryController();
 
         FormIndex formIndex = formEntryController.getModel().getFormIndex();

--- a/test/org/javarosa/core/test/FormParseInit.java
+++ b/test/org/javarosa/core/test/FormParseInit.java
@@ -1,6 +1,8 @@
 package org.javarosa.core.test;
 
-import org.javarosa.core.PathConst;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+
+import java.nio.file.Path;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -11,7 +13,6 @@ import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.util.XFormUtils;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.List;
@@ -39,28 +40,23 @@ import org.slf4j.LoggerFactory;
 
 public class FormParseInit {
     private static final Logger logger = LoggerFactory.getLogger(FormParseInit.class);
-    private String FORM_NAME = (new File(PathConst.getTestResourcePath(), "ImageSelectTester.xhtml")).getAbsolutePath();
+    private final String FORM_NAME;
     private FormDef xform;
     private FormEntryController fec;
     private FormEntryModel femodel;
 
 
     public FormParseInit(){
+        FORM_NAME = r("ImageSelectTester.xhtml").toString();
         this.init();
     }
 
-    /**
-     * Set a new form to be parsed (instead of the default), and calls
-     * init() immediately to parse it.  It is uneccessary to call init() again after
-     * using this method.
-     * @param uri URI pointing to the xform.
-     */
-    public void setFormToParse(String uri){
-        FORM_NAME = uri;
+    public FormParseInit(Path form){
+        FORM_NAME = form.toString();
         this.init();
     }
 
-    public void init(){
+    private void init(){
         String xf_name = FORM_NAME;
         FileInputStream is;
         try {

--- a/test/org/javarosa/form/api/FormNavigationTestCase.java
+++ b/test/org/javarosa/form/api/FormNavigationTestCase.java
@@ -63,8 +63,7 @@ public class FormNavigationTestCase {
     // form and then decreasing until the beginning of the form.
     // Verify the expected indices before and after each operation.
     public void testIndices() {
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(r("navigation/" + formName).toString());
+        FormParseInit fpi = new FormParseInit(r("navigation/" + formName));
         FormEntryController formEntryController = fpi.getFormEntryController();
         FormEntryModel formEntryModel = fpi.getFormEntryModel();
 

--- a/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
+++ b/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
@@ -42,8 +42,7 @@ public class OutputInComputedConstraintTextTest {
 
   @Before
   public void setUp() {
-    FormParseInit fpi = new FormParseInit();
-    fpi.setFormToParse(r("constraint-message-error.xml").toString());
+    FormParseInit fpi = new FormParseInit(r("constraint-message-error.xml"));
     formDef = fpi.getFormDef();
     formDef.getLocalizer().setLocale("English");
     ctrl = fpi.getFormEntryController();

--- a/test/org/javarosa/xform/parse/AttributesTestCase.java
+++ b/test/org/javarosa/xform/parse/AttributesTestCase.java
@@ -1,14 +1,12 @@
 package org.javarosa.xform.parse;
 
-import org.javarosa.core.PathConst;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Test;
 
-import java.nio.file.Paths;
-
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -19,8 +17,7 @@ public class AttributesTestCase {
 
     @Test
     public void testBindAttributes() {
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "form_with_bind_attributes.xml").toString());
+        FormParseInit fpi = new FormParseInit(r("form_with_bind_attributes.xml"));
         FormEntryModel formEntryModel = fpi.getFormEntryModel();
         FormDef formDef = fpi.getFormDef();
         FormEntryPrompt formEntryPrompt;
@@ -42,8 +39,7 @@ public class AttributesTestCase {
 
     @Test
     public void testAdditionalAttributes() {
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "form_with_additional_attributes.xml").toString());
+        FormParseInit fpi = new FormParseInit(r("form_with_additional_attributes.xml"));
         FormEntryModel formEntryModel = fpi.getFormEntryModel();
         FormDef formDef = fpi.getFormDef();
         FormEntryPrompt formEntryPrompt;

--- a/test/org/javarosa/xform/parse/FisherYatesExamplesTest.java
+++ b/test/org/javarosa/xform/parse/FisherYatesExamplesTest.java
@@ -1,0 +1,42 @@
+package org.javarosa.xform.parse;
+
+import static org.javarosa.xform.parse.FisherYatesTest.list;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class FisherYatesExamplesTest {
+    @Parameterized.Parameter(value = 0)
+    public String testName;
+
+    @Parameterized.Parameter(value = 1)
+    public List<?> input;
+
+    @Parameterized.Parameter(value = 2)
+    public Long seed;
+
+    @Parameterized.Parameter(value = 3)
+    public List<?> expectedOutput;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Numbers [0-9], seed 33", list(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), 33L, list(3, 5, 4, 8, 2, 0, 1, 6, 9, 7)},
+            {"Numbers [0-9], seed 42", list(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), 42L, list(0, 5, 9, 1, 8, 4, 6, 3, 7, 2)},
+            {"Letters [A-F], seed 42", list("ABCDEF"), 42L, list("AFCBDE")},
+            {"Letters [A-F], seed -42", list("ABCDEF"), -42L, list("EDAFBC")},
+            {"Letters [A-F], seed 1", list("ABCDEF"), 1L, list("BFEACD")},
+            {"Letters [A-F], seed 11111111", list("ABCDEF"), 11111111L, list("ACDBFE")},
+        });
+    }
+
+    @Test
+    public void seeded_shuffle_produces_predictable_outputs() {
+        assertEquals(expectedOutput, FisherYates.shuffle(input, seed));
+    }
+}

--- a/test/org/javarosa/xform/parse/FisherYatesTest.java
+++ b/test/org/javarosa/xform/parse/FisherYatesTest.java
@@ -1,14 +1,12 @@
 package org.javarosa.xform.parse;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import org.junit.Test;
 
 public class FisherYatesTest {
@@ -16,37 +14,29 @@ public class FisherYatesTest {
 
     @Test
     public void it_produces_a_list_with_the_same_elements_in_different_order() {
-        List<Integer> output = new ArrayList<>(INPUT);
-        FisherYates.shuffle(output, new Random());
-        assertNotEquals(INPUT, output);
+        assertNotEquals(INPUT, FisherYates.shuffle(INPUT));
     }
 
     @Test
     public void shuffling_an_empty_list_has_no_effect() {
-        List<Object> emptyList = Collections.emptyList();
-        FisherYates.shuffle(emptyList, new Random());
-        assertTrue(emptyList.isEmpty());
+        assertTrue(FisherYates.shuffle(emptyList()).isEmpty());
     }
 
     @Test
     public void different_random_seeds_output_different_predictable_outputs() {
-        List<Integer> output1 = new ArrayList<>(INPUT);
-        FisherYates.shuffle(output1, new Random(42));
-        assertEquals(Arrays.asList(2, 3, 7, 4, 8, 5, 0, 9, 1, 6), output1);
+        List<Integer> output1 = FisherYates.shuffle(INPUT, 33);
+        assertEquals(Arrays.asList(3, 5, 4, 8, 2, 0, 1, 6, 9, 7), output1);
 
-        List<Integer> output2 = new ArrayList<>(INPUT);
-        FisherYates.shuffle(output2, new Random(33));
-        assertEquals(Arrays.asList(0, 8, 1, 6, 7, 2, 5, 4, 9, 3), output2);
+        List<Integer> output2 = FisherYates.shuffle(INPUT, 42);
+        assertEquals(Arrays.asList(0, 5, 9, 1, 8, 4, 6, 3, 7, 2), output2);
     }
 
     @Test
     public void same_random_seeds_output_same_predictable_outputs() {
-        List<Integer> output1 = new ArrayList<>(INPUT);
-        FisherYates.shuffle(output1, new Random(42));
-        assertEquals(Arrays.asList(2, 3, 7, 4, 8, 5, 0, 9, 1, 6), output1);
+        List<Integer> output1 = FisherYates.shuffle(INPUT, 42);
+        assertEquals(Arrays.asList(0, 5, 9, 1, 8, 4, 6, 3, 7, 2), output1);
 
-        List<Integer> output2 = new ArrayList<>(INPUT);
-        FisherYates.shuffle(output2, new Random(42));
-        assertEquals(Arrays.asList(2, 3, 7, 4, 8, 5, 0, 9, 1, 6), output2);
+        List<Integer> output2 = FisherYates.shuffle(INPUT, 42);
+        assertEquals(Arrays.asList(0, 5, 9, 1, 8, 4, 6, 3, 7, 2), output2);
     }
 }

--- a/test/org/javarosa/xform/parse/FisherYatesTest.java
+++ b/test/org/javarosa/xform/parse/FisherYatesTest.java
@@ -1,7 +1,7 @@
 package org.javarosa.xform.parse;
 
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
+import static org.javarosa.xform.parse.FisherYates.shuffle;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -10,33 +10,29 @@ import java.util.List;
 import org.junit.Test;
 
 public class FisherYatesTest {
-    private static final List<Integer> INPUT = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    private static final List<Integer> INPUT = list(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
     @Test
     public void it_produces_a_list_with_the_same_elements_in_different_order() {
-        assertNotEquals(INPUT, FisherYates.shuffle(INPUT));
+        assertNotEquals(INPUT, shuffle(INPUT));
     }
 
     @Test
     public void shuffling_an_empty_list_has_no_effect() {
-        assertTrue(FisherYates.shuffle(emptyList()).isEmpty());
+        assertTrue(shuffle(emptyList()).isEmpty());
     }
 
     @Test
-    public void different_random_seeds_output_different_predictable_outputs() {
-        List<Integer> output1 = FisherYates.shuffle(INPUT, 33);
-        assertEquals(Arrays.asList(3, 5, 4, 8, 2, 0, 1, 6, 9, 7), output1);
-
-        List<Integer> output2 = FisherYates.shuffle(INPUT, 42);
-        assertEquals(Arrays.asList(0, 5, 9, 1, 8, 4, 6, 3, 7, 2), output2);
+    public void different_random_seeds_output_different_outputs() {
+        assertNotEquals(shuffle(INPUT, 33), shuffle(INPUT, 42));
     }
 
-    @Test
-    public void same_random_seeds_output_same_predictable_outputs() {
-        List<Integer> output1 = FisherYates.shuffle(INPUT, 42);
-        assertEquals(Arrays.asList(0, 5, 9, 1, 8, 4, 6, 3, 7, 2), output1);
+    @SafeVarargs
+    static <T> List<T> list(T... values) {
+        return Arrays.asList(values);
+    }
 
-        List<Integer> output2 = FisherYates.shuffle(INPUT, 42);
-        assertEquals(Arrays.asList(0, 5, 9, 1, 8, 4, 6, 3, 7, 2), output2);
+    static List<String> list(String values) {
+        return Arrays.asList(values.split(""));
     }
 }

--- a/test/org/javarosa/xform/parse/FisherYatesTest.java
+++ b/test/org/javarosa/xform/parse/FisherYatesTest.java
@@ -1,0 +1,52 @@
+package org.javarosa.xform.parse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+
+public class FisherYatesTest {
+    private static final List<Integer> INPUT = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    @Test
+    public void it_produces_a_list_with_the_same_elements_in_different_order() {
+        List<Integer> output = new ArrayList<>(INPUT);
+        FisherYates.shuffle(output, new Random());
+        assertNotEquals(INPUT, output);
+    }
+
+    @Test
+    public void shuffling_an_empty_list_has_no_effect() {
+        List<Object> emptyList = Collections.emptyList();
+        FisherYates.shuffle(emptyList, new Random());
+        assertTrue(emptyList.isEmpty());
+    }
+
+    @Test
+    public void different_random_seeds_output_different_predictable_outputs() {
+        List<Integer> output1 = new ArrayList<>(INPUT);
+        FisherYates.shuffle(output1, new Random(42));
+        assertEquals(Arrays.asList(2, 3, 7, 4, 8, 5, 0, 9, 1, 6), output1);
+
+        List<Integer> output2 = new ArrayList<>(INPUT);
+        FisherYates.shuffle(output2, new Random(33));
+        assertEquals(Arrays.asList(0, 8, 1, 6, 7, 2, 5, 4, 9, 3), output2);
+    }
+
+    @Test
+    public void same_random_seeds_output_same_predictable_outputs() {
+        List<Integer> output1 = new ArrayList<>(INPUT);
+        FisherYates.shuffle(output1, new Random(42));
+        assertEquals(Arrays.asList(2, 3, 7, 4, 8, 5, 0, 9, 1, 6), output1);
+
+        List<Integer> output2 = new ArrayList<>(INPUT);
+        FisherYates.shuffle(output2, new Random(42));
+        assertEquals(Arrays.asList(2, 3, 7, 4, 8, 5, 0, 9, 1, 6), output2);
+    }
+}

--- a/test/org/javarosa/xform/parse/ParkMillerTest.java
+++ b/test/org/javarosa/xform/parse/ParkMillerTest.java
@@ -1,0 +1,31 @@
+package org.javarosa.xform.parse;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ParkMillerTest {
+    @Test
+    public void same_seeds_produce_same_predictable_numbers() {
+        ParkMiller random1 = new ParkMiller(42);
+        ParkMiller random2 = new ParkMiller(42);
+
+        // We test the sequence of the first million integers
+        for (int i = 0; i < 1_000_000; i++) {
+            assertEquals(random1.nextInt(), random2.nextInt());
+            assertEquals(random1.nextDouble(), random2.nextDouble(), 0.0);
+        }
+    }
+
+    @Test
+    public void it_admits_negative_seeds() {
+        ParkMiller random1 = new ParkMiller(-42);
+        ParkMiller random2 = new ParkMiller(-42);
+
+        // We test the sequence of the first million integers
+        for (int i = 0; i < 1_000_000; i++) {
+            assertEquals(random1.nextInt(), random2.nextInt());
+            assertEquals(random1.nextDouble(), random2.nextDouble(), 0.0);
+        }
+    }
+}

--- a/test/org/javarosa/xform/parse/RandomizeHelperTest.java
+++ b/test/org/javarosa/xform/parse/RandomizeHelperTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xform.parse;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotSame;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.parseSeed;
+import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+public class RandomizeHelperTest {
+    @Test
+    public void cleans_the_nodeset_definition() {
+        // We will try different combinations of whitespace and seed presence around the path
+        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path)"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize( /some/path )"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path,33)"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path, 33)"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize( /some/path , 33)"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_cleaning_a_nodeset_that_does_not_use_randomize_variant_1() {
+        cleanNodesetDefinition("this doesn't start with randomize( )");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_cleaning_a_nodeset_that_does_not_use_randomize_variant_2() {
+        cleanNodesetDefinition("this doesn't end with ) *some filler here*");
+    }
+
+    @Test
+    public void parses_the_seed() {
+        assertNull(parseSeed("randomize(/some/path)"));
+        // We will try different combinations of whitespace
+        assertEquals(new Long(33), parseSeed("randomize(/some/path,33)"));
+        assertEquals(new Long(33), parseSeed("randomize(/some/path, 33)"));
+        assertEquals(new Long(33), parseSeed("randomize(/some/path, 33 )"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_parsing_the_seed_from_a_nodeset_that_does_not_use_randomize_variant_1() {
+        parseSeed("this doesn't start with randomize( )");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_parsing_the_seed_from_a_nodeset_that_does_not_use_randomize_variant_2() {
+        parseSeed("this doesn't end with ) *some filler here*");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void throws_when_parsing_a_seed_that_is_not_long() {
+        parseSeed("randomize(/some/path, xyz)");
+    }
+
+    @Test
+    public void given_an_empty_list_shuffle_outputs_a_new_empty_list() {
+        List<?> input = Collections.emptyList();
+        List<?> output = shuffle(input);
+
+        assertNotSame(input, output);
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void given_a_non_empty_nodeset_randomize_outputs_a_nodeset_with_same_elements_shuffled() {
+        List<Wrap<Integer>> input = Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(Wrap::wrap).collect(toList());
+        List<Wrap<Integer>> output = shuffle(input);
+
+        assertEquals(input.size(), output.size());
+        assertTrue(output.containsAll(input));
+        assertTrue(nodesEqualInAnyOrder(input, output));
+        assertFalse(nodesEqualInOrder(input, output));
+        // Although, in fact, this could happen, because it's random.
+    }
+
+    @Test
+    public void given_the_same_seed_randomize_should_output_nodesets_with_the_same_elements_in_the_same_order() {
+        List<Wrap<Integer>> input = Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(Wrap::wrap).collect(toList());
+        List<Wrap<Integer>> output1 = shuffle(input, 42L);
+        List<Wrap<Integer>> output2 = shuffle(input, 42L);
+
+        assertNotSame(output1, output2);
+        assertTrue(nodesEqualInOrder(output1, output2));
+    }
+
+    // We will use this class in the test just to force equality
+    // rules to work by reference, not by value
+    private static class Wrap<T> {
+        private final T t;
+
+        Wrap(T t) {
+            this.t = t;
+        }
+
+        static <U> Wrap<U> wrap(U u) {
+            return new Wrap<>(u);
+        }
+    }
+
+    private static boolean nodesEqualInOrder(List<?> left, List<?> right) {
+        if (left.size() != right.size())
+            return false;
+
+        for (int i = 0; i < left.size(); i++)
+            if (!left.get(i).equals(right.get(i)))
+                return false;
+
+        return true;
+    }
+
+    private static boolean nodesEqualInAnyOrder(List<?> left, List<?> right) {
+        if (left.size() != right.size())
+            return false;
+
+        return left.containsAll(right);
+    }
+}

--- a/test/org/javarosa/xpath/XPathNodesetShuffleTest.java
+++ b/test/org/javarosa/xpath/XPathNodesetShuffleTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.xpath;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.javarosa.xpath.XPathNodeset.shuffle;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.javarosa.core.model.instance.TreeReference;
+import org.junit.Test;
+
+public class XPathNodesetShuffleTest {
+    @Test
+    public void given_an_empty_nodeset_randomize_outputs_a_new_empty_nodeset() {
+        XPathNodeset input = new XPathNodeset(new ArrayList<>(), null, null);
+        XPathNodeset output = shuffle(input);
+
+        assertNotSame(input, output);
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void given_a_non_empty_nodeset_randomize_outputs_a_nodeset_with_same_elements_shuffled() {
+        XPathNodeset input = getInputNodeset();
+        XPathNodeset output = shuffle(input);
+
+        assertTrue(nodesEqualInAnyOrder(input, output));
+        assertFalse(nodesEqualInOrder(input, output));
+        // Although, in fact, this could happen, because it's random.
+    }
+
+    @Test
+    public void given_the_same_seed_randomize_should_output_nodesets_with_the_same_elements_in_the_same_order() {
+        XPathNodeset input = getInputNodeset();
+        XPathNodeset output1 = shuffle(input, 42L);
+        XPathNodeset output2 = shuffle(input, 42L);
+
+        assertTrue(nodesEqualInOrder(output1, output2));
+    }
+
+    private static boolean nodesEqualInOrder(XPathNodeset left, XPathNodeset right) {
+        if (left.size() != right.size())
+            return false;
+
+        for (int i = 0; i < left.size(); i++)
+            if (left.getRefAt(i) != right.getRefAt(i))
+                return false;
+
+        return true;
+    }
+
+    private static boolean nodesEqualInAnyOrder(XPathNodeset left, XPathNodeset right) {
+        if (left.size() != right.size())
+            return false;
+
+        Set<TreeReference> leftRefs = new HashSet<>();
+        Set<TreeReference> rightRefs = new HashSet<>();
+        for (int i = 0; i < left.size(); i++) {
+            leftRefs.add(left.getRefAt(i));
+            rightRefs.add(right.getRefAt(i));
+        }
+
+        return leftRefs.containsAll(rightRefs);
+    }
+
+    private static XPathNodeset getInputNodeset() {
+        List<TreeReference> refs = new ArrayList<>();
+        for (int i = 0; i < 10; i++)
+            refs.add(new TreeReference());
+        return new XPathNodeset(refs, null, null);
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_UNBOUND;
+import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XPathFuncExprRandomizeTest {
+
+    private FormDef formDef;
+
+    @Before
+    public void setUp() {
+        // Take a look to the form file:
+        //  - The first pair of fields use randomize without a seed.
+        //  - The second pair of fields use randomize with a seed.
+        FormParseInit fpi = new FormParseInit();
+        fpi.setFormToParse(r("randomize.xml").toString());
+        formDef = fpi.getFormDef();
+    }
+
+    @Test
+    public void fields_without_seed_in_the_same_form_get_a_different_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/fruit1");
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/fruit2");
+
+        assertFalse(nodesEqualInOrder(choices1, choices2));
+    }
+
+    @Test
+    public void the_same_field_without_seed_in_different_instances_gets_a_different_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/fruit1");
+
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/fruit1");
+
+        assertFalse(nodesEqualInOrder(choices1, choices2));
+    }
+
+    @Test
+    public void seeded_fields_in_the_same_form_get_the_same_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/seededFruit1");
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/seededFruit2");
+
+        assertTrue(nodesEqualInOrder(choices1, choices2));
+    }
+
+    @Test
+    public void the_same_seeded_field_in_different_instances_gets_the_same_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/seededFruit2");
+
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/seededFruit2");
+
+        assertTrue(nodesEqualInOrder(choices1, choices2));
+    }
+
+    private static void initializeNewInstance(FormDef formDef) {
+        formDef.initialize(true, new InstanceInitializationFactory());
+    }
+
+    private List<SelectChoice> getSelectChoices(FormDef formDef, String ref) {
+        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
+        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
+        return formEntryPrompt.getSelectChoices();
+    }
+
+    private FormIndex getFormIndex(FormDef formDef, TreeReference ref) {
+        for (int localIndex = 0, lastIndex = formDef.getChildren().size(); localIndex < lastIndex; localIndex++)
+            if (formDef.getChild(localIndex).getBind().getReference().equals(ref))
+                return new FormIndex(localIndex, 0, ref);
+        throw new IllegalArgumentException("Reference " + ref + " not found");
+    }
+
+    private static boolean nodesEqualInOrder(List<SelectChoice> left, List<SelectChoice> right) {
+        if (left.size() != right.size())
+            return false;
+
+        for (int i = 0; i < left.size(); i++)
+            if (!left.get(i).getValue().equals(right.get(i).getValue()))
+                return false;
+
+        return true;
+    }
+
+    private static TreeReference absoluteRef(String path) {
+        TreeReference tr = new TreeReference();
+        tr.setRefLevel(REF_ABSOLUTE);
+        tr.setContext(CONTEXT_ABSOLUTE);
+        tr.setInstanceName(null);
+        Arrays.stream(path.split("/"))
+            .filter(s -> !s.isEmpty())
+            .forEach(s -> tr.add(s, INDEX_UNBOUND));
+        return tr;
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -56,8 +56,7 @@ public class XPathFuncExprRandomizeTest {
         // Take a look to the form file:
         //  - The first pair of fields use randomize without a seed.
         //  - The second pair of fields use randomize with a seed.
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(r("randomize.xml").toString());
+        FormParseInit fpi = new FormParseInit(r("randomize.xml"));
         formDef = fpi.getFormDef();
     }
 


### PR DESCRIPTION
Closes #273 

#### What has been done to verify that this works as intended?
Wrote comprehensive unit tests, covering both positive cases and border cases:
- One for the low-level `RandomizeHelper`, which ultimately holds all the implementation to support everything around randomize()
- One for `XPathNodeset.shuffle()`, which ensures that everything works at the `XPathNodeset` level
- One outside-in test with a real form file that uses randomize for shuffling the choices on a select field.

#### Why is this the best possible solution? Were any other approaches considered?
This PR implements a generic randomize() implementation and an override to specifically using it with itemset nodeset definitions.

We need to consider a fully-generic support for randomize() which involves changing the way nodeset definitions work. We're already discussing this on this PR's comments and we're exploring options.

#### Are there any risks to merging this code? If so, what are they?
None.

-------
(Previous conversation about this PR)

I'd like to get this out to receive some feedback from more experienced contributors. Am I going in the right direction with this?

So far:
- I've written a new `XPathNodeset.shuffle(nodeset, seed?)` method and tested based on @lognaturel's https://github.com/lognaturel/javarosa/commit/daf9dfa6211eff6dba26e9c72d91dda4289b3e2f
- I've written a new xform `randomize(nodeset, seed)` function and a test with a form that uses it.
- I haven't changed yet anything related to the `ItemsetBinding` class

Especially, I'd like to validate that the form file I'm using on my `XPathFuncExprRandomizeTest` is correct and represents the new behavior we're trying to implement.

I'd also like to comment on the strategy I've been trying to follow (without success yet). Honestly, I am kind of reverse engineering the code and I still don't understand much of JR's code.

The error I get with my test is:
```
org.javarosa.xpath.XPathTypeMismatchException: XPath evaluation: type mismatch 
Expected XPath path, got XPath expression: [randomize(instance('counties')/root/item[state=/data/state])],null

	at org.javarosa.model.xform.XPathReference.getPathExpr(XPathReference.java:72)
	at org.javarosa.xform.parse.XFormParser.parseItemset(XFormParser.java:1276)
	at org.javarosa.xform.parse.XFormParser.parseControl(XFormParser.java:968)
	at org.javarosa.xform.parse.XFormParser.parseControl(XFormParser.java:882)
	at org.javarosa.xform.parse.XFormParser.access$200(XFormParser.java:118)
	at org.javarosa.xform.parse.XFormParser$1$5.handle(XFormParser.java:229)
	at org.javarosa.xform.parse.XFormParser.parseElement(XFormParser.java:513)
	at org.javarosa.xform.parse.XFormParser.parseElement(XFormParser.java:522)
	at org.javarosa.xform.parse.XFormParser.parseElement(XFormParser.java:522)
	at org.javarosa.xform.parse.XFormParser.parseDoc(XFormParser.java:429)
	at org.javarosa.xform.parse.XFormParser.parse(XFormParser.java:343)
	at org.javarosa.xform.util.XFormUtils.getFormFromInputStream(XFormUtils.java:81)
	at org.javarosa.core.test.FormParseInit.init(FormParseInit.java:74)
	at org.javarosa.core.test.FormParseInit.setFormToParse(FormParseInit.java:60)
	at org.javarosa.xpath.expr.XPathFuncExprRandomizeTest.name(XPathFuncExprRandomizeTest.java:19)
```
This is just like we would expect because in `XFormParser.parseItemset(XFormParser.java:1276)` we expect an `XPathPathExpr` and there's an `XPathFuncExpr` `randomize(instance('counties')/root/item[state=/data/state])` instead.

To work around this, we could change `getPathExpr(String nodeset)` to return an `XPathExpression` (`XPathPathExpr`'s and `XPathFuncExpr`'s super) like so:
```java
public static XPathExpression getPathExpr(String nodeset) {
    try {
        XPathExpression path = XPathParseTool.parseXPath(nodeset);
        if ((path instanceof XPathPathExpr) || (path instanceof XPathFuncExpr))
            return path;
        else
            throw new XPathTypeMismatchException("Expected an XPath path or an XPath function, got XPath expression: [" + nodeset + "]");
    } catch (XPathSyntaxException xse) {
        logger.error("Error", xse);
        throw new XPathException("Parse error in XPath path: [" + nodeset + "]." + (xse.getMessage() == null ? "" : "\n" + xse.getMessage()));
    }
}
```
(then, `XPathReference.ref` can be null)

At this point, I can make all the tests pass expect the new one focused on testing `randomize()`, which now errors:
```
java.lang.ClassCastException: org.javarosa.xpath.expr.XPathFuncExpr cannot be cast to org.javarosa.xpath.expr.XPathPathExpr

	at org.javarosa.core.model.ItemsetBinding.initReferences(ItemsetBinding.java:107)
	at org.javarosa.core.model.FormDef.updateItemsetReferences(FormDef.java:1469)
	at org.javarosa.xform.parse.FormInstanceParser.parseInstance(FormInstanceParser.java:81)
	at org.javarosa.xform.parse.XFormParser.parseDoc(XFormParser.java:463)
	at org.javarosa.xform.parse.XFormParser.parse(XFormParser.java:344)
	at org.javarosa.xform.util.XFormUtils.getFormFromInputStream(XFormUtils.java:81)
	at org.javarosa.core.test.FormParseInit.init(FormParseInit.java:74)
	at org.javarosa.core.test.FormParseInit.setFormToParse(FormParseInit.java:60)
	at org.javarosa.xpath.expr.XPathFuncExprRandomizeTest.name(XPathFuncExprRandomizeTest.java:19)
```
(finally got to `ItemsetBinding`)

If I understood correctly, we want an itemset to support values that can be actual nodesets or functions that return nodesets. This implies that the `ItemsetBinding.nodesetRef` won't always exist.

Adjusting this class to the fact that `((XPathConditional) this.nodesetExpr).getExpr()` will return an `XPathExpression` (which can be a path or a function) I can conditionally assign a null in `nodesetRef` to get going.

That gets my test to a new error:
```
java.lang.NullPointerException
	at org.javarosa.xform.parse.FormInstanceParser.getRepeatableRefs(FormInstanceParser.java:579)
	at org.javarosa.xform.parse.FormInstanceParser.flagRepeatables(FormInstanceParser.java:115)
	at org.javarosa.xform.parse.FormInstanceParser.processRepeats(FormInstanceParser.java:107)
	at org.javarosa.xform.parse.FormInstanceParser.parseInstance(FormInstanceParser.java:82)
	at org.javarosa.xform.parse.XFormParser.parseDoc(XFormParser.java:463)
	at org.javarosa.xform.parse.XFormParser.parse(XFormParser.java:344)
	at org.javarosa.xform.util.XFormUtils.getFormFromInputStream(XFormUtils.java:81)
	at org.javarosa.core.test.FormParseInit.init(FormParseInit.java:74)
	at org.javarosa.core.test.FormParseInit.setFormToParse(FormParseInit.java:60)
	at org.javarosa.xpath.expr.XPathFuncExprRandomizeTest.name(XPathFuncExprRandomizeTest.java:19)
```

That's normal because now the `nodesetRef` is null.

Here's the deal:
I wanted to explore the idea of lazy evaluating the refs of an itemset using its `nodesetExpr` but that requires to get the `EvaluationContext`. Does this make sense?

I've pushed a WIP branch with the changes I mention here: https://github.com/ggalmazor/javarosa/commit/c11b7ca8c42e016c5f997b051e189f6815f9b1d9





