### PR TITLE
Improve the DataType enum and the use of data type classes

### DIFF
--- a/src/org/javarosa/core/model/Constants.java
+++ b/src/org/javarosa/core/model/Constants.java
@@ -46,41 +46,26 @@ public class Constants {
     /** Over The Air or HTTP Connection */
     public static final int CONNECTION_OTA = 4;
 
-    public static final int DATATYPE_UNSUPPORTED = -1;
-    /** For nodes that have no data, or data type otherwise unknown */
-    public static final int DATATYPE_NULL = 0;
-    /** Text question type. */
-    public static final int DATATYPE_TEXT = 1;
-    /** Numeric question type. These are numbers without decimal points. */
-    public static final int DATATYPE_INTEGER = 2;
-    /** Decimal question type. These are numbers with decimals. */
-    public static final int DATATYPE_DECIMAL = 3;
-    /** Date question type. This has only date component without time. */
-    public static final int DATATYPE_DATE = 4;
-    /** Time question type. This has only time element without date. */
-    public static final int DATATYPE_TIME = 5;
-    /** Date and Time question type. This has both the date and time components */
-    public static final int DATATYPE_DATE_TIME = 6;
-    /** This is a question with a list of options where not more than one option can be selected at a time. */
-    public static final int DATATYPE_CHOICE = 7;
-    /** This is a question with a list of items used for selecting multiple answers or ordering them. */
+    public static final int DATATYPE_UNSUPPORTED    = -1;
+    public static final int DATATYPE_NULL           = 0;
+    public static final int DATATYPE_TEXT           = 1;
+    public static final int DATATYPE_INTEGER        = 2;
+    public static final int DATATYPE_DECIMAL        = 3;
+    public static final int DATATYPE_DATE           = 4;
+    public static final int DATATYPE_TIME           = 5;
+    public static final int DATATYPE_DATE_TIME      = 6;
+    public static final int DATATYPE_CHOICE         = 7;
+    /** A list of items used for selecting multiple answers or ordering them */
     public static final int DATATYPE_MULTIPLE_ITEMS = 8;
-    /** The same as above but exists only for backwards compatibility. */
-    public static final int DATATYPE_CHOICE_LIST = 8;
-    /** Question with true and false answers. */
-    public static final int DATATYPE_BOOLEAN = 9;
-    /** Question with location answer. */
-    public static final int DATATYPE_GEOPOINT = 10;
-    /** Question with barcode string answer. */
-    public static final int DATATYPE_BARCODE = 11;
-    /** Question with external binary answer. */
-    public static final int DATATYPE_BINARY = 12;
-    /** Question with external binary answer. */
-    public static final int DATATYPE_LONG = 13;
-    /** Question with GeoShape answer. */
-    public static final int DATATYPE_GEOSHAPE = 14;
-    /** Question with GeoTrace answer. */
-    public static final int DATATYPE_GEOTRACE = 15;
+    /** The same as {@link Constants#DATATYPE_MULTIPLE_ITEMS} (for backwards compatibility) */
+    public static final int DATATYPE_CHOICE_LIST    = 8;
+    public static final int DATATYPE_BOOLEAN        = 9;
+    public static final int DATATYPE_GEOPOINT       = 10;
+    public static final int DATATYPE_BARCODE        = 11;
+    public static final int DATATYPE_BINARY         = 12;
+    public static final int DATATYPE_LONG           = 13;
+    public static final int DATATYPE_GEOSHAPE       = 14;
+    public static final int DATATYPE_GEOTRACE       = 15;
 
     public static final int CONTROL_UNTYPED = -1;
     public static final int CONTROL_INPUT = 1;

--- a/src/org/javarosa/core/model/DataType.java
+++ b/src/org/javarosa/core/model/DataType.java
@@ -16,45 +16,27 @@
 
 package org.javarosa.core.model;
 
-import static org.javarosa.core.model.Constants.DATATYPE_BARCODE;
-import static org.javarosa.core.model.Constants.DATATYPE_BINARY;
-import static org.javarosa.core.model.Constants.DATATYPE_BOOLEAN;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
-import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
-import static org.javarosa.core.model.Constants.DATATYPE_DATE;
-import static org.javarosa.core.model.Constants.DATATYPE_DATE_TIME;
-import static org.javarosa.core.model.Constants.DATATYPE_DECIMAL;
-import static org.javarosa.core.model.Constants.DATATYPE_GEOPOINT;
-import static org.javarosa.core.model.Constants.DATATYPE_GEOSHAPE;
-import static org.javarosa.core.model.Constants.DATATYPE_GEOTRACE;
-import static org.javarosa.core.model.Constants.DATATYPE_INTEGER;
-import static org.javarosa.core.model.Constants.DATATYPE_LONG;
-import static org.javarosa.core.model.Constants.DATATYPE_NULL;
-import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
-import static org.javarosa.core.model.Constants.DATATYPE_TIME;
-import static org.javarosa.core.model.Constants.DATATYPE_UNSUPPORTED;
-
 /**
  * The model data types.
  */
 public enum DataType {
-    UNSUPPORTED     (DATATYPE_UNSUPPORTED),
-    NULL            (DATATYPE_NULL),
-    TEXT            (DATATYPE_TEXT),
-    INTEGER         (DATATYPE_INTEGER),
-    DECIMAL         (DATATYPE_DECIMAL),
-    DATE            (DATATYPE_DATE),
-    TIME            (DATATYPE_TIME),
-    DATE_TIME       (DATATYPE_DATE_TIME),
-    CHOICE          (DATATYPE_CHOICE),
-    MULTIPLE_ITEMS  (DATATYPE_MULTIPLE_ITEMS),
-    BOOLEAN         (DATATYPE_BOOLEAN),
-    GEOPOINT        (DATATYPE_GEOPOINT),
-    BARCODE         (DATATYPE_BARCODE),
-    BINARY          (DATATYPE_BINARY),
-    LONG            (DATATYPE_LONG),
-    GEOSHAPE        (DATATYPE_GEOSHAPE),
-    GEOTRACE        (DATATYPE_GEOTRACE);
+    UNSUPPORTED     (-1),
+    NULL            (0),
+    TEXT            (1),
+    INTEGER         (2),
+    DECIMAL         (3),
+    DATE            (4),
+    TIME            (5),
+    DATE_TIME       (6),
+    CHOICE          (7),
+    MULTIPLE_ITEMS  (8),
+    BOOLEAN         (9),
+    GEOPOINT        (10),
+    BARCODE         (11),
+    BINARY          (12),
+    LONG            (13),
+    GEOSHAPE        (14),
+    GEOTRACE        (15);
 
     public final int value;
 

--- a/src/org/javarosa/core/model/DataTypeClasses.java
+++ b/src/org/javarosa/core/model/DataTypeClasses.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model;
+
+import org.javarosa.core.model.data.BooleanData;
+import org.javarosa.core.model.data.DateData;
+import org.javarosa.core.model.data.DateTimeData;
+import org.javarosa.core.model.data.DecimalData;
+import org.javarosa.core.model.data.GeoPointData;
+import org.javarosa.core.model.data.GeoShapeData;
+import org.javarosa.core.model.data.GeoTraceData;
+import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.core.model.data.LongData;
+import org.javarosa.core.model.data.SelectMultiData;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.data.TimeData;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.javarosa.core.model.DataType.BOOLEAN;
+import static org.javarosa.core.model.DataType.CHOICE;
+import static org.javarosa.core.model.DataType.DATE;
+import static org.javarosa.core.model.DataType.DATE_TIME;
+import static org.javarosa.core.model.DataType.DECIMAL;
+import static org.javarosa.core.model.DataType.GEOPOINT;
+import static org.javarosa.core.model.DataType.GEOSHAPE;
+import static org.javarosa.core.model.DataType.GEOTRACE;
+import static org.javarosa.core.model.DataType.INTEGER;
+import static org.javarosa.core.model.DataType.LONG;
+import static org.javarosa.core.model.DataType.MULTIPLE_ITEMS;
+import static org.javarosa.core.model.DataType.NULL;
+import static org.javarosa.core.model.DataType.TEXT;
+import static org.javarosa.core.model.DataType.TIME;
+
+public class DataTypeClasses {
+    private final static Object[][] typesAndClasses = new Object[][]{
+        {NULL,              StringData      .class},
+        {TEXT,              StringData      .class},
+        {INTEGER,           IntegerData     .class},
+        {LONG,              LongData        .class},
+        {DECIMAL,           DecimalData     .class},
+        {BOOLEAN,           BooleanData     .class},
+        {DATE,              DateData        .class},
+        {TIME,              TimeData        .class},
+        {DATE_TIME,         DateTimeData    .class},
+        {CHOICE,            SelectOneData   .class},
+        {MULTIPLE_ITEMS,    SelectMultiData .class},
+        {GEOPOINT,          GeoPointData    .class},
+        {GEOSHAPE,          GeoShapeData    .class},
+        {GEOTRACE,          GeoTraceData    .class}
+    };
+
+    public static Class classForType(DataType dataType) {
+        return classesByType.get(dataType);
+    }
+
+    private final static Map<DataType, Class> classesByType = createMap();
+
+    private static Map<DataType, Class> createMap() {
+        Map<DataType, Class> m = new HashMap<>();
+        for (Object[] typeAndClass : typesAndClasses) {
+            m.put((DataType) typeAndClass[0], (Class) typeAndClass[1]);
+        }
+        return Collections.unmodifiableMap(m);
+    }
+}

--- a/src/org/javarosa/core/model/condition/Recalculate.java
+++ b/src/org/javarosa/core/model/condition/Recalculate.java
@@ -17,7 +17,7 @@
 package org.javarosa.core.model.condition;
 
 import java.util.Date;
-import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.DataType;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.data.DateTimeData;
@@ -36,6 +36,17 @@ import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
+
+import static org.javarosa.core.model.DataType.BOOLEAN;
+import static org.javarosa.core.model.DataType.CHOICE;
+import static org.javarosa.core.model.DataType.MULTIPLE_ITEMS;
+import static org.javarosa.core.model.DataType.DATE;
+import static org.javarosa.core.model.DataType.GEOPOINT;
+import static org.javarosa.core.model.DataType.GEOSHAPE;
+import static org.javarosa.core.model.DataType.GEOTRACE;
+import static org.javarosa.core.model.DataType.INTEGER;
+import static org.javarosa.core.model.DataType.LONG;
+import static org.javarosa.core.model.DataType.TIME;
 
 public class Recalculate extends Triggerable {
 
@@ -86,13 +97,15 @@ public class Recalculate extends Triggerable {
      * convert the data object returned by the xpath expression into an IAnswerData suitable for
      * storage in the FormInstance
      */
-    public static IAnswerData wrapData(Object val, int dataType) {
+    public static IAnswerData wrapData(Object val, int intDataType) {
         if ((val instanceof String && ((String) val).length() == 0) ||
                 (val instanceof Double && ((Double) val).isNaN())) {
             return null;
         }
 
-        if (Constants.DATATYPE_BOOLEAN == dataType || val instanceof Boolean) {
+        final DataType dataType = DataType.from(intDataType);
+
+        if (BOOLEAN == dataType || val instanceof Boolean) {
             //ctsims: We should really be using the boolean datatype for real, it's
             //necessary for backend calculations and XSD compliance
 
@@ -115,30 +128,30 @@ public class Recalculate extends Triggerable {
             double d = (Double) val;
             long l = (long) d;
             boolean isIntegral = Math.abs(d - l) < 1.0e-9;
-            if (Constants.DATATYPE_INTEGER == dataType ||
+            if (INTEGER == dataType ||
                     (isIntegral && (Integer.MAX_VALUE >= l) && (Integer.MIN_VALUE <= l))) {
                 return new IntegerData((int) d);
-            } else if (Constants.DATATYPE_LONG == dataType || isIntegral) {
+            } else if (LONG == dataType || isIntegral) {
                 return new LongData((long) d);
             } else {
                 return new DecimalData(d);
             }
-        } else if (dataType == Constants.DATATYPE_GEOPOINT) {
+        } else if (dataType == GEOPOINT) {
             return new GeoPointData().cast(new UncastData(String.valueOf(val)));
-        } else if (dataType == Constants.DATATYPE_GEOSHAPE) {
+        } else if (dataType == GEOSHAPE) {
             return new GeoShapeData().cast(new UncastData(String.valueOf(val)));
-        } else if (dataType == Constants.DATATYPE_GEOTRACE) {
+        } else if (dataType == GEOTRACE) {
             return new GeoTraceData().cast(new UncastData(String.valueOf(val)));
-        } else if (dataType == Constants.DATATYPE_CHOICE) {
+        } else if (dataType == CHOICE) {
             return new SelectOneData().cast(new UncastData(String.valueOf(val)));
-        } else if (dataType == Constants.DATATYPE_MULTIPLE_ITEMS) {
+        } else if (dataType == MULTIPLE_ITEMS) {
             return new MultipleItemsData().cast(new UncastData(String.valueOf(val)));
         } else if (val instanceof String) {
             return new StringData((String) val);
         } else if (val instanceof Date) {
-            if (dataType == Constants.DATATYPE_TIME)
+            if (dataType == TIME)
                 return new TimeData((Date) val);
-            if (dataType == Constants.DATATYPE_DATE)
+            if (dataType == DATE)
                 return new DateData((Date) val);
             return new DateTimeData((Date) val);
         } else {

--- a/src/org/javarosa/core/model/data/AnswerDataFactory.java
+++ b/src/org/javarosa/core/model/data/AnswerDataFactory.java
@@ -4,6 +4,7 @@
 package org.javarosa.core.model.data;
 
 import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.DataType;
 
 /**
  * This is not a factory, actually, since there's no drop-in component model, but
@@ -24,10 +25,6 @@ public class AnswerDataFactory {
      * which to cast incoming values.
      *
      * All enormous spaghetti ifs should be replaced with a call to this
-     *
-     * @param controlType
-     * @param dataType
-     * @return
      */
     public static IAnswerData template(int controlType, int datatype) {
         //First take care of the easy two, selections, since their
@@ -46,40 +43,40 @@ public class AnswerDataFactory {
     }
 
     public static IAnswerData templateByDataType(int datatype) {
-        switch(datatype) {
-            case Constants.DATATYPE_CHOICE:
+        switch(DataType.from(datatype)) {
+            case CHOICE:
                 return new SelectOneData();
-            case Constants.DATATYPE_MULTIPLE_ITEMS:
+            case MULTIPLE_ITEMS:
                 return new MultipleItemsData();
-            case Constants.DATATYPE_BOOLEAN:
+            case BOOLEAN:
                 return new BooleanData();
-            case Constants.DATATYPE_DATE:
+            case DATE:
                 return new DateData();
-            case Constants.DATATYPE_DATE_TIME:
+            case DATE_TIME:
                 return new DateTimeData();
-            case Constants.DATATYPE_DECIMAL:
+            case DECIMAL:
                 return new DecimalData();
-            case Constants.DATATYPE_GEOPOINT:
+            case GEOPOINT:
                 return new GeoPointData();
-            case Constants.DATATYPE_GEOSHAPE:
+            case GEOSHAPE:
                 return new GeoShapeData();
-            case Constants.DATATYPE_GEOTRACE:
+            case GEOTRACE:
                 return new GeoTraceData();
-            case Constants.DATATYPE_INTEGER:
+            case INTEGER:
                 return new IntegerData();
-            case Constants.DATATYPE_LONG:
+            case LONG:
                 return new LongData();
-            case Constants.DATATYPE_TEXT:
+            case TEXT:
                 return new StringData();
-            case Constants.DATATYPE_TIME:
+            case TIME:
                 return new TimeData();
 
             //All of these are things that might require other manipulations in the future, but
             //for low can all just live as untyped
-            case Constants.DATATYPE_BARCODE:
-            case Constants.DATATYPE_BINARY:
-            case Constants.DATATYPE_UNSUPPORTED:
-            case Constants.DATATYPE_NULL:
+            case BARCODE:
+            case BINARY:
+            case UNSUPPORTED:
+            case NULL:
                 return new UncastData();
 
             //If this is new and we don't know what's going on, just leave it untyped

--- a/src/org/javarosa/core/model/instance/utils/CompactInstanceWrapper.java
+++ b/src/org/javarosa/core/model/instance/utils/CompactInstanceWrapper.java
@@ -16,29 +16,17 @@
 
 package org.javarosa.core.model.instance.utils;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.DataType;
+import org.javarosa.core.model.DataTypeClasses;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
-import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.DecimalData;
-import org.javarosa.core.model.data.GeoPointData;
-import org.javarosa.core.model.data.GeoShapeData;
-import org.javarosa.core.model.data.GeoTraceData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
-import org.javarosa.core.model.data.LongData;
 import org.javarosa.core.model.data.MultipleItemsData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.StringData;
-import org.javarosa.core.model.data.TimeData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InvalidReferenceException;
@@ -56,6 +44,13 @@ import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.ExternalizableWrapper;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * An alternate serialization format for FormInstances (saved form instances) that drastically reduces the
@@ -472,24 +467,7 @@ public class CompactInstanceWrapper implements WrappingStorageUtility.Serializat
      * @param dataType
      * @return
      */
-    public static Class classForDataType (int dataType) {
-        switch (dataType) {
-        case Constants.DATATYPE_NULL: return StringData.class;
-        case Constants.DATATYPE_TEXT: return StringData.class;
-        case Constants.DATATYPE_INTEGER: return IntegerData.class;
-        case Constants.DATATYPE_LONG: return LongData.class;
-        case Constants.DATATYPE_DECIMAL: return DecimalData.class;
-        case Constants.DATATYPE_BOOLEAN: return BooleanData.class;
-        case Constants.DATATYPE_DATE: return DateData.class;
-        case Constants.DATATYPE_TIME: return TimeData.class;
-        case Constants.DATATYPE_DATE_TIME: return DateTimeData.class;
-        case Constants.DATATYPE_CHOICE: return SelectOneData.class;
-        case Constants.DATATYPE_MULTIPLE_ITEMS: return MultipleItemsData.class;
-        case Constants.DATATYPE_GEOPOINT: return GeoPointData.class;
-        case Constants.DATATYPE_GEOSHAPE: return GeoShapeData.class;
-        case Constants.DATATYPE_GEOTRACE: return GeoTraceData.class;
-        default: return null;
-        }
+    public static Class classForDataType(int dataType) {
+        return DataTypeClasses.classForType(DataType.from(dataType));
     }
-
 }

--- a/test/org/javarosa/core/model/DataTypeClassesTest.java
+++ b/test/org/javarosa/core/model/DataTypeClassesTest.java
@@ -1,0 +1,11 @@
+package org.javarosa.core.model;
+
+import org.javarosa.core.model.data.SelectOneData;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class DataTypeClassesTest {
+    @Test public void correctClassIsReturned() {
+        assertEquals(SelectOneData.class, DataTypeClasses.classForType(DataType.CHOICE));
+    }
+}


### PR DESCRIPTION

#### What has been done to verify that this works as intended?
Ran all automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This simplifies code and moves us closer to eliminating the “int enum antipattern” of DATATYPE.* in Constants.

#### Are there any risks to merging this code? If so, what are they?
Not that I can see.
