### PR TITLE
Improve XPathPathExpr code quality

### DIFF
--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -115,7 +115,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
         // To construct the xxxRef, we need the full model, which wasn't available before now.
         // Compute the xxxRefs now.
         nodesetRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(
-                ((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference(true)), contextRef));
+                ((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference()), contextRef));
         if ( labelExpr != null ) {
             labelRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) labelExpr).getExpr())),
                     nodesetRef));

--- a/src/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -21,6 +21,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -49,8 +50,6 @@ import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapList;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xform.util.XFormAnswerDataSerializer;
-import org.javarosa.xpath.XPathException;
-import org.javarosa.xpath.XPathMissingInstanceException;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnsupportedException;
@@ -70,209 +69,134 @@ public class XPathPathExpr extends XPathExpression {
     //for INIT_CONTEXT_EXPR only
     public XPathFilterExpr filtExpr;
 
-    public XPathPathExpr () { } //for deserialization
+    public XPathPathExpr() {
+    } //for deserialization
 
-    public XPathPathExpr (int init_context, XPathStep[] steps) {
+    public XPathPathExpr(int init_context, XPathStep[] steps) {
         this.init_context = init_context;
         this.steps = steps;
     }
 
-    public XPathPathExpr (XPathFilterExpr filtExpr, XPathStep[] steps) {
+    public XPathPathExpr(XPathFilterExpr filtExpr, XPathStep[] steps) {
         this(INIT_CONTEXT_EXPR, steps);
         this.filtExpr = filtExpr;
-    }
-
-    public TreeReference getReference () throws XPathUnsupportedException {
-        return getReference(false);
     }
 
     /**
      * translate an xpath path reference into a TreeReference
      * TreeReferences only support a subset of true xpath paths; restrictions are:
-     *   simple child name tests 'child::name', '.', and '..' allowed only
-     *   no predicates
-     *   all '..' steps must come before anything else
+     * simple child name tests 'child::name', '.', and '..' allowed only
+     * no predicates
+     * all '..' steps must come before anything else
      */
-    public TreeReference getReference (boolean allowPredicates) throws XPathUnsupportedException {
-        TreeReference ref = new TreeReference();
+    public TreeReference getReference() throws XPathUnsupportedException {
+        final TreeReference ref = new TreeReference();
         boolean parentsAllowed;
         switch (init_context) {
-        case XPathPathExpr.INIT_CONTEXT_ROOT:
-            ref.setRefLevel(TreeReference.REF_ABSOLUTE);
-            parentsAllowed = false;
-            break;
-        case XPathPathExpr.INIT_CONTEXT_RELATIVE:
-            ref.setRefLevel(0);
-            parentsAllowed = true;
-            break;
-        case XPathPathExpr.INIT_CONTEXT_EXPR:
-            if (this.filtExpr.x != null && this.filtExpr.x instanceof XPathFuncExpr)
-            {
-                XPathFuncExpr func = (XPathFuncExpr)(this.filtExpr.x);
-                if(func.id.toString().equals("instance"))
-                {
-                    ref.setRefLevel(TreeReference.REF_ABSOLUTE); //i assume when refering the non main instance you have to be absolute
-                    parentsAllowed = false;
-                    if(func.args.length != 1)
-                    {
-                        throw new XPathUnsupportedException("instance() function used with "+func.args.length+ " arguements. Expecting 1 arguement");
+            case XPathPathExpr.INIT_CONTEXT_ROOT:
+                ref.setRefLevel(TreeReference.REF_ABSOLUTE);
+                parentsAllowed = false;
+                break;
+            case XPathPathExpr.INIT_CONTEXT_RELATIVE:
+                ref.setRefLevel(0);
+                parentsAllowed = true;
+                break;
+            case XPathPathExpr.INIT_CONTEXT_EXPR:
+                if (filtExpr.x instanceof XPathFuncExpr) {
+                    XPathFuncExpr func = (XPathFuncExpr) (this.filtExpr.x);
+                    switch (func.id.toString()) {
+                        case "instance":
+                            ref.setRefLevel(TreeReference.REF_ABSOLUTE); //i assume when refering the non main instance you have to be absolute
+
+                            parentsAllowed = false;
+                            if (func.args.length != 1) {
+                                throw new XPathUnsupportedException("instance() function used with " + func.args.length + " arguments. Expecting 1 argument");
+                            }
+                            if (!(func.args[0] instanceof XPathStringLiteral)) {
+                                throw new XPathUnsupportedException("instance() function expecting 1 string literal argument");
+                            }
+                            XPathStringLiteral strLit = (XPathStringLiteral) (func.args[0]);
+                            //we've got a non-standard instance in play, watch out
+                            if (strLit.s == null) {
+                                // absolute reference to the main instance
+                                ref.setContext(TreeReference.CONTEXT_ABSOLUTE);
+                                ref.setInstanceName(null);
+                            } else {
+                                ref.setContext(TreeReference.CONTEXT_INSTANCE);
+                                ref.setInstanceName(strLit.s);
+                            }
+                            break;
+                        case "current":
+                            parentsAllowed = true;
+                            ref.setContext(TreeReference.CONTEXT_ORIGINAL);
+                            break;
+                        default:
+                            //We only support expression root contexts for instance refs, everything else is an illegal filter
+                            throw new XPathUnsupportedException("filter expression");
                     }
-                    if(!(func.args[0] instanceof XPathStringLiteral))
-                    {
-                        throw new XPathUnsupportedException("instance() function expecting 1 string literal arguement arguement");
-                    }
-                    XPathStringLiteral strLit = (XPathStringLiteral)(func.args[0]);
-                    //we've got a non-standard instance in play, watch out
-                    if(strLit.s == null) {
-                        // absolute reference to the main instance
-                        ref.setContext(TreeReference.CONTEXT_ABSOLUTE);
-                        ref.setInstanceName(null);
-                    } else{
-                        ref.setContext(TreeReference.CONTEXT_INSTANCE);
-                        ref.setInstanceName(strLit.s);
-                    }
-                } else if(func.id.toString().equals("current")){
-                    parentsAllowed = true;
-                    ref.setContext(TreeReference.CONTEXT_ORIGINAL);
                 } else {
                     //We only support expression root contexts for instance refs, everything else is an illegal filter
                     throw new XPathUnsupportedException("filter expression");
                 }
-            } else {
-                //We only support expression root contexts for instance refs, everything else is an illegal filter
-                throw new XPathUnsupportedException("filter expression");
-            }
 
-            break;
-        default: throw new XPathUnsupportedException("filter expression");
+                break;
+            default:
+                throw new XPathUnsupportedException("filter expression");
         }
         for (int i = 0; i < steps.length; i++) {
-            XPathStep step = steps[i];
-            if (step.axis == XPathStep.AXIS_SELF) {
-                if (step.test != XPathStep.TEST_TYPE_NODE) {
+            final XPathStep step = steps[i];
+            switch (step.axis) {
+                case XPathStep.AXIS_SELF:
+                    if (step.test != XPathStep.TEST_TYPE_NODE) {
+                        throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
+                    }
+                    break;
+                case XPathStep.AXIS_PARENT:
+                    if (!parentsAllowed || step.test != XPathStep.TEST_TYPE_NODE) {
+                        throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
+                    } else {
+                        ref.incrementRefLevel();
+                    }
+                    break;
+                case XPathStep.AXIS_ATTRIBUTE:
+                    if (step.test == XPathStep.TEST_NAME) {
+                        ref.add(step.name.toString(), TreeReference.INDEX_ATTRIBUTE);
+                        parentsAllowed = false;
+                        //TODO: Can you step back from an attribute, or should this always be
+                        //the last step?
+                    } else {
+                        throw new XPathUnsupportedException("attribute step other than 'attribute::name");
+                    }
+                    break;
+                case XPathStep.AXIS_CHILD:
+                    if (step.test == XPathStep.TEST_NAME) {
+                        ref.add(step.name.toString(), TreeReference.INDEX_UNBOUND);
+                        parentsAllowed = true;
+                    } else if (step.test == XPathStep.TEST_NAME_WILDCARD) {
+                        ref.add(TreeReference.NAME_WILDCARD, TreeReference.INDEX_UNBOUND);
+                        parentsAllowed = true;
+                    } else {
+                        throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
+                    }
+                    break;
+                default:
                     throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
-                }
-            } else if (step.axis == XPathStep.AXIS_PARENT) {
-                if (!parentsAllowed || step.test != XPathStep.TEST_TYPE_NODE) {
-                    throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
-                } else {
-                    ref.incrementRefLevel();
-                }
-            } else if (step.axis == XPathStep.AXIS_ATTRIBUTE) {
-                if (step.test == XPathStep.TEST_NAME) {
-                    ref.add(step.name.toString(), TreeReference.INDEX_ATTRIBUTE);
-                    parentsAllowed = false;
-                    //TODO: Can you step back from an attribute, or should this always be
-                    //the last step?
-                } else {
-                    throw new XPathUnsupportedException("attribute step other than 'attribute::name");
-                }
-            }else if (step.axis == XPathStep.AXIS_CHILD) {
-                if (step.test == XPathStep.TEST_NAME) {
-                    ref.add(step.name.toString(), TreeReference.INDEX_UNBOUND);
-                    parentsAllowed = true;
-                } else if(step.test == XPathStep.TEST_NAME_WILDCARD) {
-                    ref.add(TreeReference.NAME_WILDCARD, TreeReference.INDEX_UNBOUND);
-                    parentsAllowed = true;
-                } else {
-                    throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
-                }
-            } else {
-                throw new XPathUnsupportedException("step other than 'child::name', '.', '..'");
             }
 
-            if(step.predicates.length > 0) {
-                int refLevel = ref.getRefLevel();
-            List<XPathExpression> v = new ArrayList<XPathExpression>(step.predicates.length);
-                for(int j = 0; j < step.predicates.length; j++)
-                {
-                    v.add(step.predicates[j]);
-                }
+            if (step.predicates.length > 0) {
+                List<XPathExpression> v = new ArrayList<XPathExpression>(step.predicates.length);
+                Collections.addAll(v, step.predicates);
                 ref.addPredicate(i, v);
             }
         }
         return ref;
     }
 
-    public XPathNodeset eval (DataInstance m, EvaluationContext ec) {
-        TreeReference genericRef = getReference();
-
-        TreeReference ref;
-        if(genericRef.getContext() == TreeReference.CONTEXT_ORIGINAL) {
-            ref = genericRef.contextualize(ec.getOriginalContext());
-        } else {
-            ref = genericRef.contextualize(ec.getContextRef());
-        }
-
-        //We don't necessarily know the model we want to be working with until we've contextualized the
-        //node
-
-        //check if this nodeset refers to a non-main instance
-        if(ref.getInstanceName() != null && ref.isAbsolute())
-        {
-            DataInstance nonMain = ec.getInstance(ref.getInstanceName());
-            if(nonMain != null)
-            {
-                m = nonMain;
-            }
-            else
-            {
-                throw new XPathMissingInstanceException(ref.getInstanceName(), "Instance referenced by " + ref.toString(true) + " does not exist");
-            }
-        } else {
-            //TODO: We should really stop passing 'm' around and start just getting the right instance from ec
-            //at a more central level
-            m = ec.getMainInstance();
-
-            if(m == null) {
-                    String refStr = ref == null ? "" : ref.toString(true);
-                    throw new XPathException("Cannot evaluate the reference [" + refStr + "] in the current evaluation context. No default instance has been declared!");
-            }
-        }
-
-        // regardless of the above, we want to ensure there is a definition
-        if(m.getRoot() == null) {
-            //This instance is _declared_, but doesn't actually have any data in it.
-            throw new XPathMissingInstanceException(ref.getInstanceName(), "Instance referenced by " + ref.toString(true) + " has not been loaded");
-        }
-
-        // this makes no sense...
-//        if (ref.isAbsolute() && m.getTemplatePath(ref) == null) {
-//            List<TreeReference> nodesetRefs = new List<TreeReference>();
-//            return new XPathNodeset(nodesetRefs, m, ec);
-//        }
-
-      List<TreeReference> nodesetRefs = ec.expandReference(ref);
-
-        //to fix conditions based on non-relevant data, filter the nodeset by relevancy
-        for (int i = 0; i < nodesetRefs.size(); i++) {
-            if (!m.resolveReference(nodesetRefs.get(i)).isRelevant()) {
-                nodesetRefs.remove(i);
-                i--;
-            }
-        }
-
-        return new XPathNodeset(nodesetRefs, m, ec);
+    public XPathNodeset eval(DataInstance unusedDataInstance, EvaluationContext ec) {
+        return new XPathPathExprEval().eval(getReference(), ec);
     }
 
-//
-//    boolean nodeset = forceNodeset;
-//    if (!nodeset) {
-//        //is this a nodeset? it is if the ref contains any unbound multiplicities AND the unbound nodes are repeatable
-//        //the way i'm calculating this sucks; there has got to be an easier way to find out if a node is repeatable
-//        TreeReference repeatTestRef = TreeReference.rootRef();
-//        for (int i = 0; i < ref.size(); i++) {
-//            repeatTestRef.add(ref.getName(i), ref.getMultiplicity(i));
-//            if (ref.getMultiplicity(i) == TreeReference.INDEX_UNBOUND) {
-//                if (m.getTemplate(repeatTestRef) != null) {
-//                    nodeset = true;
-//                    break;
-//                }
-//            }
-//        }
-//    }
-
-    public static Object getRefValue (DataInstance model, EvaluationContext ec, TreeReference ref) {
+    public static Object getRefValue(DataInstance model, EvaluationContext ec, TreeReference ref) {
         if (ec.isConstraint && ref.equals(ec.getContextRef())) {
             //ITEMSET TODO: need to update this; for itemset/copy constraints, need to simulate a whole xml sub-tree here
             Object result = unpackValue(ec.candidateValue);
@@ -295,7 +219,7 @@ public class XPathPathExpr extends XPathExpression {
         return result;
     }
 
-    public static Object unpackValue (IAnswerData val) {
+    public static Object unpackValue(IAnswerData val) {
         if (val == null) {
             return "";
         } else if (val instanceof UncastData) {
@@ -309,7 +233,7 @@ public class XPathPathExpr extends XPathExpression {
         } else if (val instanceof StringData) {
             return val.getValue();
         } else if (val instanceof SelectOneData) {
-            return ((Selection)val.getValue()).getValue();
+            return ((Selection) val.getValue()).getValue();
         } else if (val instanceof SelectMultiData) {
             return (new XFormAnswerDataSerializer()).serializeAnswerData(val);
         } else if (val instanceof DateData) {
@@ -335,14 +259,20 @@ public class XPathPathExpr extends XPathExpression {
         }
     }
 
-    public String toString () {
+    public String toString() {
         StringBuilder sb = new StringBuilder();
 
         sb.append("{path-expr:");
         switch (init_context) {
-        case INIT_CONTEXT_ROOT: sb.append("abs"); break;
-        case INIT_CONTEXT_RELATIVE: sb.append("rel"); break;
-        case INIT_CONTEXT_EXPR: sb.append(filtExpr.toString()); break;
+            case INIT_CONTEXT_ROOT:
+                sb.append("abs");
+                break;
+            case INIT_CONTEXT_RELATIVE:
+                sb.append("rel");
+                break;
+            case INIT_CONTEXT_EXPR:
+                sb.append(filtExpr.toString());
+                break;
         }
         sb.append(",{");
         for (int i = 0; i < steps.length; i++) {
@@ -355,16 +285,16 @@ public class XPathPathExpr extends XPathExpression {
         return sb.toString();
     }
 
-    public boolean equals (Object o) {
+    public boolean equals(Object o) {
         if (o instanceof XPathPathExpr) {
-            XPathPathExpr x = (XPathPathExpr)o;
+            XPathPathExpr x = (XPathPathExpr) o;
 
             //Shortcuts for easily comparable values
-            if(init_context != x.init_context || steps.length != x.steps.length) {
+            if (init_context != x.init_context || steps.length != x.steps.length) {
                 return false;
             }
 
-            return ExtUtil.arrayEquals(steps, x.steps) && (init_context == INIT_CONTEXT_EXPR ? filtExpr.equals(x.filtExpr) : true);
+            return ExtUtil.arrayEquals(steps, x.steps) && (init_context != INIT_CONTEXT_EXPR || filtExpr.equals(x.filtExpr));
         } else {
             return false;
         }
@@ -382,9 +312,9 @@ public class XPathPathExpr extends XPathExpression {
      * \/data\/path\/to
      * will "match"
      * \/data\/*\/to
-     *
+     * <p>
      * even though they are not equal.
-     *
+     * <p>
      * Matching is reflexive, consistent, and symmetric, but _not_ transitive.
      *
      * @param o
@@ -392,10 +322,10 @@ public class XPathPathExpr extends XPathExpression {
      */
     public boolean matches(XPathExpression o) {
         if (o instanceof XPathPathExpr) {
-            XPathPathExpr x = (XPathPathExpr)o;
+            XPathPathExpr x = (XPathPathExpr) o;
 
             //Shortcuts for easily comparable values
-            if(init_context != x.init_context || steps.length != x.steps.length) {
+            if (init_context != x.init_context || steps.length != x.steps.length) {
                 return false;
             }
 
@@ -417,29 +347,31 @@ public class XPathPathExpr extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         init_context = ExtUtil.readInt(in);
         if (init_context == INIT_CONTEXT_EXPR) {
-            filtExpr = (XPathFilterExpr)ExtUtil.read(in, XPathFilterExpr.class, pf);
+            filtExpr = (XPathFilterExpr) ExtUtil.read(in, XPathFilterExpr.class, pf);
         }
 
-      List<Object> v = (List<Object>)ExtUtil.read(in, new ExtWrapList(XPathStep.class), pf);
+        List<Object> v = (List<Object>) ExtUtil.read(in, new ExtWrapList(XPathStep.class), pf);
         steps = new XPathStep[v.size()];
         for (int i = 0; i < steps.length; i++)
-            steps[i] = ((XPathStep)v.get(i)).intern();
+            steps[i] = ((XPathStep) v.get(i)).intern();
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, init_context);
         if (init_context == INIT_CONTEXT_EXPR) {
             ExtUtil.write(out, filtExpr);
         }
 
-      List<XPathStep> v = Arrays.asList(steps);
+        List<XPathStep> v = Arrays.asList(steps);
         ExtUtil.write(out, new ExtWrapList(v));
     }
 
-    public static XPathPathExpr fromRef (TreeReference ref) {
+    public static XPathPathExpr fromRef(TreeReference ref) {
         XPathPathExpr path = new XPathPathExpr();
         path.init_context = (ref.isAbsolute() ? INIT_CONTEXT_ROOT : INIT_CONTEXT_RELATIVE);
         path.steps = new XPathStep[ref.size()];
@@ -453,20 +385,19 @@ public class XPathPathExpr extends XPathExpression {
         return path;
     }
 
-    public Object pivot (DataInstance model, EvaluationContext evalContext, List<Object> pivots, Object sentinal) throws UnpivotableExpressionException {
-        TreeReference ref = this.getReference();
+    @Override
+    public Object pivot(DataInstance model, EvaluationContext evalContext, List<Object> pivots, Object sentinal) throws UnpivotableExpressionException {
+        TreeReference ref = getReference();
         //Either concretely the sentinal, or "."
-        if(ref.equals(sentinal) || (ref.getRefLevel() == 0)) {
+        if (ref.equals(sentinal) || (ref.getRefLevel() == 0)) {
             return sentinal;
         }
-        else {
-            //It's very, very hard to figure out how to pivot predicates. For now, just skip it
-            for(int i = 0 ; i < ref.size(); ++i) {
-                if(ref.getPredicate(i) != null && ref.getPredicate(i).size() > 0) {
-                    throw new UnpivotableExpressionException("Can't pivot filtered treereferences. Ref: " + ref.toString(true) + " has predicates.");
-                }
+        //It's very, very hard to figure out how to pivot predicates. For now, just skip it
+        for (int i = 0; i < ref.size(); ++i) {
+            if (ref.getPredicate(i) != null && ref.getPredicate(i).size() > 0) {
+                throw new UnpivotableExpressionException("Can't pivot filtered treereferences. Ref: " + ref.toString(true) + " has predicates.");
             }
-            return this.eval(model, evalContext);
         }
+        return eval(model, evalContext);
     }
 }

--- a/src/org/javarosa/xpath/expr/XPathPathExprEval.java
+++ b/src/org/javarosa/xpath/expr/XPathPathExprEval.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xpath.XPathException;
+import org.javarosa.xpath.XPathMissingInstanceException;
+import org.javarosa.xpath.XPathNodeset;
+
+import java.util.List;
+
+/** The eval operation of XPathPathExpr */
+public class XPathPathExprEval {
+
+    public XPathNodeset eval(TreeReference reference, EvaluationContext ec) {
+        TreeReference ref = getContextualizedTreeReference(reference, ec);
+        DataInstance dataInstance = getDataInstance(ec, ref);
+        List<TreeReference> nodesetRefs = ec.expandReference(ref);
+        removeIrrelevantNodesets(dataInstance, nodesetRefs);
+        return new XPathNodeset(nodesetRefs, dataInstance, ec);
+    }
+
+    /** Removes irrelevant nodesets, to fix conditions based on non-relevant data */
+    private void removeIrrelevantNodesets(DataInstance dataInstance, List<TreeReference> nodesetRefs) {
+        for (int i = 0; i < nodesetRefs.size(); i++) {
+            if (!dataInstance.resolveReference(nodesetRefs.get(i)).isRelevant()) {
+                nodesetRefs.remove(i);
+                i--;
+            }
+        }
+    }
+
+    private DataInstance getDataInstance(EvaluationContext ec, TreeReference ref) {
+        final DataInstance dataInstance;
+
+        if (refersToNonMainInstance(ref)) {
+            final DataInstance nonMainInstance = ec.getInstance(ref.getInstanceName());
+            if (nonMainInstance != null) {
+                dataInstance = nonMainInstance;
+            } else {
+                throw new XPathMissingInstanceException(ref.getInstanceName(),
+                    "Instance referenced by " + ref.toString(true) + " does not exist");
+            }
+        } else {
+            //TODO: We should really stop passing 'dataInstance' around and start just getting the right instance from ec at a more central level
+            dataInstance = ec.getMainInstance();
+
+            if (dataInstance == null) {
+                throw new XPathException("Cannot evaluate the reference [" + ref.toString(true) +
+                    "] in the current evaluation context. No default instance has been declared!");
+            }
+        }
+        // Regardless of the above, we want to ensure there is a definition
+        if (dataInstance.getRoot() == null) {
+            //This instance is _declared_, but doesn't actually have any data in it.
+            throw new XPathMissingInstanceException(ref.getInstanceName(),
+                "Instance referenced by " + ref.toString(true) + " has not been loaded");
+        }
+
+        return dataInstance;
+    }
+
+    private boolean refersToNonMainInstance(TreeReference ref) {
+        return ref.getInstanceName() != null && ref.isAbsolute();
+    }
+
+    private TreeReference getContextualizedTreeReference(TreeReference genericRef, EvaluationContext ec) {
+        // We don't necessarily know the model we want to be working with until we've contextualized the node
+        TreeReference contextRef = genericRef.getContext() == TreeReference.CONTEXT_ORIGINAL ?
+            ec.getOriginalContext() : ec.getContextRef();
+        return genericRef.contextualize(contextRef);
+    }
+}


### PR DESCRIPTION
Move eval method from XPathPathExpr to new class, XPathPathExprEval, and modernize its code and make it much more understandable.

(cherry picked from commit 2d5998d)

#### What has been done to verify that this works as intended?
I saw that all tests still pass, and I stepped through the code in the debugger.

#### Why is this the best possible solution? Were any other approaches considered?
The goal was to separate the `eval` concern from the rest of XPathPathExpr, and to modernize code using automatic IDEA refactorings.

#### Are there any risks to merging this code? If so, what are they?
The risk seems low. I used refactorings like extract method, which are safe.