### PR TITLE
Add logging to XPathEqExpr and XPathPathExpr

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathEqExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathEqExpr.java
@@ -25,71 +25,77 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.Math.abs;
+import static org.javarosa.xpath.expr.XPathFuncExpr.toBoolean;
+import static org.javarosa.xpath.expr.XPathFuncExpr.toNumeric;
+import static org.javarosa.xpath.expr.XPathFuncExpr.unpack;
 
 public class XPathEqExpr extends XPathBinaryOpExpr {
+    private static final Logger logger = LoggerFactory.getLogger(XPathEqExpr.class.getSimpleName());
     public boolean equal;
 
-    public XPathEqExpr () { } //for deserialization
+    /** Deserialization constructor */
+    public XPathEqExpr() {
+        logger.debug("XPathEqExpr{}()", id());
+    }
 
-    public XPathEqExpr (boolean equal, XPathExpression a, XPathExpression b) {
+    public XPathEqExpr(boolean equal, XPathExpression a, XPathExpression b) {
         super(a, b);
         this.equal = equal;
+        logger.debug("XPathEqExpr{}({}, {}, {})", id(), equal, a, b);
     }
 
-    public Object eval (DataInstance model, EvaluationContext evalContext) {
-        Object aval = XPathFuncExpr.unpack(a.eval(model, evalContext));
-        Object bval = XPathFuncExpr.unpack(b.eval(model, evalContext));
-        boolean eq = false;
+    @Override
+    public Object eval(DataInstance model, EvaluationContext evalContext) {
+        logger.debug("XPathEqExpr{}.eval starting. model: {}, candidate: {}, expecting equal: {}", id(), model,
+            evalContext.candidateValue == null ? "None" : evalContext.candidateValue.getDisplayText(), equal);
+        final Object aval = unpack(a.eval(model, evalContext));
+        final Object bval = unpack(b.eval(model, evalContext));
+        final boolean eq;
 
         if (aval instanceof Boolean || bval instanceof Boolean) {
-            if (!(aval instanceof Boolean)) {
-                aval = XPathFuncExpr.toBoolean(aval);
-            } else if (!(bval instanceof Boolean)) {
-                bval = XPathFuncExpr.toBoolean(bval);
-            }
-
-            boolean ba = ((Boolean)aval).booleanValue();
-            boolean bb = ((Boolean)bval).booleanValue();
-            eq = (ba == bb);
+            boolean a = aval instanceof Boolean ? (Boolean) aval : toBoolean(aval);
+            boolean b = bval instanceof Boolean ? (Boolean) bval : toBoolean(bval);
+            eq = a == b;
         } else if (aval instanceof Double || bval instanceof Double) {
-            if (!(aval instanceof Double)) {
-                aval = XPathFuncExpr.toNumeric(aval);
-            } else if (!(bval instanceof Double)) {
-                bval = XPathFuncExpr.toNumeric(bval);
-            }
-
-            double fa = ((Double)aval).doubleValue();
-            double fb = ((Double)bval).doubleValue();
-            eq = Math.abs(fa - fb) < 1.0e-12;
+            double a = aval instanceof Double ? (Double) aval : toNumeric(aval);
+            double b = bval instanceof Double ? (Double) bval : toNumeric(bval);
+            eq = abs(a - b) < 1e-12;
         } else {
-            aval = XPathFuncExpr.toString(aval);
-            bval = XPathFuncExpr.toString(bval);
-            eq = (aval.equals(bval));
+            eq = XPathFuncExpr.toString(aval).equals(XPathFuncExpr.toString(bval));
         }
 
-        return new Boolean(equal ? eq : !eq);
+        boolean result = equal == eq;
+        logger.debug("XPathEqExpr{}.eval returning {}. a: {}, b: {}", id(), result, aval, bval);
+        return result;
     }
 
-    public String toString () {
+    public String toString() {
         return super.toString(equal ? "==" : "!=");
     }
 
-    public boolean equals (Object o) {
-        if (o instanceof XPathEqExpr) {
-            XPathEqExpr x = (XPathEqExpr)o;
-            return super.equals(o) && equal == x.equal;
-        } else {
-            return false;
-        }
+    public boolean equals(Object o) {
+        return o instanceof XPathEqExpr && (super.equals(o) && equal == ((XPathEqExpr) o).equal);
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         equal = ExtUtil.readBool(in);
         super.readExternal(in, pf);
+        logger.debug("XPathEqExpr{}.readExternal {}, {}, {}", id(), a, b, equal);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
+        logger.debug("XPathEqExpr{}.writeExternal", id());
         ExtUtil.writeBool(out, equal);
         super.writeExternal(out);
+    }
+
+    private String id() {
+        return "@" + Integer.toHexString(System.identityHashCode(this));
     }
 }


### PR DESCRIPTION
Add logging to `XPathEqExpr` and `XPathPathExpr` to help show their behavior. Do some safe cleanup of bloated code in `XPathEqExpr`.

See https://github.com/opendatakit/collect/issues/2041

#### What has been done to verify that this works as intended?
Tests pass
#### Why is this the best possible solution? Were any other approaches considered?
N/A
#### Are there any risks to merging this code? If so, what are they?
No