### PR TITLE
Fix randomize test form and add extra tests

### DIFF
--- a/resources/org/javarosa/xpath/expr/randomize.xml
+++ b/resources/org/javarosa/xpath/expr/randomize.xml
@@ -59,8 +59,8 @@
             <bind nodeset="/randomize/fruit2" type="select1"/>
             <bind nodeset="/randomize/seededFruit1" type="select1"/>
             <bind nodeset="/randomize/seededFruit2" type="select1"/>
-            <bind nodeset="/randomize/randomValue" calculate="max(randomize(instance('numbers')/root/value))"/>
-            <bind nodeset="/randomize/seededRandomValue" calculate="max(randomize(instance('numbers')/root/value, 42))"/>
+            <bind nodeset="/randomize/randomValue" calculate="max(randomize(instance('numbers')/root/item))"/>
+            <bind nodeset="/randomize/seededRandomValue" calculate="max(randomize(instance('numbers')/root/item, 42))"/>
             <bind calculate="concat('uuid:', uuid())" nodeset="/randomize/meta/instanceID" readonly="true()" type="string"/>
         </model>
     </h:head>

--- a/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -23,6 +23,7 @@ import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
 import static org.javarosa.core.model.instance.TreeReference.INDEX_UNBOUND;
 import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -113,6 +114,20 @@ public class XPathFuncExprRandomizeTest {
         assertTrue(nodesEqualInOrder(choices1, choices2));
     }
 
+    @Test
+    public void randomize_function_can_be_used_outside_itemset_nodeset_definitions() {
+        initializeNewInstance(formDef);
+        // The ref /randomize/randomValue is the max from a randomized nodeset of numbers from 1 to 6
+        assertEquals(6, getAnswerValue(formDef, "/randomize/randomValue"));
+    }
+
+    @Test
+    public void seeded_randomize_function_can_be_used_outside_itemset_nodeset_definitions() {
+        initializeNewInstance(formDef);
+        // The ref /randomize/seededRandomValue is the max from a randomized nodeset of numbers from 1 to 6
+        assertEquals(6, getAnswerValue(formDef, "/randomize/seededRandomValue"));
+    }
+
     private FormDef serializeAndDeserializeForm(FormDef formDef) throws IOException, DeserializationException {
         // Initialize serialization
         PrototypeManager.registerPrototypes(JavaRosaCoreModule.classNames);
@@ -142,6 +157,12 @@ public class XPathFuncExprRandomizeTest {
         FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
         FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
         return formEntryPrompt.getSelectChoices();
+    }
+
+    private Object getAnswerValue(FormDef formDef, String ref) {
+        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
+        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
+        return formEntryPrompt.getAnswerValue().getValue();
     }
 
     private FormIndex getFormIndex(FormDef formDef, TreeReference ref) {


### PR DESCRIPTION
This fixes some defects that got merged in #296 by accident:
- Fixed the randomize function params in the test form
- Added specific tests that make sure calculated fields that use randomize get some expected value

#### What has been done to verify that this works as intended?
Run the tests & checked coverage report to ensure tests exercise the code.

#### Why is this the best possible solution? Were any other approaches considered?
Nope.

#### Are there any risks to merging this code? If so, what are they?
Nope.