### PR TITLE
Add DataType enum

### DIFF
--- a/src/org/javarosa/core/model/Constants.java
+++ b/src/org/javarosa/core/model/Constants.java
@@ -16,7 +16,12 @@
 
 package org.javarosa.core.model;
 
-/** Constants shared throughout classes in the containing package. */
+/**
+ * Constants shared throughout classes in the containing package.
+ * <p/>
+ * Where possible use {@link DataType} instead of the DATATYPE_*
+ * “int enum” fields.
+ */
 public class Constants {
 
     public static final String EMPTY_STRING = "";

--- a/src/org/javarosa/core/model/DataType.java
+++ b/src/org/javarosa/core/model/DataType.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model;
+
+import static org.javarosa.core.model.Constants.DATATYPE_BARCODE;
+import static org.javarosa.core.model.Constants.DATATYPE_BINARY;
+import static org.javarosa.core.model.Constants.DATATYPE_BOOLEAN;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
+import static org.javarosa.core.model.Constants.DATATYPE_DATE;
+import static org.javarosa.core.model.Constants.DATATYPE_DATE_TIME;
+import static org.javarosa.core.model.Constants.DATATYPE_DECIMAL;
+import static org.javarosa.core.model.Constants.DATATYPE_GEOPOINT;
+import static org.javarosa.core.model.Constants.DATATYPE_GEOSHAPE;
+import static org.javarosa.core.model.Constants.DATATYPE_GEOTRACE;
+import static org.javarosa.core.model.Constants.DATATYPE_INTEGER;
+import static org.javarosa.core.model.Constants.DATATYPE_LONG;
+import static org.javarosa.core.model.Constants.DATATYPE_NULL;
+import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
+import static org.javarosa.core.model.Constants.DATATYPE_TIME;
+import static org.javarosa.core.model.Constants.DATATYPE_UNSUPPORTED;
+
+/**
+ * The model data types.
+ */
+public enum DataType {
+    UNSUPPORTED (DATATYPE_UNSUPPORTED),
+    NULL        (DATATYPE_NULL),
+    TEXT        (DATATYPE_TEXT),
+    INTEGER     (DATATYPE_INTEGER),
+    DECIMAL     (DATATYPE_DECIMAL),
+    DATE        (DATATYPE_DATE),
+    TIME        (DATATYPE_TIME),
+    DATE_TIME   (DATATYPE_DATE_TIME),
+    CHOICE      (DATATYPE_CHOICE),
+    CHOICE_LIST (DATATYPE_CHOICE_LIST),
+    BOOLEAN     (DATATYPE_BOOLEAN),
+    GEOPOINT    (DATATYPE_GEOPOINT),
+    BARCODE     (DATATYPE_BARCODE),
+    BINARY      (DATATYPE_BINARY),
+    LONG        (DATATYPE_LONG),
+    GEOSHAPE    (DATATYPE_GEOSHAPE),
+    GEOTRACE    (DATATYPE_GEOTRACE);
+
+    public final int value;
+
+    DataType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns a {@link DataType} from its int value
+     *
+     * @param intDataType the int value of the requested DataType
+     * @return the related {@link DataType} instance
+     */
+    public static DataType from(int intDataType) {
+        for (DataType dt : values()) {
+            if (dt.value == intDataType)
+                return dt;
+        }
+        throw new IllegalArgumentException("No DataType with value " + intDataType);
+    }
+}

--- a/src/org/javarosa/xform/util/XFormAnswerDataParser.java
+++ b/src/org/javarosa/xform/util/XFormAnswerDataParser.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.BooleanData;
@@ -66,70 +66,60 @@ public class XFormAnswerDataParser {
     public static IAnswerData getAnswerData (String text, int dataType) {
         return getAnswerData(text, dataType, null);
     }
-    public static IAnswerData getAnswerData (String text, int dataType, QuestionDef q) {
+    public static IAnswerData getAnswerData (String text, int intDataType, QuestionDef q) {
         String trimmedText = text.trim();
         if (trimmedText.length() == 0)
             trimmedText = null;
 
-        switch (dataType) {
-        case Constants.DATATYPE_NULL:
-        case Constants.DATATYPE_UNSUPPORTED:
-        case Constants.DATATYPE_TEXT:
-        case Constants.DATATYPE_BARCODE:
-        case Constants.DATATYPE_BINARY:
-
+        switch (DataType.from(intDataType)) {
+        case NULL:
+        case UNSUPPORTED:
+        case TEXT:
+        case BARCODE:
+        case BINARY:
             return new StringData(text);
 
-        case Constants.DATATYPE_INTEGER:
-
+        case INTEGER:
             try {
                 return (trimmedText == null ? null : new IntegerData(Integer.parseInt(trimmedText)));
             } catch (NumberFormatException nfe) {
                 return null;
             }
 
-        case Constants.DATATYPE_LONG:
-
+        case LONG:
             try {
                 return (trimmedText == null ? null : new LongData(Long.parseLong(trimmedText)));
             } catch (NumberFormatException nfe) {
                 return null;
             }
 
-        case Constants.DATATYPE_DECIMAL:
-
+        case DECIMAL:
             try {
                 return (trimmedText == null ? null : new DecimalData(Double.parseDouble(trimmedText)));
             } catch (NumberFormatException nfe) {
                 return null;
             }
 
-        case Constants.DATATYPE_CHOICE:
-
+        case CHOICE:
             Selection selection = getSelection(text, q);
             return (selection == null ? null : new SelectOneData(selection));
 
-        case Constants.DATATYPE_CHOICE_LIST:
-
+        case CHOICE_LIST:
             return new SelectMultiData(getSelections(text, q));
 
-        case Constants.DATATYPE_DATE_TIME:
-
+        case DATE_TIME:
             Date dt = (trimmedText == null ? null : DateUtils.parseDateTime(trimmedText));
             return (dt == null ? null : new DateTimeData(dt));
 
-        case Constants.DATATYPE_DATE:
-
+        case DATE:
             Date d = (trimmedText == null ? null : DateUtils.parseDate(trimmedText));
             return (d == null ? null : new DateData(d));
 
-        case Constants.DATATYPE_TIME:
-
+        case TIME:
             Date t = (trimmedText == null ? null : DateUtils.parseTime(trimmedText));
             return (t == null ? null : new TimeData(t));
 
-        case Constants.DATATYPE_BOOLEAN:
-
+        case BOOLEAN:
             if(trimmedText == null) {
                 return null;
             } else {
@@ -138,7 +128,7 @@ public class XFormAnswerDataParser {
                 return trimmedText.equals("t") ? new BooleanData(true) : new BooleanData(false);
             }
 
-        case Constants.DATATYPE_GEOPOINT:
+        case GEOPOINT:
             if ( trimmedText == null ) {
                 return new GeoPointData();
             }
@@ -152,7 +142,7 @@ public class XFormAnswerDataParser {
                 return null;
             }
 
-        case Constants.DATATYPE_GEOSHAPE:
+        case GEOSHAPE:
             if ( trimmedText == null ) {
                 return new GeoShapeData();
             }
@@ -166,7 +156,7 @@ public class XFormAnswerDataParser {
                 return null;
             }
 
-        case Constants.DATATYPE_GEOTRACE:
+        case GEOTRACE:
             if ( trimmedText == null ) {
                 return new GeoTraceData();
             }

--- a/test/org/javarosa/core/model/Safe2014DagImplTest.java
+++ b/test/org/javarosa/core/model/Safe2014DagImplTest.java
@@ -357,7 +357,7 @@ public class Safe2014DagImplTest {
 
         // Construct the required amount of repeats
         final TreeElement templateRepeat = mainInstance.getRoot().getChildAt(0);
-        final int numberOfRepeats = 200; // Raise this value to really measure
+        final int numberOfRepeats = 10; // Raise this value to really measure
         for (int i = 0; i < numberOfRepeats; i++) {
             final TreeReference refToNewRepeat = templateRepeat.getRef();
             refToNewRepeat.setMultiplicity(1, i); // set the correct multiplicity


### PR DESCRIPTION
I assume JavaRosa was created before enums were added to the language in Java 5. This change adds an enum for DataType. Gradually we can replace uses of the “int enum anti-pattern” with the enum. Immediately we can use it in [Briefcase](https://github.com/opendatakit/briefcase/pull/457).

I threw in a tiny [unrelated change](https://github.com/opendatakit/javarosa/commit/47c950d322f41f390a2b825108f33851c583b229) that will speed up the automated tests.

#### What has been done to verify that this works as intended?
I saw through tests and code coverage that the code is exercised and works.

#### Are there any risks to merging this code? If so, what are they?
No