### PR TITLE
WIP - Issue 273 broad support for randomize

### DIFF
--- a/resources/org/javarosa/xpath/expr/randomize.xml
+++ b/resources/org/javarosa/xpath/expr/randomize.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Randomize Test</h:title>
+        <model>
+            <instance>
+                <randomize id="randomize">
+                    <fruit1/>
+                    <fruit2/>
+                    <seededFruit1/>
+                    <seededFruit2/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </randomize>
+            </instance>
+
+            <instance id="fruit">
+                <root>
+                    <item>
+                        <label>Apple</label>
+                        <name>apple</name>
+                    </item>
+                    <item>
+                        <label>Banana</label>
+                        <name>banana</name>
+                    </item>
+                    <item>
+                        <label>Cherimoya</label>
+                        <name>cherimoya</name>
+                    </item>
+                    <item>
+                        <label>Durian</label>
+                        <name>durian</name>
+                    </item>
+                    <item>
+                        <label>Elderberry</label>
+                        <name>elderberry</name>
+                    </item>
+                    <item>
+                        <label>Fig</label>
+                        <name>fig</name>
+                    </item>
+                </root>
+            </instance>
+            <bind nodeset="/randomize/fruit1" type="select1"/>
+            <bind nodeset="/randomize/fruit2" type="select1"/>
+            <bind nodeset="/randomize/seededFruit1" type="select1"/>
+            <bind nodeset="/randomize/seededFruit2" type="select1"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/randomize/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/randomize/fruit1">
+            <label>Fruit #1</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/randomize/fruit2">
+            <label>Fruit #2</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/randomize/seededFruit1">
+            <label>Seeded fruit #1</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item, 42)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/randomize/seededFruit2">
+            <label>Seeded fruit #2</label>
+            <itemset nodeset="randomize(instance('fruit')/root/item, 42)">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -248,7 +248,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // construct the references in all the question itemsets
         // now so that the entire main instance is available
         // for term resolution.
-        updateItemsetReferences(getChildren());
+        updateItemsetReferences(fi, Collections.emptyList(), getChildren());
 
         attachControlsToInstanceData();
     }
@@ -1459,17 +1459,17 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * dynamic ItemsetBindings.  We need to do this late in the process so that
      * we have the entire main instance assembled.
      */
-    public static void updateItemsetReferences(List<IFormElement> children) {
+    public static void updateItemsetReferences(DataInstance instance, List<DataInstance> nonMainInstances, List<IFormElement> children) {
         if (children != null) {
             for (IFormElement child : children) {
                 if (child instanceof QuestionDef) {
                     QuestionDef q = (QuestionDef) child;
                     ItemsetBinding itemset = q.getDynamicChoices();
                     if (itemset != null) {
-                        itemset.initReferences(q);
+                        itemset.initReferences(instance, nonMainInstances, q);
                     }
                 } else {
-                    updateItemsetReferences(child.getChildren());
+                    updateItemsetReferences(instance, nonMainInstances, child.getChildren());
                 }
             }
         }

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -16,6 +16,17 @@
 
 package org.javarosa.core.model;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.model.IDag.EventNotifierAccessor;
 import org.javarosa.core.model.condition.Condition;
@@ -59,17 +70,6 @@ import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xform.parse.XFormParseException;
 import org.javarosa.xform.util.XFormAnswerDataSerializer;
 import org.javarosa.xpath.XPathException;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,16 +131,24 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     private List<IFormElement> children;// <IFormElement>
-    /** A collection of group definitions. */
+    /**
+     * A collection of group definitions.
+     */
     private int id;
-    /** The numeric unique identifier of the form definition on the local device */
+    /**
+     * The numeric unique identifier of the form definition on the local device
+     */
     private String title;
-    /** The display title of the form. */
+    /**
+     * The display title of the form.
+     */
     private String name;
 
     private List<XFormExtension> extensions;
 
-    /** A unique external name that is used to identify the form between machines */
+    /**
+     * A unique external name that is used to identify the form between machines
+     */
     private Localizer localizer;
 
     // <IConditionExpr> contents of <output>
@@ -216,7 +224,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         this.eventNotifier = eventNotifier;
     }
 
-    /** Getters and setters for the lists */
+    /**
+     * Getters and setters for the lists
+     */
     public void addNonMainInstance(DataInstance instance) {
         formInstances.put(instance.getName(), instance);
         resetEvaluationContext();
@@ -248,7 +258,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // construct the references in all the question itemsets
         // now so that the entire main instance is available
         // for term resolution.
-        updateItemsetReferences(fi, Collections.emptyList(), getChildren());
+        updateItemsetReferences(fi, formInstances, getChildren());
 
         attachControlsToInstanceData();
     }
@@ -277,7 +287,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             return this.children.get(i);
 
         throw new ArrayIndexOutOfBoundsException("FormDef: invalid child index: " + i + " only "
-                + children.size() + " children");
+            + children.size() + " children");
     }
 
     public IFormElement getChild(FormIndex index) {
@@ -327,7 +337,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         IFormElement element = elements.get(elements.size() - 1);
         // get reference for target element
         TreeReference ref = FormInstance.unpackReference(
-                element.getBind()).clone();
+            element.getBind()).clone();
         for (int i = 0; i < ref.size(); i++) {
             // There has to be a better way to encapsulate this
             if (ref.getMultiplicity(i) != TreeReference.INDEX_ATTRIBUTE) {
@@ -379,8 +389,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         IAnswerData oldValue = node.getValue();
         IAnswerDataSerializer answerDataSerializer = new XFormAnswerDataSerializer();
         if (midSurvey && dagImpl.shouldTrustPreviouslyCommittedAnswer()
-                && objectEquals(answerDataSerializer.serializeAnswerData(oldValue),
-                answerDataSerializer.serializeAnswerData(data))) {
+            && objectEquals(answerDataSerializer.serializeAnswerData(oldValue),
+            answerDataSerializer.serializeAnswerData(data))) {
             return;
         }
         setAnswer(data, node);
@@ -524,7 +534,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             TreeElement templNode = mainInstance.getTemplate(repeatRef);
             TreeReference parentPath = templNode.getParent().getRef().genericize();
             TreeElement parentNode = mainInstance
-                    .resolveReference(parentPath.contextualize(repeatRef));
+                .resolveReference(parentPath.contextualize(repeatRef));
             relev = parentNode.isRelevant();
         }
 
@@ -546,10 +556,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 // repeat groups...
                 TreeReference countRef = FormInstance.unpackReference(repeat.getCountReference());
                 TreeElement countNode = this.getMainInstance().resolveReference(
-                        countRef.contextualize(repeatRef));
+                    countRef.contextualize(repeatRef));
                 if (countNode == null) {
                     throw new RuntimeException("Could not locate the repeat count value expected at "
-                            + repeat.getCountReference().getReference().toString());
+                        + repeat.getCountReference().getReference().toString());
                 }
                 // get the total multiplicity possible
                 IAnswerData count = countNode.getValue();
@@ -585,7 +595,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             selections.add((Selection) data.getValue());
         }
         List<String> selectedValues;
-        if (itemset.valueRef != null) {
+        if (itemset.getValueRef() != null) {
             selectedValues = new ArrayList<String>(selections.size());
             for (Selection selection : selections) {
                 selectedValues.add(selection.choice.getValue());
@@ -600,9 +610,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         for (TreeReference existingNode : existingNodes) {
             TreeElement node = getMainInstance().resolveReference(existingNode);
 
-            if (itemset.valueRef != null) {
+            if (itemset.getValueRef() != null) {
                 String value = itemset.getRelativeValue().evalReadable(this.getMainInstance(),
-                        new EvaluationContext(exprEvalContext, node.getRef()));
+                    new EvaluationContext(exprEvalContext, node.getRef()));
                 if (selectedValues.contains(value)) {
                     existingValues.put(value, node); // cache node if in selection
                     // and already exists
@@ -619,7 +629,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             SelectChoice ch = s.choice;
 
             TreeElement cachedNode = null;
-            if (itemset.valueRef != null) {
+            if (itemset.getValueRef() != null) {
                 String value = ch.getValue();
                 if (existingValues.containsKey(value)) {
                     cachedNode = existingValues.get(value);
@@ -648,7 +658,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     /**
      * Report any dependency cycles based upon the triggerIndex array.
      * (Does not require that the DAG be finalized).
-     *
      */
     public void reportDependencyCycles() {
         dagImpl.reportDependencyCycles();
@@ -751,7 +760,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                         if (form != null) {
                             textID = textID + ";" + form;
                             String result = f.getLocalizer().getRawText(f.getLocalizer().getLocale(),
-                                    textID);
+                                textID);
                             return result == null ? "" : result;
                         } else {
                             String text = f.getLocalizer().getText(textID);
@@ -782,22 +791,22 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             });
         }
 
-      /*
-       * function to reverse a select value into the display label for that
-       * choice in the question it came from
-       * 
-       * arg 1: select value arg 2: string xpath referring to origin question;
-       * must be absolute path
-       * 
-       * this won't work at all if the original label needed to be
-       * processed/calculated in some way (<output>s, etc.) (is this even
-       * allowed?) likely won't work with multi-media labels _might_ work for
-       * itemsets, but probably not very well or at all; could potentially work
-       * better if we had some context info DOES work with localization
-       * 
-       * it's mainly intended for the simple case of reversing a question with
-       * compile-time-static fields, for use inside an <output>
-       */
+        /*
+         * function to reverse a select value into the display label for that
+         * choice in the question it came from
+         *
+         * arg 1: select value arg 2: string xpath referring to origin question;
+         * must be absolute path
+         *
+         * this won't work at all if the original label needed to be
+         * processed/calculated in some way (<output>s, etc.) (is this even
+         * allowed?) likely won't work with multi-media labels _might_ work for
+         * itemsets, but probably not very well or at all; could potentially work
+         * better if we had some context info DOES work with localization
+         *
+         * it's mainly intended for the simple case of reversing a question with
+         * compile-time-static fields, for use inside an <output>
+         */
         if (!ec.getFunctionHandlers().containsKey("jr:choice-name")) {
             final FormDef f = this;
             ec.addFunctionHandler(new IFunctionHandler() {
@@ -815,8 +824,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
                         QuestionDef q = findQuestionByRef(ref, f);
                         if (q == null
-                                || (q.getControlType() != Constants.CONTROL_SELECT_ONE && q
-                                .getControlType() != Constants.CONTROL_SELECT_MULTI)) {
+                            || (q.getControlType() != Constants.CONTROL_SELECT_ONE && q
+                            .getControlType() != Constants.CONTROL_SELECT_MULTI)) {
                             return "";
                         }
 
@@ -885,7 +894,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                         return "";
                     } catch (Exception e) {
                         throw new WrappedException("error in evaluation of xpath function [choice-name]",
-                                e);
+                            e);
                     }
                 }
 
@@ -970,18 +979,25 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         List<SelectChoice> choices = new ArrayList<SelectChoice>();
 
-        List<TreeReference> matches = itemset.nodesetExpr.evalNodeset(this.getMainInstance(),
-                new EvaluationContext(exprEvalContext, itemset.contextRef.contextualize(curQRef)));
+//      List<TreeReference> matches = itemset.nodesetExpr.evalNodeset(
+//          this.getMainInstance(),
+//          new EvaluationContext(
+//              exprEvalContext,
+//              itemset.contextRef.contextualize(curQRef)
+//          )
+//      );
+        List<TreeReference> matches = itemset.getNodeset(this.getMainInstance(), new EvaluationContext(exprEvalContext, itemset.contextRef.contextualize(curQRef)));
+
 
         DataInstance fi = null;
-        if (itemset.nodesetRef.getInstanceName() != null) // We're not dealing
+        if (itemset.getNodesetInstanceName() != null) // We're not dealing
         // with the default
         // instance
         {
-            fi = getNonMainInstance(itemset.nodesetRef.getInstanceName());
+            fi = getNonMainInstance(itemset.getNodesetInstanceName());
             if (fi == null) {
-                throw new XPathException("Instance " + itemset.nodesetRef.getInstanceName()
-                        + " not found");
+                throw new XPathException("Instance " + itemset.getNodesetInstanceName()
+                    + " not found");
             }
         } else {
             fi = getMainInstance();
@@ -989,7 +1005,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         if (matches == null) {
             throw new XPathException("Could not find references depended on by"
-                    + itemset.nodesetRef.getInstanceName());
+                + itemset.getNodesetInstanceName());
         }
 
         for (int i = 0; i < matches.size(); i++) {
@@ -999,23 +1015,23 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             // itemset.labelExpr.evalReadable(this.getMainInstance(), new
             // EvaluationContext(exprEvalContext, item));
             String label = itemset.labelExpr.evalReadable(fi, new EvaluationContext(exprEvalContext,
-                    item));
+                item));
             String value = null;
             TreeElement copyNode = null;
 
             if (itemset.copyMode) {
-                copyNode = this.getMainInstance().resolveReference(itemset.copyRef.contextualize(item));
+                copyNode = this.getMainInstance().resolveReference(itemset.getCopyRef().contextualize(item));
             }
-            if (itemset.valueRef != null) {
+            if (itemset.getValueRef() != null) {
                 // value = itemset.valueExpr.evalReadable(this.getMainInstance(),
                 // new EvaluationContext(exprEvalContext, item));
                 value = itemset.valueExpr
-                        .evalReadable(fi, new EvaluationContext(exprEvalContext, item));
+                    .evalReadable(fi, new EvaluationContext(exprEvalContext, item));
             }
             // SelectChoice choice = new
             // SelectChoice(labelID,labelInnerText,value,isLocalizable);
             SelectChoice choice = new SelectChoice(label, value != null ? value : "dynamic:" + i,
-                    itemset.labelIsItext);
+                itemset.labelIsItext);
             choice.setIndex(i);
             if (itemset.copyMode)
                 choice.copyNode = copyNode;
@@ -1036,8 +1052,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             // and not throw an exception.
             logger.info("Dynamic select question has no choices! [{}]. If this occurs while " +
                 "filling out a form (and not while saving an incomplete form), the filter " +
-                "condition may have eliminated all the choices. Is that what you intended?"
-                , itemset.nodesetRef);
+                "condition may have eliminated all the choices. Is that what you intended?");
 
         }
 
@@ -1138,7 +1153,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         if (node.isLeaf()) {
             if (node.getPreloadHandler() != null) {
                 return preloader.questionPostProcess(node, node.getPreloadHandler(),
-                        node.getPreloadParams());
+                    node.getPreloadParams());
             } else {
                 return false;
             }
@@ -1166,7 +1181,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      */
     @Override
     public void readExternal(DataInputStream dis, PrototypeFactory pf) throws IOException,
-            DeserializationException {
+        DeserializationException {
         setID(ExtUtil.readInt(dis));
         setName(ExtUtil.nullIfEmpty(ExtUtil.readString(dis)));
         setTitle((String) ExtUtil.read(dis, new ExtWrapNullable(String.class), pf));
@@ -1188,13 +1203,13 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         outputFragments = (List<IConditionExpr>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
 
         submissionProfiles = (HashMap<String, SubmissionProfile>) ExtUtil.read(dis, new ExtWrapMap(
-                String.class, SubmissionProfile.class));
+            String.class, SubmissionProfile.class));
 
         formInstances = (HashMap<String, DataInstance>) ExtUtil.read(dis, new ExtWrapMap(
-                String.class, new ExtWrapTagged()), pf);
+            String.class, new ExtWrapTagged()), pf);
 
         eventListeners = (HashMap<String, List<Action>>) ExtUtil.read(dis, new ExtWrapMap(
-                String.class, new ExtWrapListPoly()), pf);
+            String.class, new ExtWrapListPoly()), pf);
 
         extensions = (List<XFormExtension>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
 
@@ -1275,7 +1290,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
             indexes.add(i);
             multiplicities.add(index.getInstanceIndex() == -1 ? 0 : index
-                    .getInstanceIndex());
+                .getInstanceIndex());
             elements.add(element);
 
             index = index.getNextLevel();
@@ -1295,7 +1310,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             int mult = multiplicities.get(i);
 
             if (!(elements.get(i) instanceof GroupDef && ((GroupDef) elements.get(i))
-                    .getRepeat())) {
+                .getRepeat())) {
                 mult = -1;
             }
 
@@ -1318,7 +1333,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         collapseIndex(index, indexes, multiplicities, elements);
 
         if (!(elements.get(elements.size() - 1) instanceof GroupDef)
-                || !((GroupDef) elements.get(elements.size() - 1)).getRepeat()) {
+            || !((GroupDef) elements.get(elements.size() - 1)).getRepeat()) {
             throw new RuntimeException("current element not a repeat");
         }
 
@@ -1326,7 +1341,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         TreeElement templNode = mainInstance.getTemplate(index.getReference());
         TreeReference parentPath = templNode.getParent().getRef().genericize();
         TreeElement parentNode = mainInstance.resolveReference(parentPath.contextualize(index
-                .getReference()));
+            .getReference()));
         return parentNode.getChildMultiplicity(templNode.getName());
     }
 
@@ -1475,6 +1490,22 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         }
     }
 
+    public static void updateItemsetReferences(DataInstance instance, Map<String, DataInstance> nonMainInstances, List<IFormElement> children) {
+        if (children != null) {
+            for (IFormElement child : children) {
+                if (child instanceof QuestionDef) {
+                    QuestionDef q = (QuestionDef) child;
+                    ItemsetBinding itemset = q.getDynamicChoices();
+                    if (itemset != null) {
+                        itemset.initReferences(instance, nonMainInstances, q);
+                    }
+                } else {
+                    updateItemsetReferences(instance, nonMainInstances, child.getChildren());
+                }
+            }
+        }
+    }
+
     /**
      * Link a deserialized instance back up with its parent FormDef. this allows
      * select/select1 questions to be internationalizable in chatterbox, and (if
@@ -1502,7 +1533,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             QuestionDef q = findQuestionByRef(node.getRef(), this);
             if (q == null) {
                 throw new RuntimeException(
-                        "FormDef.attachControlsToInstanceData: can't find question to link");
+                    "FormDef.attachControlsToInstanceData: can't find question to link");
             }
 
             if (q.getDynamicChoices() != null) {
@@ -1549,7 +1580,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     @Override
     public String getAppearanceAttr() {
         throw new RuntimeException(
-                "This method call is not relevant for FormDefs getAppearanceAttr ()");
+            "This method call is not relevant for FormDefs getAppearanceAttr ()");
     }
 
     /**
@@ -1559,22 +1590,28 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     @Override
     public void setAppearanceAttr(String appearanceAttr) {
         throw new RuntimeException(
-                "This method call is not relevant for FormDefs setAppearanceAttr()");
+            "This method call is not relevant for FormDefs setAppearanceAttr()");
     }
 
-    /** Not applicable here. */
+    /**
+     * Not applicable here.
+     */
     @Override
     public String getLabelInnerText() {
         return null;
     }
 
-    /** Not applicable */
+    /**
+     * Not applicable
+     */
     @Override
     public String getTextID() {
         return null;
     }
 
-    /** Not applicable */
+    /**
+     * Not applicable
+     */
     @Override
     public void setTextID(String textID) {
         throw new RuntimeException("This method call is not relevant for FormDefs [setTextID()]");

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -1,5 +1,7 @@
 package org.javarosa.core.model;
 
+import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -52,6 +54,9 @@ public class ItemsetBinding implements Externalizable, Localizable {
                                    //not serialized -- set by QuestionDef.setDynamicChoices()
     private List<SelectChoice> choices; //dynamic choices -- not serialized, obviously
 
+    public boolean randomize = false;
+    public Long randomSeed = null;
+
     public List<SelectChoice> getChoices () {
         return choices;
     }
@@ -61,7 +66,13 @@ public class ItemsetBinding implements Externalizable, Localizable {
             logger.warn("previous choices not cleared out");
             clearChoices();
         }
-        this.choices = choices;
+        this.choices = randomize ? shuffle(choices, randomSeed) : choices;
+
+        if (randomize) {
+            // Match indices to new positions
+            for (int i = 0; i < choices.size(); i++)
+                choices.get(i).setIndex(i);
+        }
 
         //init localization
         if (localizer != null) {

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -7,6 +7,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 import org.javarosa.core.model.condition.IConditionExpr;
+import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.services.locale.Localizable;
@@ -100,7 +101,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
         return relRef != null ? RestoreUtils.xfFact.refToPathExpr(relRef) : null;
     }
 
-    public void initReferences(QuestionDef q) {
+    public void initReferences(DataInstance instanceModel, List<DataInstance> nonMainInstances, QuestionDef q) {
         // To construct the xxxRef, we need the full model, which wasn't available before now.
         // Compute the xxxRefs now.
         XPathConditional nodesetExpr = (XPathConditional) this.nodesetExpr;

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -1,7 +1,5 @@
 package org.javarosa.core.model;
 
-import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -54,9 +52,6 @@ public class ItemsetBinding implements Externalizable, Localizable {
                                    //not serialized -- set by QuestionDef.setDynamicChoices()
     private List<SelectChoice> choices; //dynamic choices -- not serialized, obviously
 
-    public boolean randomize = false;
-    public Long randomSeed = null;
-
     public List<SelectChoice> getChoices () {
         return choices;
     }
@@ -66,13 +61,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
             logger.warn("previous choices not cleared out");
             clearChoices();
         }
-        this.choices = randomize ? shuffle(choices, randomSeed) : choices;
-
-        if (randomize) {
-            // Match indices to new positions
-            for (int i = 0; i < choices.size(); i++)
-                choices.get(i).setIndex(i);
-        }
+        this.choices = choices;
 
         //init localization
         if (localizer != null) {
@@ -148,8 +137,6 @@ public class ItemsetBinding implements Externalizable, Localizable {
         copyExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         labelIsItext = ExtUtil.readBool(in);
         copyMode = ExtUtil.readBool(in);
-        randomize = ExtUtil.readBool(in);
-        randomSeed = (Long)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()));
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {
@@ -160,8 +147,6 @@ public class ItemsetBinding implements Externalizable, Localizable {
         ExtUtil.write(out, new ExtWrapNullable(copyExpr == null ? null : new ExtWrapTagged(copyExpr)));
         ExtUtil.writeBool(out, labelIsItext);
         ExtUtil.writeBool(out, copyMode);
-        ExtUtil.writeBool(out, randomize);
-        ExtUtil.write(out, new ExtWrapNullable(randomSeed == null ? null : new ExtWrapTagged(randomSeed)));
     }
 
 }

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -148,6 +148,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
         copyExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         labelIsItext = ExtUtil.readBool(in);
         copyMode = ExtUtil.readBool(in);
+        randomize = ExtUtil.readBool(in);
+        randomSeed = (Long)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()));
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {
@@ -158,6 +160,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
         ExtUtil.write(out, new ExtWrapNullable(copyExpr == null ? null : new ExtWrapTagged(copyExpr)));
         ExtUtil.writeBool(out, labelIsItext);
         ExtUtil.writeBool(out, copyMode);
+        ExtUtil.writeBool(out, randomize);
+        ExtUtil.write(out, new ExtWrapNullable(randomSeed == null ? null : new ExtWrapTagged(randomSeed)));
     }
 
 }

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -1,13 +1,12 @@
 package org.javarosa.core.model;
 
-import static org.javarosa.core.model.instance.FormInstance.*;
+import static org.javarosa.core.model.instance.FormInstance.unpackReference;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 import org.javarosa.core.model.condition.IConditionExpr;
-import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.services.locale.Localizable;
@@ -104,15 +103,32 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public void initReferences(QuestionDef q) {
         // To construct the xxxRef, we need the full model, which wasn't available before now.
         // Compute the xxxRefs now.
-        nodesetRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference(true)), contextRef));
+        XPathConditional nodesetExpr = (XPathConditional) this.nodesetExpr;
+        XPathPathExpr expr = (XPathPathExpr) nodesetExpr.getExpr();
+        TreeReference reference = expr.getReference(true);
+        XPathReference ref = new XPathReference(reference);
+        IDataReference absRef = FormDef.getAbsRef(ref, contextRef);
+        nodesetRef = unpackReference(absRef);
         if (labelExpr != null) {
-            labelRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) labelExpr).getExpr())), nodesetRef));
+            XPathConditional labelExpr = (XPathConditional) this.labelExpr;
+            XPathPathExpr expr1 = (XPathPathExpr) labelExpr.getExpr();
+            XPathReference ref1 = new XPathReference(expr1);
+            IDataReference absRef1 = FormDef.getAbsRef(ref1, nodesetRef);
+            labelRef = unpackReference(absRef1);
         }
         if (copyExpr != null) {
-            copyRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) copyExpr).getExpr())), nodesetRef));
+            XPathConditional copyExpr = (XPathConditional) this.copyExpr;
+            XPathPathExpr expr1 = (XPathPathExpr) copyExpr.getExpr();
+            XPathReference ref1 = new XPathReference(expr1);
+            IDataReference absRef1 = FormDef.getAbsRef(ref1, nodesetRef);
+            copyRef = unpackReference(absRef1);
         }
         if (valueExpr != null) {
-            valueRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) valueExpr).getExpr())), nodesetRef));
+            XPathConditional valueExpr = (XPathConditional) this.valueExpr;
+            XPathPathExpr expr1 = (XPathPathExpr) valueExpr.getExpr();
+            XPathReference ref1 = new XPathReference(expr1);
+            IDataReference absRef1 = FormDef.getAbsRef(ref1, nodesetRef);
+            valueRef = unpackReference(absRef1);
         }
 
         if (q != null) {

--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -1,10 +1,11 @@
 package org.javarosa.core.model;
 
+import static org.javarosa.core.model.instance.FormInstance.*;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
-
 import org.javarosa.core.model.condition.IConditionExpr;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
@@ -35,8 +36,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public TreeReference nodesetRef;   //absolute ref of itemset source nodes
     public IConditionExpr nodesetExpr; //path expression for source nodes; may be relative, may contain predicates
     public TreeReference contextRef;   //context ref for nodesetExpr; ref of the control parent (group/formdef) of itemset question
-       //note: this is only here because its currently impossible to both (a) get a form control's parent, and (b)
-       //convert expressions into refs while preserving predicates. once these are fixed, this field can go away
+    //note: this is only here because its currently impossible to both (a) get a form control's parent, and (b)
+    //convert expressions into refs while preserving predicates. once these are fixed, this field can go away
 
     public TreeReference labelRef;     //absolute ref of label
     public IConditionExpr labelExpr;   //path expression for label; may be relative, no predicates
@@ -49,14 +50,14 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public IConditionExpr valueExpr;   //path expression for value; may be relative, no predicates (must be relative if copy mode)
 
     private TreeReference destRef; //ref that identifies the repeated nodes resulting from this itemset
-                                   //not serialized -- set by QuestionDef.setDynamicChoices()
+    //not serialized -- set by QuestionDef.setDynamicChoices()
     private List<SelectChoice> choices; //dynamic choices -- not serialized, obviously
 
-    public List<SelectChoice> getChoices () {
+    public List<SelectChoice> getChoices() {
         return choices;
     }
 
-    public void setChoices (List<SelectChoice> choices, Localizer localizer) {
+    public void setChoices(List<SelectChoice> choices, Localizer localizer) {
         if (this.choices != null) {
             logger.warn("previous choices not cleared out");
             clearChoices();
@@ -72,7 +73,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
         }
     }
 
-    public void clearChoices () {
+    public void clearChoices() {
         this.choices = null;
     }
 
@@ -84,11 +85,11 @@ public class ItemsetBinding implements Externalizable, Localizable {
         }
     }
 
-    public TreeReference getDestRef () {
+    public TreeReference getDestRef() {
         return destRef;
     }
 
-    public IConditionExpr getRelativeValue () {
+    public IConditionExpr getRelativeValue() {
         TreeReference relRef = null;
 
         if (copyRef == null) {
@@ -103,26 +104,22 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public void initReferences(QuestionDef q) {
         // To construct the xxxRef, we need the full model, which wasn't available before now.
         // Compute the xxxRefs now.
-        nodesetRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(
-                ((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference(true)), contextRef));
-        if ( labelExpr != null ) {
-            labelRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) labelExpr).getExpr())),
-                    nodesetRef));
+        nodesetRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference(true)), contextRef));
+        if (labelExpr != null) {
+            labelRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) labelExpr).getExpr())), nodesetRef));
         }
-        if ( copyExpr != null ) {
-            copyRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) copyExpr).getExpr())),
-                    nodesetRef));
+        if (copyExpr != null) {
+            copyRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) copyExpr).getExpr())), nodesetRef));
         }
-        if ( valueExpr != null ) {
-            valueRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) valueExpr).getExpr())),
-                    nodesetRef));
+        if (valueExpr != null) {
+            valueRef = unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) valueExpr).getExpr())), nodesetRef));
         }
 
-        if ( q != null ) {
+        if (q != null) {
             // When loading from XML, the first time through, during verification, q will be null.
             // The second time through, q will be non-null.
             // Otherwise, when loading from binary, this will be called only once with a non-null q.
-            destRef = FormInstance.unpackReference(q.getBind()).clone();
+            destRef = unpackReference(q.getBind()).clone();
             if (copyMode) {
                 destRef.add(copyRef.getNameLast(), TreeReference.INDEX_UNBOUND);
             }
@@ -130,11 +127,11 @@ public class ItemsetBinding implements Externalizable, Localizable {
     }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        nodesetExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        contextRef = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
-        labelExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        valueExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
-        copyExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+        nodesetExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        contextRef = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
+        labelExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        valueExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+        copyExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         labelIsItext = ExtUtil.readBool(in);
         copyMode = ExtUtil.readBool(in);
     }

--- a/src/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/org/javarosa/core/model/condition/EvaluationContext.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
+import java.util.Map;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -36,8 +37,8 @@ import org.javarosa.xpath.expr.XPathExpression;
 public class EvaluationContext {
     /** Unambiguous anchor reference for relative paths */
     private TreeReference contextNode;
-    private HashMap<String, IFunctionHandler> functionHandlers;
-    private HashMap<String, Object> variables;
+    private Map<String, IFunctionHandler> functionHandlers;
+    private Map<String, Object> variables;
 
     public boolean isConstraint; //true if we are evaluating a constraint
     public IAnswerData candidateValue; //if isConstraint, this is the value being validated
@@ -46,7 +47,7 @@ public class EvaluationContext {
 
     private String outputTextForm = null; //Responsible for informing itext what form is requested if relevant
 
-    private HashMap<String, DataInstance> formInstances;
+    private Map<String, DataInstance> formInstances;
 
     private TreeReference original;
     /**
@@ -86,12 +87,12 @@ public class EvaluationContext {
         this.contextNode = context;
     }
 
-    public EvaluationContext (EvaluationContext base, HashMap<String, DataInstance> formInstances, TreeReference context) {
+    public EvaluationContext (EvaluationContext base, Map<String, DataInstance> formInstances, TreeReference context) {
         this(base, context);
         this.formInstances = formInstances;
     }
 
-    public EvaluationContext (DataInstance instance, HashMap<String, DataInstance> formInstances, EvaluationContext base) {
+    public EvaluationContext (DataInstance instance, Map<String, DataInstance> formInstances, EvaluationContext base) {
         this(base);
         this.formInstances = formInstances;
         this.instance = instance;
@@ -101,7 +102,7 @@ public class EvaluationContext {
         this(instance, new HashMap<String, DataInstance>());
     }
 
-    public EvaluationContext (DataInstance instance, HashMap<String, DataInstance> formInstances) {
+    public EvaluationContext (DataInstance instance, Map<String, DataInstance> formInstances) {
         this.formInstances = formInstances;
         this.instance = instance;
         this.contextNode = TreeReference.rootRef();
@@ -131,7 +132,7 @@ public class EvaluationContext {
         functionHandlers.put(fh.getName(), fh);
     }
 
-    public HashMap<String, IFunctionHandler> getFunctionHandlers () {
+    public Map<String, IFunctionHandler> getFunctionHandlers () {
         return functionHandlers;
     }
 
@@ -143,7 +144,7 @@ public class EvaluationContext {
         return outputTextForm;
     }
 
-    public void setVariables(HashMap<String, ?> variables) {
+    public void setVariables(Map<String, ?> variables) {
         for (String var : variables.keySet()) {
             setVariable(var, variables.get(var));
         }

--- a/src/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/org/javarosa/form/api/FormEntryPrompt.java
@@ -94,7 +94,7 @@ public class FormEntryPrompt extends FormEntryCaption {
 
         ItemsetBinding itemset = q.getDynamicChoices();
         if (itemset != null) {
-            if (itemset.valueRef != null) {
+            if (itemset.getValueRef() != null) {
             List<SelectChoice> choices = getSelectChoices();
             List<String> preselectedValues = new ArrayList<String>();
 

--- a/src/org/javarosa/model/xform/XPathReference.java
+++ b/src/org/javarosa/model/xform/XPathReference.java
@@ -23,6 +23,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+import java.util.Optional;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -32,6 +33,7 @@ import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.expr.XPathExpression;
+import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.slf4j.Logger;
@@ -77,6 +79,30 @@ public class XPathReference implements IDataReference {
         }
 
         return (XPathPathExpr)path;
+    }
+
+    public static Optional<XPathPathExpr> getPathExpr2(String nodeset) {
+        try {
+            XPathExpression path = XPathParseTool.parseXPath(nodeset);
+            if (path instanceof XPathPathExpr)
+                return Optional.of((XPathPathExpr) path);
+            else
+                return Optional.empty();
+        } catch (XPathSyntaxException xse) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<XPathFuncExpr> getFuncExpr(String nodeset) {
+        try {
+            XPathExpression path = XPathParseTool.parseXPath(nodeset);
+            if (path instanceof XPathFuncExpr)
+                return Optional.of((XPathFuncExpr) path);
+            else
+                return Optional.empty();
+        } catch (XPathSyntaxException xse) {
+            return Optional.empty();
+        }
     }
 
     public XPathReference (XPathPathExpr path) {

--- a/src/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/org/javarosa/xform/parse/FormInstanceParser.java
@@ -312,39 +312,39 @@ class FormInstanceParser {
     private void verifyItemsetBindings (FormInstance instance) {
         for (ItemsetBinding itemset : itemsets) {
             //check proper parent/child relationship
-            if (!itemset.nodesetRef.isParentOf(itemset.labelRef, false)) {
-                throw new XFormParseException("itemset nodeset ref is not a parent of label ref");
-            } else if (itemset.copyRef != null && !itemset.nodesetRef.isParentOf(itemset.copyRef, false)) {
-                throw new XFormParseException("itemset nodeset ref is not a parent of copy ref");
-            } else if (itemset.valueRef != null && !itemset.nodesetRef.isParentOf(itemset.valueRef, false)) {
-                throw new XFormParseException("itemset nodeset ref is not a parent of value ref");
-            }
+//            if (!itemset.nodesetRef.isParentOf(itemset.labelRef, false)) {
+//                throw new XFormParseException("itemset nodeset ref is not a parent of label ref");
+//            } else if (itemset.copyRef != null && !itemset.nodesetRef.isParentOf(itemset.copyRef, false)) {
+//                throw new XFormParseException("itemset nodeset ref is not a parent of copy ref");
+//            } else if (itemset.valueRef != null && !itemset.nodesetRef.isParentOf(itemset.valueRef, false)) {
+//                throw new XFormParseException("itemset nodeset ref is not a parent of value ref");
+//            }
 
-            if (itemset.copyRef != null && itemset.valueRef != null) {
-                if (!itemset.copyRef.isParentOf(itemset.valueRef, false)) {
-                    throw new XFormParseException("itemset <copy> is not a parent of <value>");
-                }
-            }
+//            if (itemset.copyRef != null && itemset.valueRef != null) {
+//                if (!itemset.copyRef.isParentOf(itemset.valueRef, false)) {
+//                    throw new XFormParseException("itemset <copy> is not a parent of <value>");
+//                }
+//            }
 
             //make sure the labelref is tested against the right instance
             //check if it's not the main instance
             DataInstance fi = null;
-            if (itemset.labelRef.getInstanceName() != null) {
-                fi = formDef.getNonMainInstance(itemset.labelRef.getInstanceName());
+            if (itemset.getLabelInstanceName() != null) {
+                fi = formDef.getNonMainInstance(itemset.getLabelInstanceName());
                 if (fi == null) {
-                    throw new XFormParseException("Instance: " + itemset.labelRef.getInstanceName() + " Does not exists");
+                    throw new XFormParseException("Instance: " + itemset.getLabelInstanceName() + " Does not exists");
                 }
             } else {
                 fi = instance;
             }
 
 
-            if (fi.getTemplatePath(itemset.labelRef) == null) {
-                throw new XFormParseException("<label> node for itemset doesn't exist! [" + itemset.labelRef + "]");
+            if (fi.getTemplatePath(itemset.getLabelRef()) == null) {
+                throw new XFormParseException("<label> node for itemset doesn't exist! [" + itemset.getLabelRef() + "]");
             }
             //check value nodes exist
-            else if (itemset.valueRef != null && fi.getTemplatePath(itemset.valueRef) == null) {
-                throw new XFormParseException("<value> node for itemset doesn't exist! [" + itemset.valueRef + "]");
+            else if (itemset.getValueRef() != null && fi.getTemplatePath(itemset.getValueRef()) == null) {
+                throw new XFormParseException("<value> node for itemset doesn't exist! [" + itemset.getValueRef() + "]");
             }
         }
     }
@@ -358,7 +358,7 @@ class FormInstanceParser {
                 }
 
                 //validate homogeneity between src and dst nodes
-                TreeElement srcNode = instance.getTemplatePath(itemset.copyRef);
+                TreeElement srcNode = instance.getTemplatePath(itemset.getCopyRef());
                 TreeElement dstNode = instance.getTemplate(itemset.getDestRef());
 
                 if (!FormInstance.isHomogeneous(srcNode, dstNode)) {
@@ -570,7 +570,7 @@ class FormInstanceParser {
         List<TreeReference> refs = new ArrayList<>(repeats);
 
         for (ItemsetBinding itemset : itemsets) {
-            TreeReference srcRef = itemset.nodesetRef;
+            TreeReference srcRef = itemset.getNodesetRef();
             if (!refs.contains(srcRef)) {
                 //CTS: Being an itemset root is not sufficient to mark
                 //a node as repeatable. It has to be nonstatic (which it

--- a/src/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/org/javarosa/xform/parse/FormInstanceParser.java
@@ -78,7 +78,7 @@ class FormInstanceParser {
             // The first time is here because they are needed before these
             // validation steps can be performed.
             // It is then done again during the call to _f.setInstance().
-            FormDef.updateItemsetReferences(formDef.getChildren());
+            FormDef.updateItemsetReferences(instanceModel, Collections.list(formDef.getNonMainInstances()), formDef.getChildren());
             processRepeats(instanceModel);
             verifyBindings(instanceModel, e.getName());
             verifyActions(instanceModel);

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -15,22 +15,82 @@
  */
 package org.javarosa.xform.parse;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
-public class RandomizeHelper {
-    public static Long parseSeed(String nodesetStr) {
-        return null;
+/**
+ * This class contains all the code needed to implement the xform randomize()
+ * function.
+ */
+public final class RandomizeHelper {
+    /**
+     * Looks for a seed in an xform randomize() expression. If it is present and
+     * it can be parsed into a {@link Long}, it returns it. If it is not present,
+     * returns null.
+     * <p>
+     * Can throw an {@link IllegalArgumentException} if the expression doesn't conform
+     * to an xform randomize() call.
+     * Can throw a {@link NumberFormatException} if it can't parse the seed into a {@link Long}
+     *
+     * @param nodesetStr an xform randomize() expression
+     * @return a {@link Long} seed or null if it is not found inside the expression
+     */
+    static Long parseSeed(String nodesetStr) {
+        String[] args = getArgs(nodesetStr);
+        return args.length == 2
+            ? Long.parseLong(args[1].trim())
+            : null;
     }
 
-    public static String cleanNodesetDefinition(String nodesetStr) {
-        return nodesetStr;
+    /**
+     * Cleans an xform randomize() expression to leave only its first argument, which
+     * should be an xpath expression.
+     * <p>
+     * Can throw an {@link IllegalArgumentException} if the expression doesn't conform
+     * to an xform randomize() call.
+     *
+     * @param nodesetStr an xform randomize() expression
+     * @return a {@link String} with the first argument of the xform randomize() expression
+     */
+    static String cleanNodesetDefinition(String nodesetStr) {
+        return getArgs(nodesetStr)[0].trim();
     }
 
+    /**
+     * This method will return a new list with the same elements, randomly reordered.
+     * Every call to this method will produce a different random seed, which will
+     * potentially produce a different ordering each time.
+     *
+     * @param elements {@link List} of elements of type T to be shuffled
+     * @param <T>      Type of the elements in the list
+     * @return a new {@link List} with the same input elements reordered
+     */
     public static <T> List<T> shuffle(List<T> elements) {
         return shuffle(elements, null);
     }
 
+    /**
+     * This method will return a new list with the same elements, randomly reordered.
+     * Given the same seed, calls to this method will produce exactly the same output.
+     *
+     * @param elements {@link List} of elements of type T to be shuffled
+     * @param seed     {@link Long} seed for the Random number generator
+     * @param <T>      Type of the elements in the list
+     * @return a new {@link List} with the same input elements reordered
+     */
     public static <T> List<T> shuffle(List<T> elements, Long seed) {
-        return elements;
+        List<T> output = new ArrayList<>(elements.size());
+        output.addAll(elements);
+
+        Collections.shuffle(output, seed != null ? new Random(seed) : new Random());
+        return output;
+    }
+
+    private static String[] getArgs(String nodesetStr) {
+        if (!nodesetStr.startsWith("randomize(") || !nodesetStr.endsWith(")"))
+            throw new IllegalArgumentException("Nodeset definition must use randomize(path, seed?) function");
+        return nodesetStr.substring(10, nodesetStr.length() - 1).split(",");
     }
 }

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xform.parse;
+
+import java.util.List;
+
+public class RandomizeHelper {
+    public static Long parseSeed(String nodesetStr) {
+        return null;
+    }
+
+    public static String cleanNodesetDefinition(String nodesetStr) {
+        return nodesetStr;
+    }
+
+    public static <T> List<T> shuffle(List<T> elements) {
+        return shuffle(elements, null);
+    }
+
+    public static <T> List<T> shuffle(List<T> elements, Long seed) {
+        return elements;
+    }
+}

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.javarosa.core.model.Action;
 import org.javarosa.core.model.DataBinding;
@@ -93,6 +94,7 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.XPathConditional;
 import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.kxml2.io.KXmlParser;
@@ -1297,8 +1299,11 @@ public class XFormParser implements IXFormParserFunctions {
         String nodesetStr = e.getAttributeValue("", NODESET_ATTR);
         if (nodesetStr == null)
             throw new RuntimeException("No nodeset attribute in element: [" + e.getName() + "]. This is required. (Element Printout:" + XFormSerializer.elementToString(e) + ")");
-        XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
-        itemset.nodesetExpr = new XPathConditional(path);
+        Optional<XPathPathExpr> path = XPathReference.getPathExpr2(nodesetStr);
+        Optional<XPathFuncExpr> func = XPathReference.getFuncExpr(nodesetStr);
+        itemset.nodesetExpr = new XPathConditional(
+            path.isPresent() ? path.get() : func.get()
+        );
         itemset.contextRef = getFormElementRef(qparent);
         // this is not valid yet...
         itemset.nodesetRef = null;

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -40,6 +40,8 @@ import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
 import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.parseSeed;
 import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 import java.io.ByteArrayInputStream;
@@ -1297,6 +1299,13 @@ public class XFormParser implements IXFormParserFunctions {
         String nodesetStr = e.getAttributeValue("", NODESET_ATTR);
         if (nodesetStr == null)
             throw new RuntimeException("No nodeset attribute in element: [" + e.getName() + "]. This is required. (Element Printout:" + XFormSerializer.elementToString(e) + ")");
+
+        if (nodesetStr.startsWith("randomize(")) {
+            itemset.randomize = true;
+            itemset.randomSeed = parseSeed(nodesetStr);
+            nodesetStr = cleanNodesetDefinition(nodesetStr);
+        }
+
         XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
         itemset.nodesetExpr = new XPathConditional(path);
         itemset.contextRef = getFormElementRef(qparent);

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -16,6 +16,45 @@
 
 package org.javarosa.xform.parse;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
+import static org.javarosa.core.model.Constants.CONTROL_INPUT;
+import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_SECRET;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
+import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
+import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
+import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
+import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
+import static org.javarosa.core.model.instance.ExternalDataInstance.getPathIfExternalDataInstance;
+import static org.javarosa.core.services.ProgramFlow.die;
+import static org.javarosa.xform.parse.Constants.ID_ATTR;
+import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
+import static org.javarosa.xform.parse.Constants.SELECT;
+import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.javarosa.core.model.Action;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
@@ -65,46 +104,6 @@ import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
-import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
-import static org.javarosa.core.model.Constants.CONTROL_INPUT;
-import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_RANGE;
-import static org.javarosa.core.model.Constants.CONTROL_SECRET;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
-import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
-import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
-import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
-import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
-import static org.javarosa.core.model.instance.ExternalDataInstance.getPathIfExternalDataInstance;
-import static org.javarosa.core.services.ProgramFlow.die;
-import static org.javarosa.xform.parse.Constants.ID_ATTR;
-import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
-import static org.javarosa.xform.parse.Constants.SELECT;
-import static org.javarosa.xform.parse.Constants.SELECTONE;
-import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
-
 
 /* droos: i think we need to start storing the contents of the <bind>s in the formdef again */
 
@@ -113,7 +112,6 @@ import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttr
  *
  * @author Daniel Kayiwa
  * @author Drew Roos
- *
  */
 public class XFormParser implements IXFormParserFunctions {
     private static final Logger logger = LoggerFactory.getLogger(XFormParser.class);
@@ -199,7 +197,8 @@ public class XFormParser implements IXFormParserFunctions {
     private static void initProcessingRules() {
         groupLevelHandlers = new HashMap<String, IElementHandler>() {{
             put("input", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     // Attributes that are passed through to additionalAttributes but shouldn't lead to warnings.
                     // These are consistently used by clients but are expected in additionalAttributes for historical
                     // reasons.
@@ -208,69 +207,82 @@ public class XFormParser implements IXFormParserFunctions {
                 }
             });
             put("range", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_RANGE,
                         asList("start", "end", "step") // Prevent warning about unexpected attributes
                     );
                 }
             });
             put("secret", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_SECRET);
                 }
             });
             put(SELECT, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_SELECT_MULTI);
                 }
             });
             put(SELECTONE, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_SELECT_ONE);
                 }
             });
             put("group", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseGroup((IFormElement) parent, e, CONTAINER_GROUP);
                 }
             });
             put("repeat", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseGroup((IFormElement) parent, e, CONTAINER_REPEAT);
                 }
             });
             put("trigger", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_TRIGGER);
                 }
             }); //multi-purpose now; need to dig deeper
             put(XFTAG_UPLOAD, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseUpload((IFormElement) parent, e, CONTROL_UPLOAD);
                 }
             });
             put(LABEL_ELEMENT, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     if (parent instanceof GroupDef) {
                         p.parseGroupLabel((GroupDef) parent, e);
-                    } else throw new XFormParseException("parent of element is not a group", e);
+                    } else
+                        throw new XFormParseException("parent of element is not a group", e);
                 }
             });
         }};
 
         topLevelHandlers = new HashMap<String, IElementHandler>() {{
             put("model", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseModel(e);
                 }
             });
             put("title", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseTitle(e);
                 }
             });
             put("meta", new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseMeta(e);
                 }
             });
@@ -278,7 +290,7 @@ public class XFormParser implements IXFormParserFunctions {
         topLevelHandlers.putAll(groupLevelHandlers);
     }
 
-    private void initState () {
+    private void initState() {
         modelFound = false;
         bindingsByID = new HashMap<>();
         bindings = new ArrayList<>();
@@ -308,7 +320,9 @@ public class XFormParser implements IXFormParserFunctions {
 
         structuredActions = new HashMap<>();
         structuredActions.put("setvalue", new IElementHandler() {
-            public void handle (XFormParser p, Element e, Object parent) { p.parseSetValueAction((FormDef)parent, e);}
+            public void handle(XFormParser p, Element e, Object parent) {
+                p.parseSetValueAction((FormDef) parent, e);
+            }
         });
     }
 
@@ -352,7 +366,9 @@ public class XFormParser implements IXFormParserFunctions {
         return _f;
     }
 
-    /** Extracts the namespaces from the given element and creates a map of URI to prefix */
+    /**
+     * Extracts the namespaces from the given element and creates a map of URI to prefix
+     */
     private static Map<String, String> buildNamespacesMap(Element el) {
         final Map<String, String> namespacePrefixesByURI = new HashMap<>();
 
@@ -363,7 +379,7 @@ public class XFormParser implements IXFormParserFunctions {
         return namespacePrefixesByURI;
     }
 
-    public static Document getXMLDocument(Reader reader) throws IOException  {
+    public static Document getXMLDocument(Reader reader) throws IOException {
         return getXMLDocument(reader, null);
     }
 
@@ -377,15 +393,16 @@ public class XFormParser implements IXFormParserFunctions {
      * @throws IOException
      * @deprecated The InterningKXmlParser is not used.
      */
-    @Deprecated public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache)
+    @Deprecated
+    public static Document getXMLDocument(Reader reader, CacheTable<String> stringCache)
         throws IOException {
         final StopWatch ctParse = StopWatch.start();
         Document doc = new Document();
 
-        try{
+        try {
             KXmlParser parser;
 
-            if(stringCache != null) {
+            if (stringCache != null) {
                 parser = new InterningKXmlParser(stringCache);
             } else {
                 parser = new KXmlParser();
@@ -394,14 +411,14 @@ public class XFormParser implements IXFormParserFunctions {
             parser.setInput(reader);
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
             doc.parse(parser);
-        }  catch (XmlPullParserException e) {
-            String errorMsg = "XML Syntax Error at Line: " + e.getLineNumber() +", Column: "+ e.getColumnNumber()+ "!";
+        } catch (XmlPullParserException e) {
+            String errorMsg = "XML Syntax Error at Line: " + e.getLineNumber() + ", Column: " + e.getColumnNumber() + "!";
             logger.error(errorMsg, e);
             throw new XFormParseException(errorMsg);
-        } catch(IOException e){
+        } catch (IOException e) {
             //CTS - 12/09/2012 - Stop swallowing IO Exceptions
             throw e;
-        } catch(Exception e){
+        } catch (Exception e) {
             logger.error("Unhandled Exception while Parsing XForm", e);
             throw new XFormParseException("Unhandled Exception while Parsing XForm");
         }
@@ -458,7 +475,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
         //now parse the main instance
-        if(mainInstanceNode != null) {
+        if (mainInstanceNode != null) {
             FormInstance fi = instanceParser.parseInstance(mainInstanceNode, true,
                 instanceNodeIdStrs.get(instanceNodes.indexOf(mainInstanceNode)), namespacePrefixesByUri);
             /*
@@ -475,7 +492,7 @@ public class XFormParser implements IXFormParserFunctions {
         // Clear the caches, as these may not have been initialized
         // entirely correctly during the validation steps.
         Enumeration<DataInstance> e = _f.getNonMainInstances();
-        while ( e.hasMoreElements() ) {
+        while (e.hasMoreElements()) {
             DataInstance instance = e.nextElement();
             final AbstractTreeElement treeElement = instance.getRoot();
             if (treeElement instanceof TreeElement) {
@@ -505,7 +522,7 @@ public class XFormParser implements IXFormParserFunctions {
         "delHeader"
     )));
 
-    private void parseElement (Element e, Object parent, HashMap<String, IElementHandler> handlers) {
+    private void parseElement(Element e, Object parent, HashMap<String, IElementHandler> handlers) {
         String name = e.getName();
 
         IElementHandler eh = handlers.get(name);
@@ -514,7 +531,7 @@ public class XFormParser implements IXFormParserFunctions {
         } else {
             if (!validElementNames.contains(name)) {
                 triggerWarning(
-                    "Unrecognized element [" + name    + "]. Ignoring and processing children...",
+                    "Unrecognized element [" + name + "]. Ignoring and processing children...",
                     getVagueLocation(e));
             }
             for (int i = 0; i < e.getChildCount(); i++) {
@@ -525,12 +542,12 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void parseTitle (Element e) {
+    private void parseTitle(Element e) {
         List<String> usedAtts = new ArrayList<>(); //no attributes parsed in title.
         String title = getXMLText(e, true);
         logger.info("Title: \"" + title + "\"");
         _f.setTitle(title);
-        if(_f.getName() == null) {
+        if (_f.getName() == null) {
             //Jan 9, 2009 - ctsims
             //We don't really want to allow for forms without
             //some unique ID, so if a title is available, use
@@ -539,31 +556,31 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseMeta (Element e) {
+    private void parseMeta(Element e) {
         List<String> usedAtts = new ArrayList<>();
         int attributes = e.getAttributeCount();
-        for(int i = 0 ; i < attributes ; ++i) {
+        for (int i = 0; i < attributes; ++i) {
             String name = e.getAttributeName(i);
             String value = e.getAttributeValue(i);
-            if("name".equals(name)) {
+            if ("name".equals(name)) {
                 _f.setName(value);
             }
         }
 
 
         usedAtts.add("name");
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
     //for ease of parsing, we assume a model comes before the controls, which isn't necessarily mandated by the xforms spec
-    private void parseModel (Element e) {
+    private void parseModel(Element e) {
         List<String> usedAtts = new ArrayList<>(); //no attributes parsed in title.
         List<Element> delayedParseElements = new ArrayList<>();
 
@@ -574,8 +591,8 @@ public class XFormParser implements IXFormParserFunctions {
         }
         modelFound = true;
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
         for (int i = 0; i < e.getChildCount(); i++) {
@@ -592,19 +609,19 @@ public class XFormParser implements IXFormParserFunctions {
                 saveInstanceNode(child);
             } else if (BIND_ATTR.equals(childName)) { //<instance> must come before <bind>s
                 parseBind(child);
-            } else if("submission".equals(childName)) {
+            } else if ("submission".equals(childName)) {
                 delayedParseElements.add(child);
-            } else if(namedActions.contains(childName) || (childName != null && structuredActions.containsKey(childName))) {
+            } else if (namedActions.contains(childName) || (childName != null && structuredActions.containsKey(childName))) {
                 delayedParseElements.add(child);
             } else { //invalid model content
                 if (type == Node.ELEMENT) {
-                    throw new XFormParseException("Unrecognized top-level tag [" + childName + "] found within <model>",child);
+                    throw new XFormParseException("Unrecognized top-level tag [" + childName + "] found within <model>", child);
                 } else if (type == Node.TEXT && getXMLText(e, i, true).length() != 0) {
-                    throw new XFormParseException("Unrecognized text content found within <model>: \"" + getXMLText(e, i, true) + "\"",child == null ? e : child);
+                    throw new XFormParseException("Unrecognized text content found within <model>: \"" + getXMLText(e, i, true) + "\"", child == null ? e : child);
                 }
             }
 
-            if(child == null || BIND_ATTR.equals(childName) || "itext".equals(childName)) {
+            if (child == null || BIND_ATTR.equals(childName) || "itext".equals(childName)) {
                 //Clayton Sims - Jun 17, 2009 - This code is used when the stinginess flag
                 //is set for the build. It dynamically wipes out old model nodes once they're
                 //used. This is sketchy if anything else plans on touching the nodes.
@@ -615,13 +632,13 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         //Now parse out the submission/action blocks (we needed the binds to all be set before we could)
-        for(Element child : delayedParseElements) {
+        for (Element child : delayedParseElements) {
             String name = child.getName();
-            if(name.equals("submission")) {
+            if (name.equals("submission")) {
                 parseSubmission(child);
             } else {
                 //For now, anything that isn't a submission is an action
-                if(namedActions.contains(name)) {
+                if (namedActions.contains(name)) {
                     parseNamedAction(child);
                 } else {
                     structuredActions.get(name).handle(this, child, _f);
@@ -669,8 +686,8 @@ public class XFormParser implements IXFormParserFunctions {
         TreeReference treeref = FormInstance.unpackReference(dataRef);
 
         actionTargets.add(treeref);
-        if(valueRef == null) {
-            if(e.getChildCount() == 0 || !e.isText(0)) {
+        if (valueRef == null) {
+            if (e.getChildCount() == 0 || !e.isText(0)) {
                 throw new XFormParseException("No 'value' attribute and no inner value set in <setvalue> associated with: " + treeref, e);
             }
             //Set expression
@@ -695,8 +712,8 @@ public class XFormParser implements IXFormParserFunctions {
         String action = submission.getAttributeValue(null, "action");
 
         SubmissionParser parser = new SubmissionParser();
-        for(SubmissionParser p : submissionParsers) {
-            if(p.matchesCustomMethod(method)) {
+        for (SubmissionParser p : submissionParsers) {
+            if (p.matchesCustomMethod(method)) {
                 parser = p;
             }
         }
@@ -728,9 +745,9 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        SubmissionProfile profile = parser.parseSubmission(method, action, dataRef, submission );
+        SubmissionProfile profile = parser.parseSubmission(method, action, dataRef, submission);
 
-        if(id == null) {
+        if (id == null) {
             //default submission profile
             _f.setDefaultSubmission(profile);
         } else {
@@ -739,7 +756,7 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void saveInstanceNode (Element instance) {
+    private void saveInstanceNode(Element instance) {
         Element instanceNode = null;
         String instanceId = instance.getAttributeValue("", "id");
 
@@ -753,7 +770,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        if(instanceNode == null) {
+        if (instanceNode == null) {
             //no kids
             instanceNode = instance;
         }
@@ -790,7 +807,7 @@ public class XFormParser implements IXFormParserFunctions {
         if ("image/*".equals(mediaType)) {
             // NOTE: this could be further expanded.
             question.setControlType(CONTROL_IMAGE_CHOOSE);
-        } else if("audio/*".equals(mediaType)) {
+        } else if ("audio/*".equals(mediaType)) {
             question.setControlType(CONTROL_AUDIO_CAPTURE);
         } else if ("video/*".equals(mediaType)) {
             question.setControlType(CONTROL_VIDEO_CAPTURE);
@@ -807,8 +824,8 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     /**
-     *  Parses the OSM Tag Elements when we are parsing
-     *  an OSM Upload element. 
+     * Parses the OSM Tag Elements when we are parsing
+     * an OSM Upload element.
      */
     private List<OSMTag> parseOsmTags(Element e) {
         List<OSMTag> tags = new ArrayList<>();
@@ -889,13 +906,13 @@ public class XFormParser implements IXFormParserFunctions {
     /**
      * Parses a form control element into a {@link org.javarosa.core.model.QuestionDef} and attaches it to its parent.
      *
-     * @param parent                the form control element's parent
-     * @param e                     the form control element to parse
-     * @param controlType           one of the control types defined in {@link org.javarosa.core.model.Constants}
-     * @param additionalUsedAtts    attributes specific to the control type
-     * @param passedThroughAtts     attributes specific to the control type that should be passed through to
-     *                              additionalAttributes for historical reasons
-     * @return                      a {@link org.javarosa.core.model.QuestionDef} representing the form control element
+     * @param parent             the form control element's parent
+     * @param e                  the form control element to parse
+     * @param controlType        one of the control types defined in {@link org.javarosa.core.model.Constants}
+     * @param additionalUsedAtts attributes specific to the control type
+     * @param passedThroughAtts  attributes specific to the control type that should be passed through to
+     *                           additionalAttributes for historical reasons
+     * @return a {@link org.javarosa.core.model.QuestionDef} representing the form control element
      */
     private QuestionDef parseControl(IFormElement parent, Element e, int controlType, List<String> additionalUsedAtts,
                                      List<String> passedThroughAtts) {
@@ -923,7 +940,7 @@ public class XFormParser implements IXFormParserFunctions {
         } else if (ref != null) {
             try {
                 dataRef = new XPathReference(ref);
-            } catch(RuntimeException el) {
+            } catch (RuntimeException el) {
                 logger.info(XFormParser.getVagueLocation(e));
                 throw el;
             }
@@ -932,7 +949,7 @@ public class XFormParser implements IXFormParserFunctions {
             if (controlType == CONTROL_TRIGGER) {
                 //TODO: special handling for triggers? also, not all triggers created equal
             } else {
-                throw new XFormParseException("XForm Parse: input control with neither 'ref' nor 'bind'",e);
+                throw new XFormParseException("XForm Parse: input control with neither 'ref' nor 'bind'", e);
             }
         }
 
@@ -991,7 +1008,7 @@ public class XFormParser implements IXFormParserFunctions {
         return controlType == CONTROL_RANGE ? new RangeQuestion() : new QuestionDef();
     }
 
-    private void parseQuestionLabel (QuestionDef q, Element e) {
+    private void parseQuestionLabel(QuestionDef q, Element e) {
         String label = getLabel(e);
         String ref = e.getAttributeValue("", REF_ATTR);
 
@@ -1012,12 +1029,12 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseGroupLabel (GroupDef g, Element e) {
+    private void parseGroupLabel(GroupDef g, Element e) {
         if (g.getRepeat())
             return; //ignore child <label>s for <repeat>; the appropriate <label> must be in the wrapping <group>
 
@@ -1042,24 +1059,25 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private String getLabel (Element e){
-        if(e.getChildCount() == 0) return null;
+    private String getLabel(Element e) {
+        if (e.getChildCount() == 0)
+            return null;
 
         recurseForOutput(e);
 
         StringBuilder sb = new StringBuilder();
-        for(int i = 0; i<e.getChildCount();i++){
-            if(e.getType(i)!=Node.TEXT && !(e.getChild(i) instanceof String)){
+        for (int i = 0; i < e.getChildCount(); i++) {
+            if (e.getType(i) != Node.TEXT && !(e.getChild(i) instanceof String)) {
                 Object b = e.getChild(i);
-                Element child = (Element)b;
+                Element child = (Element) b;
 
                 //If the child is in the HTML namespace, retain it.
-                if(NAMESPACE_HTML.equals(child.getNamespace())) {
+                if (NAMESPACE_HTML.equals(child.getNamespace())) {
                     sb.append(XFormSerializer.elementToString(child));
                 } else {
                     //Otherwise, ignore it.
@@ -1067,7 +1085,7 @@ public class XFormParser implements IXFormParserFunctions {
                         "use HTML markup? If so, ensure that the element is defined in " +
                         "the HTML namespace.", child.getName());
                 }
-            }else{
+            } else {
                 sb.append(e.getText(i));
             }
         }
@@ -1075,30 +1093,35 @@ public class XFormParser implements IXFormParserFunctions {
         return sb.toString().trim();
     }
 
-    private void recurseForOutput(Element e){
-        if(e.getChildCount() == 0) return;
+    private void recurseForOutput(Element e) {
+        if (e.getChildCount() == 0)
+            return;
 
-        for(int i=0;i<e.getChildCount();i++){
+        for (int i = 0; i < e.getChildCount(); i++) {
             int kidType = e.getType(i);
-            if(kidType == Node.TEXT) { continue; }
-            if(e.getChild(i) instanceof String) { continue; }
-            Element kid = (Element)e.getChild(i);
+            if (kidType == Node.TEXT) {
+                continue;
+            }
+            if (e.getChild(i) instanceof String) {
+                continue;
+            }
+            Element kid = (Element) e.getChild(i);
 
             //is just text
-            if(kidType == Node.ELEMENT && XFormUtils.isOutput(kid)){
-                String s = "${"+parseOutput(kid)+"}";
+            if (kidType == Node.ELEMENT && XFormUtils.isOutput(kid)) {
+                String s = "${" + parseOutput(kid) + "}";
                 e.removeChild(i);
                 e.addChild(i, Node.TEXT, s);
 
                 //has kids? Recurse through them and swap output tag for parsed version
-            }else if(kid.getChildCount() !=0){
+            } else if (kid.getChildCount() != 0) {
                 recurseForOutput(kid);
                 //is something else
             }
         }
     }
 
-    private String parseOutput (Element e) {
+    private String parseOutput(Element e) {
         List<String> usedAtts = new ArrayList<>();
         usedAtts.add(REF_ATTR);
         usedAtts.add(VALUE);
@@ -1108,7 +1131,7 @@ public class XFormParser implements IXFormParserFunctions {
             xpath = e.getAttributeValue(null, VALUE);
         }
         if (xpath == null) {
-            throw new XFormParseException("XForm Parse: <output> without 'ref' or 'value'",e);
+            throw new XFormParseException("XForm Parse: <output> without 'ref' or 'value'", e);
         }
 
         XPathConditional expr = null;
@@ -1127,14 +1150,14 @@ public class XFormParser implements IXFormParserFunctions {
             _f.getOutputFragments().add(expr);
         }
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
         return String.valueOf(index);
     }
 
-    private void parseHint (QuestionDef q, Element e) {
+    private void parseHint(QuestionDef q, Element e) {
         List<String> usedAtts = new ArrayList<>();
         usedAtts.add(REF_ATTR);
         String hint = getXMLText(e, true);
@@ -1155,12 +1178,12 @@ public class XFormParser implements IXFormParserFunctions {
             q.setHelpText(hint);
         }
 
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseItem (QuestionDef q, Element e) {
+    private void parseItem(QuestionDef q, Element e) {
         final int MAX_VALUE_LEN = 32;
 
         //catalogue of used attributes in this method/element
@@ -1182,8 +1205,8 @@ public class XFormParser implements IXFormParserFunctions {
             if (LABEL_ELEMENT.equals(childName)) {
 
                 //print attribute warning for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, labelUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, labelUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
                 }
                 labelInnerText = getLabel(child);
                 String ref = child.getAttributeValue("", REF_ATTR);
@@ -1194,18 +1217,18 @@ public class XFormParser implements IXFormParserFunctions {
 
                         verifyTextMappings(textRef, "Item <label>", true);
                     } else {
-                        throw new XFormParseException("malformed ref [" + ref + "] for <item>",child);
+                        throw new XFormParseException("malformed ref [" + ref + "] for <item>", child);
                     }
                 }
             } else if (VALUE.equals(childName)) {
                 value = getXMLText(child, true);
 
                 //print attribute warning for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, valueUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, valueUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
                 }
 
-                if (value != null)  {
+                if (value != null) {
                     if (value.length() > MAX_VALUE_LEN) {
                         triggerWarning(
                             "choice value [" + value + "] is too long; max. suggested length " + MAX_VALUE_LEN + " chars",
@@ -1230,25 +1253,25 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         if (textRef == null && labelInnerText == null) {
-            throw new XFormParseException("<item> without proper <label>",e);
+            throw new XFormParseException("<item> without proper <label>", e);
         }
         if (value == null) {
-            throw new XFormParseException("<item> without proper <value>",e);
+            throw new XFormParseException("<item> without proper <value>", e);
         }
 
         if (textRef != null) {
             q.addSelectChoice(new SelectChoice(textRef, value));
         } else {
-            q.addSelectChoice(new SelectChoice(null,labelInnerText, value, false));
+            q.addSelectChoice(new SelectChoice(null, labelInnerText, value, false));
         }
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
             triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
     }
 
-    private void parseItemset (QuestionDef q, Element e, IFormElement qparent) {
+    private void parseItemset(QuestionDef q, Element e, IFormElement qparent) {
         ItemsetBinding itemset = new ItemsetBinding();
 
         ////////////////USED FOR PARSER WARNING OUTPUT ONLY
@@ -1272,7 +1295,8 @@ public class XFormParser implements IXFormParserFunctions {
          * We will patch this all up in the verifyItemsetBindings() method.
          */
         String nodesetStr = e.getAttributeValue("", NODESET_ATTR);
-        if(nodesetStr == null ) throw new RuntimeException("No nodeset attribute in element: ["+e.getName()+"]. This is required. (Element Printout:"+XFormSerializer.elementToString(e)+")");
+        if (nodesetStr == null)
+            throw new RuntimeException("No nodeset attribute in element: [" + e.getName() + "]. This is required. (Element Printout:" + XFormSerializer.elementToString(e) + ")");
         XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
         itemset.nodesetExpr = new XPathConditional(path);
         itemset.contextRef = getFormElementRef(qparent);
@@ -1291,8 +1315,8 @@ public class XFormParser implements IXFormParserFunctions {
                 boolean labelItext = false;
 
                 //print unused attribute warning message for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, labelUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, labelUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, labelUA), getVagueLocation(child));
                 }
                 /////////////////////////////////////////////////////////////
 
@@ -1314,8 +1338,8 @@ public class XFormParser implements IXFormParserFunctions {
                 String copyXpath = child.getAttributeValue("", REF_ATTR);
 
                 //print unused attribute warning message for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, copyUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, copyUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, copyUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, copyUA), getVagueLocation(child));
                 }
 
                 if (copyXpath == null) {
@@ -1331,8 +1355,8 @@ public class XFormParser implements IXFormParserFunctions {
                 String valueXpath = child.getAttributeValue("", REF_ATTR);
 
                 //print unused attribute warning message for child element
-                if(XFormUtils.showUnusedAttributeWarning(child, valueUA)){
-                    triggerWarning( XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
+                if (XFormUtils.showUnusedAttributeWarning(child, valueUA)) {
+                    triggerWarning(XFormUtils.unusedAttWarning(child, valueUA), getVagueLocation(child));
                 }
 
                 if (valueXpath == null) {
@@ -1354,7 +1378,7 @@ public class XFormParser implements IXFormParserFunctions {
 
         if (itemset.copyExpr != null) {
             if (itemset.valueExpr == null) {
-                triggerWarning( "<itemset>s with <copy> are STRONGLY recommended to have <value> as well; pre-selecting, default answers, and display of answers will not work properly otherwise",getVagueLocation(e));
+                triggerWarning("<itemset>s with <copy> are STRONGLY recommended to have <value> as well; pre-selecting, default answers, and display of answers will not work properly otherwise", getVagueLocation(e));
             }
         }
 
@@ -1362,13 +1386,13 @@ public class XFormParser implements IXFormParserFunctions {
         q.setDynamicChoices(itemset);
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
             triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
     }
 
-    private void parseGroup (IFormElement parent, Element e, int groupType) {
+    private void parseGroup(IFormElement parent, Element e, int groupType) {
         GroupDef group = new GroupDef();
         group.setID(serialQuestionID++); //until we come up with a better scheme
         IDataReference dataRef = null;
@@ -1394,7 +1418,7 @@ public class XFormParser implements IXFormParserFunctions {
         if (bind != null) {
             DataBinding binding = bindingsByID.get(bind);
             if (binding == null) {
-                throw new XFormParseException("XForm Parse: invalid binding ID [" + bind + "]",e);
+                throw new XFormParseException("XForm Parse: invalid binding ID [" + bind + "]", e);
             }
             dataRef = binding.getReference();
             refFromBind = true;
@@ -1403,7 +1427,7 @@ public class XFormParser implements IXFormParserFunctions {
                 if (nodeset != null) {
                     dataRef = new XPathReference(nodeset);
                 } else {
-                    throw new XFormParseException("XForm Parse: <repeat> with no binding ('bind' or 'nodeset')",e);
+                    throw new XFormParseException("XForm Parse: <repeat> with no binding ('bind' or 'nodeset')", e);
                 }
             } else {
                 if (ref != null) {
@@ -1470,27 +1494,28 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         // save all the unused attributes verbatim...
-        for(int i=0;i<e.getAttributeCount();i++){
+        for (int i = 0; i < e.getAttributeCount(); i++) {
             String name = e.getAttributeName(i);
-            if ( usedAtts.contains(name) ) continue;
+            if (usedAtts.contains(name))
+                continue;
             group.setAdditionalAttribute(e.getAttributeNamespace(i), name, e.getAttributeValue(i));
         }
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(e, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
+        if (XFormUtils.showUnusedAttributeWarning(e, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(e, usedAtts), getVagueLocation(e));
         }
 
         parent.addChild(group);
     }
 
-    private TreeReference getFormElementRef (IFormElement fe) {
+    private TreeReference getFormElementRef(IFormElement fe) {
         if (fe instanceof FormDef) {
             TreeReference ref = TreeReference.rootRef();
             ref.add(mainInstanceNode.getName(), 0);
             return ref;
         } else {
-            return (TreeReference)fe.getBind().getReference();
+            return (TreeReference) fe.getBind().getReference();
         }
     }
 
@@ -1499,8 +1524,10 @@ public class XFormParser implements IXFormParserFunctions {
         return FormDef.getAbsRef(ref, getFormElementRef(parent));
     }
 
-    /** Collapses groups whose only child is a repeat into a single repeat that uses the label of the wrapping group */
-    private static void collapseRepeatGroups (IFormElement fe) {
+    /**
+     * Collapses groups whose only child is a repeat into a single repeat that uses the label of the wrapping group
+     */
+    private static void collapseRepeatGroups(IFormElement fe) {
         if (fe.getChildren() == null)
             return;
 
@@ -1508,14 +1535,14 @@ public class XFormParser implements IXFormParserFunctions {
             IFormElement child = fe.getChild(i);
             GroupDef group = null;
             if (child instanceof GroupDef)
-                group = (GroupDef)child;
+                group = (GroupDef) child;
 
             if (group != null) {
                 if (!group.getRepeat() && group.getChildren().size() == 1) {
                     IFormElement grandchild = group.getChildren().get(0);
                     GroupDef repeat = null;
                     if (grandchild instanceof GroupDef)
-                        repeat = (GroupDef)grandchild;
+                        repeat = (GroupDef) grandchild;
 
                     if (repeat != null && repeat.getRepeat()) {
                         //collapse the wrapping group
@@ -1538,7 +1565,7 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void parseIText (Element itext) {
+    private void parseIText(Element itext) {
         Localizer l = new Localizer(true, true);
 
         ArrayList<String> usedAtts = new ArrayList<>(); //used for warning message
@@ -1552,20 +1579,20 @@ public class XFormParser implements IXFormParserFunctions {
         }
 
         if (l.getAvailableLocales().length == 0)
-            throw new XFormParseException("no <translation>s defined",itext);
+            throw new XFormParseException("no <translation>s defined", itext);
 
         if (l.getDefaultLocale() == null)
             l.setDefaultLocale(l.getAvailableLocales()[0]);
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(itext, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(itext, usedAtts), getVagueLocation(itext));
+        if (XFormUtils.showUnusedAttributeWarning(itext, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(itext, usedAtts), getVagueLocation(itext));
         }
 
         localizer = l;
     }
 
-    private void parseTranslation (Localizer l, Element trans) {
+    private void parseTranslation(Localizer l, Element trans) {
         /////for warning message
         List<String> usedAtts = new ArrayList<>();
         usedAtts.add("lang");
@@ -1574,17 +1601,17 @@ public class XFormParser implements IXFormParserFunctions {
 
         String lang = trans.getAttributeValue("", "lang");
         if (lang == null || lang.length() == 0) {
-            throw new XFormParseException("no language specified for <translation>",trans);
+            throw new XFormParseException("no language specified for <translation>", trans);
         }
         String isDefault = trans.getAttributeValue("", "default");
 
         if (!l.addAvailableLocale(lang)) {
-            throw new XFormParseException("duplicate <translation> for language '" + lang + "'",trans);
+            throw new XFormParseException("duplicate <translation> for language '" + lang + "'", trans);
         }
 
         if (isDefault != null) {
             if (l.getDefaultLocale() != null)
-                throw new XFormParseException("more than one <translation> set as default",trans);
+                throw new XFormParseException("more than one <translation> set as default", trans);
             l.setDefaultLocale(lang);
         }
 
@@ -1607,14 +1634,14 @@ public class XFormParser implements IXFormParserFunctions {
         ElementChildDeleter.delete(trans, removeIndexes);
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(trans, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(trans, usedAtts), getVagueLocation(trans));
+        if (XFormUtils.showUnusedAttributeWarning(trans, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(trans, usedAtts), getVagueLocation(trans));
         }
 
         l.registerLocaleResource(lang, source);
     }
 
-    private void parseTextHandle (TableLocaleSource l, Element text) {
+    private void parseTextHandle(TableLocaleSource l, Element text) {
         String id = text.getAttributeValue("", ID_ATTR);
 
         //used for parser warnings...
@@ -1627,14 +1654,15 @@ public class XFormParser implements IXFormParserFunctions {
         //////////
 
         if (id == null || id.length() == 0) {
-            throw new XFormParseException("no id defined for <text>",text);
+            throw new XFormParseException("no id defined for <text>", text);
         }
 
         for (int k = 0; k < text.getChildCount(); k++) {
             Element value = text.getElement(k);
-            if (value == null) continue;
-            if(!value.getName().equals(VALUE)){
-                throw new XFormParseException("Unrecognized element ["+value.getName()+"] in Itext->translation->text");
+            if (value == null)
+                continue;
+            if (!value.getName().equals(VALUE)) {
+                throw new XFormParseException("Unrecognized element [" + value.getName() + "] in Itext->translation->text");
             }
 
             String form = value.getAttributeValue("", FORM_ATTR);
@@ -1648,27 +1676,27 @@ public class XFormParser implements IXFormParserFunctions {
 
             String textID = (form == null ? id : id + ";" + form);  //kind of a hack
             if (l.hasMapping(textID)) {
-                throw new XFormParseException("duplicate definition for text ID \"" + id + "\" and form \"" + form + "\""+". Can only have one definition for each text form.",text);
+                throw new XFormParseException("duplicate definition for text ID \"" + id + "\" and form \"" + form + "\"" + ". Can only have one definition for each text form.", text);
             }
             l.setLocaleMapping(textID, data);
 
             //print unused attribute warning message for child element
-            if(XFormUtils.showUnusedAttributeWarning(value, childUsedAtts)){
-                triggerWarning( XFormUtils.unusedAttWarning(value, childUsedAtts), getVagueLocation(value));
+            if (XFormUtils.showUnusedAttributeWarning(value, childUsedAtts)) {
+                triggerWarning(XFormUtils.unusedAttWarning(value, childUsedAtts), getVagueLocation(value));
             }
         }
 
         //print unused attribute warning message for parent element
-        if(XFormUtils.showUnusedAttributeWarning(text, usedAtts)){
-            triggerWarning( XFormUtils.unusedAttWarning(text, usedAtts), getVagueLocation(text));
+        if (XFormUtils.showUnusedAttributeWarning(text, usedAtts)) {
+            triggerWarning(XFormUtils.unusedAttWarning(text, usedAtts), getVagueLocation(text));
         }
     }
 
-    private boolean hasITextMapping (String textID, String locale) {
+    private boolean hasITextMapping(String textID, String locale) {
         return localizer.hasMapping(locale == null ? localizer.getDefaultLocale() : locale, textID);
     }
 
-    private void verifyTextMappings (String textID, String type, boolean allowSubforms) {
+    private void verifyTextMappings(String textID, String type, boolean allowSubforms) {
         String[] locales = localizer.getAvailableLocales();
 
         for (String locale : locales) {
@@ -1679,7 +1707,7 @@ public class XFormParser implements IXFormParserFunctions {
                         "': text is not localizable for default locale [" + localizer.getDefaultLocale() + "]!");
                 }
 
-                triggerWarning( type + " '" +
+                triggerWarning(type + " '" +
                     textID + "': text is not localizable for locale " + locale + ".", null);
             }
         }
@@ -1693,20 +1721,20 @@ public class XFormParser implements IXFormParserFunctions {
      */
     private boolean hasSpecialFormMapping(String textID, String locale) {
         //First check our guesses
-        for(String guess : itextKnownForms) {
-            if(hasITextMapping(textID + ";" + guess, locale)) {
+        for (String guess : itextKnownForms) {
+            if (hasITextMapping(textID + ";" + guess, locale)) {
                 return true;
             }
         }
         //Otherwise this sucks and we have to test the keys
         for (String key : localizer.getLocaleData(locale).keySet()) {
-            if(key.startsWith(textID + ";")) {
+            if (key.startsWith(textID + ";")) {
                 //A key is found, pull it out, add it to the list of guesses, and return positive
                 String textForm = key.substring(key.indexOf(";") + 1, key.length());
                 //Kind of a long story how we can end up getting here. It involves the default locale loading values
                 //for the other locale, but isn't super good.
                 //TODO: Clean up being able to get here
-                if(!itextKnownForms.contains(textForm)) {
+                if (!itextKnownForms.contains(textForm)) {
                     logger.info("adding unexpected special itext form: {} to list of expected forms", textForm);
                     itextKnownForms.add(textForm);
                 }
@@ -1721,7 +1749,9 @@ public class XFormParser implements IXFormParserFunctions {
             createBinding(this, _f, usedAtts, passedThroughAtts, element);
     }
 
-    /** Attributes that are read into DataBinding fields **/
+    /**
+     * Attributes that are read into DataBinding fields
+     **/
     private final List<String> usedAtts = unmodifiableList(asList(
         ID_ATTR,
         NODESET_ATTR,
@@ -1743,8 +1773,8 @@ public class XFormParser implements IXFormParserFunctions {
      * These are consistently used by clients but are expected in additionalAttrs for historical reasons.
      **/
     private final List<String> passedThroughAtts = unmodifiableList(asList(
-            "requiredMsg",
-            "saveIncomplete"
+        "requiredMsg",
+        "saveIncomplete"
     ));
 
     private void parseBind(Element element) {
@@ -1769,7 +1799,9 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    /** e is the top-level _data_ node of the instance (immediate (and only) child of <instance>) */
+    /**
+     * e is the top-level _data_ node of the instance (immediate (and only) child of <instance>)
+     */
     private void addMainInstanceToFormDef(Element e, FormInstance instanceModel) {
         loadInstanceData(e, instanceModel.getRoot(), _f);
 
@@ -1779,24 +1811,24 @@ public class XFormParser implements IXFormParserFunctions {
 
         try {
             _f.finalizeTriggerables();
-        } catch(IllegalStateException ise) {
+        } catch (IllegalStateException ise) {
             throw new XFormParseException(ise.getMessage() == null ? "Form has an illegal cycle in its calculate and relevancy expressions!" : ise.getMessage());
         }
     }
 
     static HashMap<String, String> loadNamespaces(Element e, FormInstance tree) {
         HashMap<String, String> prefixes = new HashMap<>();
-        for(int i = 0 ; i < e.getNamespaceCount(); ++i ) {
+        for (int i = 0; i < e.getNamespaceCount(); ++i) {
             String uri = e.getNamespaceUri(i);
             String prefix = e.getNamespacePrefix(i);
-            if(uri != null && prefix != null) {
+            if (uri != null && prefix != null) {
                 tree.addNamespace(prefix, uri);
             }
         }
         return prefixes;
     }
 
-    public static TreeElement buildInstanceStructure (Element node, TreeElement parent, Map<String,
+    public static TreeElement buildInstanceStructure(Element node, TreeElement parent, Map<String,
         String> namespacePrefixesByUri, Integer multiplicityFromGroup) {
         return buildInstanceStructure(node, parent, null, node.getNamespace(), namespacePrefixesByUri, multiplicityFromGroup);
     }
@@ -1814,9 +1846,9 @@ public class XFormParser implements IXFormParserFunctions {
      *                               expensive search can be avoided.
      * @return a new TreeElement
      */
-    public static TreeElement buildInstanceStructure (Element node, TreeElement parent,
-                                                      String instanceName, String docnamespace, Map<String, String> namespacePrefixesByUri,
-                                                      Integer multiplicityFromGroup) {
+    public static TreeElement buildInstanceStructure(Element node, TreeElement parent,
+                                                     String instanceName, String docnamespace, Map<String, String> namespacePrefixesByUri,
+                                                     Integer multiplicityFromGroup) {
         TreeElement element;
 
         //catch when text content is mixed with children
@@ -1826,7 +1858,8 @@ public class XFormParser implements IXFormParserFunctions {
         for (int i = 0; i < numChildren; i++) {
             switch (node.getType(i)) {
                 case Node.ELEMENT:
-                    hasElements = true; break;
+                    hasElements = true;
+                    break;
                 case Node.TEXT:
                     if (node.getText(i).trim().length() > 0)
                         hasText = true;
@@ -1843,7 +1876,7 @@ public class XFormParser implements IXFormParserFunctions {
         if (isTemplate(node)) {
             multiplicity = TreeReference.INDEX_TEMPLATE;
             if (parent != null && parent.getChild(name, TreeReference.INDEX_TEMPLATE) != null) {
-                throw new XFormParseException("More than one node declared as the template for the same repeated set [" + name + "]",node);
+                throw new XFormParseException("More than one node declared as the template for the same repeated set [" + name + "]", node);
             }
         } else {
             multiplicity = multiplicityFromGroup != null ? multiplicityFromGroup :
@@ -1853,15 +1886,15 @@ public class XFormParser implements IXFormParserFunctions {
 
         String modelType = node.getAttributeValue(NAMESPACE_JAVAROSA, "modeltype");
         //create node; handle children
-        if(modelType == null) {
+        if (modelType == null) {
             element = new TreeElement(name, multiplicity);
             element.setInstanceName(instanceName);
         } else {
-            if( typeMappings.get(modelType) == null ){
-                throw new XFormParseException("ModelType " + modelType + " is not recognized.",node);
+            if (typeMappings.get(modelType) == null) {
+                throw new XFormParseException("ModelType " + modelType + " is not recognized.", node);
             }
-            element = (TreeElement)modelPrototypes.getNewInstance(typeMappings.get(modelType).toString());
-            if(element == null) {
+            element = (TreeElement) modelPrototypes.getNewInstance(typeMappings.get(modelType).toString());
+            if (element == null) {
                 element = new TreeElement(name, multiplicity);
                 logger.info("No model type prototype available for {}", modelType);
             } else {
@@ -1869,8 +1902,8 @@ public class XFormParser implements IXFormParserFunctions {
                 element.setMult(multiplicity);
             }
         }
-        if(node.getNamespace() != null) {
-            if(!node.getNamespace().equals(docnamespace)) {
+        if (node.getNamespace() != null) {
+            if (!node.getNamespace().equals(docnamespace)) {
                 element.setNamespace(node.getNamespace());
             }
             if (namespacePrefixesByUri.containsKey(node.getNamespace())) {
@@ -1947,7 +1980,7 @@ public class XFormParser implements IXFormParserFunctions {
     //FIXME: the 'ref' and FormDef parameters (along with the helper function above that initializes them) are only needed so that we
     //can fetch QuestionDefs bound to the given node, as the QuestionDef reference is needed to properly represent answers
     //to select questions. obviously, we want to fix this.
-    private static void loadInstanceData (Element node, TreeElement cur, FormDef f) {
+    private static void loadInstanceData(Element node, TreeElement cur, FormDef f) {
         int numChildren = node.getChildCount();
         boolean hasElements = false;
         for (int i = 0; i < numChildren; i++) {
@@ -1988,8 +2021,10 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    /** Finds a questiondef that binds to ref, if the data type is a 'select' question type */
-    public static QuestionDef ghettoGetQuestionDef (int dataType, FormDef f, TreeReference ref) {
+    /**
+     * Finds a questiondef that binds to ref, if the data type is a 'select' question type
+     */
+    public static QuestionDef ghettoGetQuestionDef(int dataType, FormDef f, TreeReference ref) {
         if (dataType == DATATYPE_CHOICE || dataType == DATATYPE_CHOICE_LIST) {
             return FormDef.findQuestionByRef(ref, f);
         } else {
@@ -1997,7 +2032,7 @@ public class XFormParser implements IXFormParserFunctions {
         }
     }
 
-    private void checkDependencyCycles () {
+    private void checkDependencyCycles() {
         _f.reportDependencyCycles();
     }
 
@@ -2007,7 +2042,7 @@ public class XFormParser implements IXFormParserFunctions {
 
     /**
      * Loads a compatible xml instance into FormDef f
-     *
+     * <p>
      * call before f.initialize()!
      */
     private static void loadXmlInstance(FormDef f, Document xmlInst) {
@@ -2036,7 +2071,7 @@ public class XFormParser implements IXFormParserFunctions {
         //     }
     }
 
-    public static String getXMLText (Node n, boolean trim) {
+    public static String getXMLText(Node n, boolean trim) {
         return (n.getChildCount() == 0 ? null : getXMLText(n, 0, trim));
     }
 
@@ -2045,7 +2080,7 @@ public class XFormParser implements IXFormParserFunctions {
      * needed because escape sequences are parsed into consecutive text nodes
      * e.g. "abc&amp;123" --> (abc)(&)(123)
      **/
-    public static String getXMLText (Node node, int i, boolean trim) {
+    public static String getXMLText(Node node, int i, boolean trim) {
         StringBuilder strBuff = null;
 
         String text = node.getText(i);
@@ -2067,7 +2102,7 @@ public class XFormParser implements IXFormParserFunctions {
         return text;
     }
 
-    public static FormInstance restoreDataModel (InputStream input, Class restorableType) throws IOException {
+    public static FormInstance restoreDataModel(InputStream input, Class restorableType) throws IOException {
         Document doc = getXMLDocument(new InputStreamReader(input, "UTF-8"));
         if (doc == null) {
             throw new RuntimeException("syntax error in XML instance; could not parse");
@@ -2075,8 +2110,8 @@ public class XFormParser implements IXFormParserFunctions {
         return restoreDataModel(doc, restorableType);
     }
 
-    public static FormInstance restoreDataModel (Document doc, Class restorableType) {
-        Restorable r = (restorableType != null ? (Restorable)PrototypeFactory.getInstance(restorableType) : null);
+    public static FormInstance restoreDataModel(Document doc, Class restorableType) {
+        Restorable r = (restorableType != null ? (Restorable) PrototypeFactory.getInstance(restorableType) : null);
 
         Element e = doc.getRootElement();
 
@@ -2091,7 +2126,7 @@ public class XFormParser implements IXFormParserFunctions {
         return dm;
     }
 
-    public static FormInstance restoreDataModel (byte[] data, Class restorableType) {
+    public static FormInstance restoreDataModel(byte[] data, Class restorableType) {
         try {
             return restoreDataModel(new ByteArrayInputStream(data), restorableType);
         } catch (IOException e) {
@@ -2103,13 +2138,13 @@ public class XFormParser implements IXFormParserFunctions {
     public static String getVagueLocation(Element e) {
         String path = e.getName();
         Element walker = e;
-        while(walker != null) {
+        while (walker != null) {
             Node n = walker.getParent();
-            if(n instanceof Element) {
-                walker = (Element)n;
+            if (n instanceof Element) {
+                walker = (Element) n;
                 String step = walker.getName();
-                for(int i = 0; i <  walker.getAttributeCount() ; ++i) {
-                    step += "[@" +walker.getAttributeName(i) + "=";
+                for (int i = 0; i < walker.getAttributeCount(); ++i) {
+                    step += "[@" + walker.getAttributeName(i) + "=";
                     step += walker.getAttributeValue(i) + "]";
                 }
                 path = step + "/" + path;
@@ -2128,15 +2163,15 @@ public class XFormParser implements IXFormParserFunctions {
 
     private static String getVagueElementPrintout(Element e, int maxDepth) {
         String elementString = "<" + e.getName();
-        for(int i = 0; i <  e.getAttributeCount() ; ++i) {
+        for (int i = 0; i < e.getAttributeCount(); ++i) {
             elementString += " " + e.getAttributeName(i) + "=\"";
             elementString += e.getAttributeValue(i) + "\"";
         }
-        if(e.getChildCount() > 0) {
+        if (e.getChildCount() > 0) {
             elementString += ">";
-            if(e.getType(0) ==Element.ELEMENT) {
-                if(maxDepth > 0) {
-                    elementString += getVagueElementPrintout((Element)e.getChild(0),maxDepth -1);
+            if (e.getType(0) == Element.ELEMENT) {
+                if (maxDepth > 0) {
+                    elementString += getVagueElementPrintout((Element) e.getChild(0), maxDepth - 1);
                 } else {
                     elementString += "...";
                 }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -1306,7 +1306,7 @@ public class XFormParser implements IXFormParserFunctions {
         );
         itemset.contextRef = getFormElementRef(qparent);
         // this is not valid yet...
-        itemset.nodesetRef = null;
+//        itemset.nodesetRef = null;
         // itemset.nodesetRef = FormInstance.unpackReference(getAbsRef(new XPathReference(path.getReference(true)), itemset.contextRef));
         itemset.copyMode = false;
 
@@ -1335,7 +1335,7 @@ public class XFormParser implements IXFormParserFunctions {
                 }
 
                 XPathPathExpr labelPath = XPathReference.getPathExpr(labelXpath);
-                itemset.labelRef = null;
+//                itemset.labelRef = null;
                 // itemset.labelRef = FormInstance.unpackReference(getAbsRef(new XPathReference(labelPath), itemset.nodesetRef));
                 itemset.labelExpr = new XPathConditional(labelPath);
                 itemset.labelIsItext = labelItext;
@@ -1352,7 +1352,7 @@ public class XFormParser implements IXFormParserFunctions {
                 }
 
                 XPathPathExpr copyPath = XPathReference.getPathExpr(copyXpath);
-                itemset.copyRef = null;
+//                itemset.copyRef = null;
                 // itemset.copyRef = FormInstance.unpackReference(getAbsRef(new XPathReference(copyPath), itemset.nodesetRef));
                 itemset.copyExpr = new XPathConditional(copyPath);
                 itemset.copyMode = true;
@@ -1369,7 +1369,7 @@ public class XFormParser implements IXFormParserFunctions {
                 }
 
                 XPathPathExpr valuePath = XPathReference.getPathExpr(valueXpath);
-                itemset.valueRef = null;
+//                itemset.valueRef = null;
                 // itemset.valueRef = FormInstance.unpackReference(getAbsRef(new XPathReference(valuePath), itemset.nodesetRef));
                 itemset.valueExpr = new XPathConditional(valuePath);
             }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -40,8 +40,6 @@ import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
 import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.SELECTONE;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
-import static org.javarosa.xform.parse.RandomizeHelper.parseSeed;
 import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 import java.io.ByteArrayInputStream;
@@ -1299,13 +1297,6 @@ public class XFormParser implements IXFormParserFunctions {
         String nodesetStr = e.getAttributeValue("", NODESET_ATTR);
         if (nodesetStr == null)
             throw new RuntimeException("No nodeset attribute in element: [" + e.getName() + "]. This is required. (Element Printout:" + XFormSerializer.elementToString(e) + ")");
-
-        if (nodesetStr.startsWith("randomize(")) {
-            itemset.randomize = true;
-            itemset.randomSeed = parseSeed(nodesetStr);
-            nodesetStr = cleanNodesetDefinition(nodesetStr);
-        }
-
         XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
         itemset.nodesetExpr = new XPathConditional(path);
         itemset.contextRef = getFormElementRef(qparent);

--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -6,7 +6,9 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.xpath.expr.XPathPathExpr;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Represents a set of XPath nodes returned from a path or other operation which acts on multiple
@@ -75,6 +77,41 @@ public class XPathNodeset {
         nodeset.pathEvaluated = pathEvaluated;
         nodeset.originalPath = originalPath;
         return nodeset;
+    }
+
+    /**
+     * Builds and returns a copy of a XPathNodeset with nodes in a randomized order.
+     *
+     * @return      a copy of this nodeset with nodes in a randomized order
+     */
+    public static XPathNodeset shuffle(XPathNodeset input) {
+        return shuffle(input, new Random());
+    }
+
+    /**
+     * Builds and returns a copy of a XPathNodeset with nodes in a randomized order.
+     *
+     * @param seed  the seed used when building a Random object to get reproducible results. If null, no seed is used
+     * @return      a copy of this nodeset with nodes in a randomized order
+     */
+    public static XPathNodeset shuffle(XPathNodeset input, long seed) {
+        return shuffle(input, new Random(seed));
+    }
+
+    private static XPathNodeset shuffle(XPathNodeset input, Random r) {
+        List<TreeReference> nodesCopy = new ArrayList<>(input.nodes);
+
+        XPathNodeset result = new XPathNodeset(nodesCopy, input.instance, input.ec);
+
+        for (int i = result.nodes.size() - 1; i > 0; i--) {
+            int randomIndex = r.nextInt(i + 1);
+
+            TreeReference current = result.nodes.remove(i);
+            result.nodes.add(i, result.nodes.get(randomIndex));
+            result.nodes.set(randomIndex, current);
+        }
+
+        return result;
     }
 
     protected void setReferences(List<TreeReference> nodes) {

--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -4,11 +4,10 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xform.parse.RandomizeHelper;
 import org.javarosa.xpath.expr.XPathPathExpr;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Represents a set of XPath nodes returned from a path or other operation which acts on multiple
@@ -85,7 +84,11 @@ public class XPathNodeset {
      * @return      a copy of this nodeset with nodes in a randomized order
      */
     public static XPathNodeset shuffle(XPathNodeset input) {
-        return shuffle(input, new Random());
+        return new XPathNodeset(
+            RandomizeHelper.shuffle(input.nodes),
+            input.instance,
+            input.ec
+        );
     }
 
     /**
@@ -95,23 +98,11 @@ public class XPathNodeset {
      * @return      a copy of this nodeset with nodes in a randomized order
      */
     public static XPathNodeset shuffle(XPathNodeset input, long seed) {
-        return shuffle(input, new Random(seed));
-    }
-
-    private static XPathNodeset shuffle(XPathNodeset input, Random r) {
-        List<TreeReference> nodesCopy = new ArrayList<>(input.nodes);
-
-        XPathNodeset result = new XPathNodeset(nodesCopy, input.instance, input.ec);
-
-        for (int i = result.nodes.size() - 1; i > 0; i--) {
-            int randomIndex = r.nextInt(i + 1);
-
-            TreeReference current = result.nodes.remove(i);
-            result.nodes.add(i, result.nodes.get(randomIndex));
-            result.nodes.set(randomIndex, current);
-        }
-
-        return result;
+        return new XPathNodeset(
+            RandomizeHelper.shuffle(input.nodes, seed),
+            input.instance,
+            input.ec
+        );
     }
 
     protected void setReferences(List<TreeReference> nodes) {

--- a/src/org/javarosa/xpath/XPathNodeset.java
+++ b/src/org/javarosa/xpath/XPathNodeset.java
@@ -31,9 +31,9 @@ import java.util.List;
  */
 public class XPathNodeset {
 
-    private List<TreeReference> nodes;
-    protected DataInstance instance;
-    protected EvaluationContext ec;
+    public List<TreeReference> nodes;
+    public DataInstance instance;
+    public EvaluationContext ec;
     // these are purely for improved error messages
     private String pathEvaluated;
     private String originalPath;

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -466,6 +466,17 @@ public class XPathFuncExpr extends XPathExpression {
                 (String) argVals[0],
                 args.length == 3 ? Encoding.from((String)argVals[2]) : Encoding.BASE64
             );
+        } else if (name.equals("randomize")) {
+            if (!(argVals[0] instanceof XPathNodeset))
+                throw new XPathTypeMismatchException("First argument to randomize must be a nodeset");
+
+            if (args.length == 1)
+                return XPathNodeset.shuffle((XPathNodeset) argVals[0]);
+
+            if (args.length == 2)
+                return XPathNodeset.shuffle((XPathNodeset) argVals[0], toNumeric(argVals[1]).longValue());
+
+            throw new XPathUnhandledException("function \'randomize\' requires 1 or 2 arguments. " + args.length + " provided.");
         } else {
             //check for custom handler
             IFunctionHandler handler = funcHandlers.get(name);

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.xpath.expr;
 
+import java.util.Map;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
@@ -147,7 +148,7 @@ public class XPathFuncExpr extends XPathExpression {
         String name = id.toString();
         Object[] argVals = new Object[args.length];
 
-        HashMap<String, IFunctionHandler> funcHandlers = evalContext.getFunctionHandlers();
+        Map<String, IFunctionHandler> funcHandlers = evalContext.getFunctionHandlers();
 
         //TODO: Func handlers should be able to declare the desire for short circuiting as well
         if (name.equals("if")) {

--- a/test/org/javarosa/core/model/condition/RecalculateTest.java
+++ b/test/org/javarosa/core/model/condition/RecalculateTest.java
@@ -16,8 +16,7 @@ public class RecalculateTest {
 
     @Before
     public void setUp() {
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(r("calculate-now.xml").toString());
+        FormParseInit fpi = new FormParseInit(r("calculate-now.xml"));
         formDef = fpi.getFormDef();
         formDef.initialize(true, new InstanceInitializationFactory());
     }

--- a/test/org/javarosa/core/model/instance/test/TreeElementTests.java
+++ b/test/org/javarosa/core/model/instance/test/TreeElementTests.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -22,9 +23,7 @@ public class TreeElementTests {
     @Test
     public void testPopulate_withNodesAttributes() {
         // Given
-        FormParseInit formParseInit = new FormParseInit();
-        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(),
-                "populate-nodes-attributes.xml").toString());
+        FormParseInit formParseInit = new FormParseInit(r("populate-nodes-attributes.xml"));
 
         FormEntryController formEntryController = formParseInit.getFormEntryController();
 

--- a/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
+++ b/test/org/javarosa/core/model/test/FormIndexSerializationTest.java
@@ -6,15 +6,14 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.nio.file.Paths;
 
-import org.javarosa.core.PathConst;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryController;
 import org.junit.Test;
 
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 
 public class FormIndexSerializationTest {
@@ -54,8 +53,7 @@ public class FormIndexSerializationTest {
 
     @Test
     public void testOnFormController() throws IOException, ClassNotFoundException {
-        FormParseInit formParseInit = new FormParseInit();
-        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "formindex-serialization.xml").toString());
+        FormParseInit formParseInit = new FormParseInit(r("formindex-serialization.xml"));
         FormEntryController formEntryController = formParseInit.getFormEntryController();
 
         FormIndex formIndex = formEntryController.getModel().getFormIndex();

--- a/test/org/javarosa/core/test/FormParseInit.java
+++ b/test/org/javarosa/core/test/FormParseInit.java
@@ -1,6 +1,8 @@
 package org.javarosa.core.test;
 
-import org.javarosa.core.PathConst;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+
+import java.nio.file.Path;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -11,7 +13,6 @@ import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.util.XFormUtils;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.List;
@@ -39,28 +40,23 @@ import org.slf4j.LoggerFactory;
 
 public class FormParseInit {
     private static final Logger logger = LoggerFactory.getLogger(FormParseInit.class);
-    private String FORM_NAME = (new File(PathConst.getTestResourcePath(), "ImageSelectTester.xhtml")).getAbsolutePath();
+    private final String FORM_NAME;
     private FormDef xform;
     private FormEntryController fec;
     private FormEntryModel femodel;
 
 
     public FormParseInit(){
+        FORM_NAME = r("ImageSelectTester.xhtml").toString();
         this.init();
     }
 
-    /**
-     * Set a new form to be parsed (instead of the default), and calls
-     * init() immediately to parse it.  It is uneccessary to call init() again after
-     * using this method.
-     * @param uri URI pointing to the xform.
-     */
-    public void setFormToParse(String uri){
-        FORM_NAME = uri;
+    public FormParseInit(Path form){
+        FORM_NAME = form.toString();
         this.init();
     }
 
-    public void init(){
+    private void init(){
         String xf_name = FORM_NAME;
         FileInputStream is;
         try {

--- a/test/org/javarosa/form/api/FormNavigationTestCase.java
+++ b/test/org/javarosa/form/api/FormNavigationTestCase.java
@@ -63,8 +63,7 @@ public class FormNavigationTestCase {
     // form and then decreasing until the beginning of the form.
     // Verify the expected indices before and after each operation.
     public void testIndices() {
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(r("navigation/" + formName).toString());
+        FormParseInit fpi = new FormParseInit(r("navigation/" + formName));
         FormEntryController formEntryController = fpi.getFormEntryController();
         FormEntryModel formEntryModel = fpi.getFormEntryModel();
 

--- a/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
+++ b/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
@@ -42,8 +42,7 @@ public class OutputInComputedConstraintTextTest {
 
   @Before
   public void setUp() {
-    FormParseInit fpi = new FormParseInit();
-    fpi.setFormToParse(r("constraint-message-error.xml").toString());
+    FormParseInit fpi = new FormParseInit(r("constraint-message-error.xml"));
     formDef = fpi.getFormDef();
     formDef.getLocalizer().setLocale("English");
     ctrl = fpi.getFormEntryController();

--- a/test/org/javarosa/xform/parse/RandomizeHelperTest.java
+++ b/test/org/javarosa/xform/parse/RandomizeHelperTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xform.parse;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotSame;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.parseSeed;
+import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+public class RandomizeHelperTest {
+    @Test
+    public void cleans_the_nodeset_definition() {
+        // We will try different combinations of whitespace and seed presence around the path
+        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path)"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize( /some/path )"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path,33)"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path, 33)"));
+        assertEquals("/some/path", cleanNodesetDefinition("randomize( /some/path , 33)"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_cleaning_a_nodeset_that_does_not_use_randomize_variant_1() {
+        cleanNodesetDefinition("this doesn't start with randomize( )");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_cleaning_a_nodeset_that_does_not_use_randomize_variant_2() {
+        cleanNodesetDefinition("this doesn't end with ) *some filler here*");
+    }
+
+    @Test
+    public void parses_the_seed() {
+        assertNull(parseSeed("randomize(/some/path)"));
+        // We will try different combinations of whitespace
+        assertEquals(new Long(33), parseSeed("randomize(/some/path,33)"));
+        assertEquals(new Long(33), parseSeed("randomize(/some/path, 33)"));
+        assertEquals(new Long(33), parseSeed("randomize(/some/path, 33 )"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_parsing_the_seed_from_a_nodeset_that_does_not_use_randomize_variant_1() {
+        parseSeed("this doesn't start with randomize( )");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_when_parsing_the_seed_from_a_nodeset_that_does_not_use_randomize_variant_2() {
+        parseSeed("this doesn't end with ) *some filler here*");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void throws_when_parsing_a_seed_that_is_not_long() {
+        parseSeed("randomize(/some/path, xyz)");
+    }
+
+    @Test
+    public void given_an_empty_list_shuffle_outputs_a_new_empty_list() {
+        List<?> input = Collections.emptyList();
+        List<?> output = shuffle(input);
+
+        assertNotSame(input, output);
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void given_a_non_empty_nodeset_randomize_outputs_a_nodeset_with_same_elements_shuffled() {
+        List<Wrap<Integer>> input = Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(Wrap::wrap).collect(toList());
+        List<Wrap<Integer>> output = shuffle(input);
+
+        assertEquals(input.size(), output.size());
+        assertTrue(output.containsAll(input));
+        assertTrue(nodesEqualInAnyOrder(input, output));
+        assertFalse(nodesEqualInOrder(input, output));
+        // Although, in fact, this could happen, because it's random.
+    }
+
+    @Test
+    public void given_the_same_seed_randomize_should_output_nodesets_with_the_same_elements_in_the_same_order() {
+        List<Wrap<Integer>> input = Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(Wrap::wrap).collect(toList());
+        List<Wrap<Integer>> output1 = shuffle(input, 42L);
+        List<Wrap<Integer>> output2 = shuffle(input, 42L);
+
+        assertNotSame(output1, output2);
+        assertTrue(nodesEqualInOrder(output1, output2));
+    }
+
+    // We will use this class in the test just to force equality
+    // rules to work by reference, not by value
+    private static class Wrap<T> {
+        private final T t;
+
+        Wrap(T t) {
+            this.t = t;
+        }
+
+        static <U> Wrap<U> wrap(U u) {
+            return new Wrap<>(u);
+        }
+    }
+
+    private static boolean nodesEqualInOrder(List<?> left, List<?> right) {
+        if (left.size() != right.size())
+            return false;
+
+        for (int i = 0; i < left.size(); i++)
+            if (!left.get(i).equals(right.get(i)))
+                return false;
+
+        return true;
+    }
+
+    private static boolean nodesEqualInAnyOrder(List<?> left, List<?> right) {
+        if (left.size() != right.size())
+            return false;
+
+        return left.containsAll(right);
+    }
+}

--- a/test/org/javarosa/xpath/XPathNodesetShuffleTest.java
+++ b/test/org/javarosa/xpath/XPathNodesetShuffleTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.xpath;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.javarosa.xpath.XPathNodeset.shuffle;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.javarosa.core.model.instance.TreeReference;
+import org.junit.Test;
+
+public class XPathNodesetShuffleTest {
+    @Test
+    public void given_an_empty_nodeset_randomize_outputs_a_new_empty_nodeset() {
+        XPathNodeset input = new XPathNodeset(new ArrayList<>(), null, null);
+        XPathNodeset output = shuffle(input);
+
+        assertNotSame(input, output);
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    public void given_a_non_empty_nodeset_randomize_outputs_a_nodeset_with_same_elements_shuffled() {
+        XPathNodeset input = getInputNodeset();
+        XPathNodeset output = shuffle(input);
+
+        assertTrue(nodesEqualInAnyOrder(input, output));
+        assertFalse(nodesEqualInOrder(input, output));
+        // Although, in fact, this could happen, because it's random.
+    }
+
+    @Test
+    public void given_the_same_seed_randomize_should_output_nodesets_with_the_same_elements_in_the_same_order() {
+        XPathNodeset input = getInputNodeset();
+        XPathNodeset output1 = shuffle(input, 42L);
+        XPathNodeset output2 = shuffle(input, 42L);
+
+        assertTrue(nodesEqualInOrder(output1, output2));
+    }
+
+    private static boolean nodesEqualInOrder(XPathNodeset left, XPathNodeset right) {
+        if (left.size() != right.size())
+            return false;
+
+        for (int i = 0; i < left.size(); i++)
+            if (left.getRefAt(i) != right.getRefAt(i))
+                return false;
+
+        return true;
+    }
+
+    private static boolean nodesEqualInAnyOrder(XPathNodeset left, XPathNodeset right) {
+        if (left.size() != right.size())
+            return false;
+
+        Set<TreeReference> leftRefs = new HashSet<>();
+        Set<TreeReference> rightRefs = new HashSet<>();
+        for (int i = 0; i < left.size(); i++) {
+            leftRefs.add(left.getRefAt(i));
+            rightRefs.add(right.getRefAt(i));
+        }
+
+        return leftRefs.containsAll(rightRefs);
+    }
+
+    private static XPathNodeset getInputNodeset() {
+        List<TreeReference> refs = new ArrayList<>();
+        for (int i = 0; i < 10; i++)
+            refs.add(new TreeReference());
+        return new XPathNodeset(refs, null, null);
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_UNBOUND;
+import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XPathFuncExprRandomizeTest {
+
+    private FormDef formDef;
+
+    @Before
+    public void setUp() {
+        // Take a look to the form file:
+        //  - The first pair of fields use randomize without a seed.
+        //  - The second pair of fields use randomize with a seed.
+        FormParseInit fpi = new FormParseInit();
+        fpi.setFormToParse(r("randomize.xml").toString());
+        formDef = fpi.getFormDef();
+    }
+
+    @Test
+    public void fields_without_seed_in_the_same_form_get_a_different_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/fruit1");
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/fruit2");
+
+        assertFalse(nodesEqualInOrder(choices1, choices2));
+    }
+
+    @Test
+    public void the_same_field_without_seed_in_different_instances_gets_a_different_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/fruit1");
+
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/fruit1");
+
+        assertFalse(nodesEqualInOrder(choices1, choices2));
+    }
+
+    @Test
+    public void seeded_fields_in_the_same_form_get_the_same_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/seededFruit1");
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/seededFruit2");
+
+        assertTrue(nodesEqualInOrder(choices1, choices2));
+    }
+
+    @Test
+    public void the_same_seeded_field_in_different_instances_gets_the_same_order_of_choices() {
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/seededFruit2");
+
+        initializeNewInstance(formDef);
+        List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/seededFruit2");
+
+        assertTrue(nodesEqualInOrder(choices1, choices2));
+    }
+
+    private static void initializeNewInstance(FormDef formDef) {
+        formDef.initialize(true, new InstanceInitializationFactory());
+    }
+
+    private List<SelectChoice> getSelectChoices(FormDef formDef, String ref) {
+        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
+        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
+        return formEntryPrompt.getSelectChoices();
+    }
+
+    private FormIndex getFormIndex(FormDef formDef, TreeReference ref) {
+        for (int localIndex = 0, lastIndex = formDef.getChildren().size(); localIndex < lastIndex; localIndex++)
+            if (formDef.getChild(localIndex).getBind().getReference().equals(ref))
+                return new FormIndex(localIndex, 0, ref);
+        throw new IllegalArgumentException("Reference " + ref + " not found");
+    }
+
+    private static boolean nodesEqualInOrder(List<SelectChoice> left, List<SelectChoice> right) {
+        if (left.size() != right.size())
+            return false;
+
+        for (int i = 0; i < left.size(); i++)
+            if (!left.get(i).getValue().equals(right.get(i).getValue()))
+                return false;
+
+        return true;
+    }
+
+    private static TreeReference absoluteRef(String path) {
+        TreeReference tr = new TreeReference();
+        tr.setRefLevel(REF_ABSOLUTE);
+        tr.setContext(CONTEXT_ABSOLUTE);
+        tr.setInstanceName(null);
+        Arrays.stream(path.split("/"))
+            .filter(s -> !s.isEmpty())
+            .forEach(s -> tr.add(s, INDEX_UNBOUND));
+        return tr;
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -56,8 +56,7 @@ public class XPathFuncExprRandomizeTest {
         // Take a look to the form file:
         //  - The first pair of fields use randomize without a seed.
         //  - The second pair of fields use randomize with a seed.
-        FormParseInit fpi = new FormParseInit();
-        fpi.setFormToParse(r("randomize.xml").toString());
+        FormParseInit fpi = new FormParseInit(r("randomize.xml"));
         formDef = fpi.getFormDef();
     }
 


### PR DESCRIPTION
This branch is based on #296 and the actual changes start with commit https://github.com/opendatakit/javarosa/commit/04745a54af978401a98a4453a009232de5ceb754

This is an exploration branch I'm working on to add broad support for the randomize function().

- Now an `ItemsetBinding` can be on one of these two states:
  - All its `*Ref` members have been resolved on initialization because we have a path in the nodeset definition
  - A nodeset has been eval-ed out from the nodeset defintion, which holds an expression.
- By making all the `*Ref` members private, we force caller sites to use getter methods that will check the presence of the eval-ed Nodeset or the `*Ref` members and act accordingly.

Currently, this implementation passes all the tests from #296 except for:
- `XPathFuncExprRandomizeTest.the_same_seeded_field_in_different_instances_from_deserialized_forms_gets_the_same_order_of_choices`
- `XPathFuncExprRandomizeTest.the_same_field_without_seed_in_different_instances_gets_a_different_order_of_choices`

I know it's heavy reading, but I would appreciate any thoughts on the strategy. Please, ask anything I should have to expand on this explanation.

Tagging @lognaturel and @dcbriccetti for advice.