### PR TITLE
Issue 314 revert use of java8 datetime api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ sourceCompatibility = '1.8'
 
 dependencies {
     // Be sure to update dependencies in pom.xml to match
+    compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     compileOnly group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,18 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
+    <!-- Be sure to update dependencies in build.gradle to match -->
     <dependency>
-      <!-- Be sure to update dependencies in build.gradle to match -->
       <groupId>net.sf.kxml</groupId>
       <artifactId>kxml2</artifactId>
       <version>2.3.0</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+       <groupId>joda-time</groupId>
+       <artifactId>joda-time</artifactId>
+       <version>2.9.9</version>
+       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/test/org/javarosa/core/model/Safe2014DagImplTest.java
+++ b/test/org/javarosa/core/model/Safe2014DagImplTest.java
@@ -1,12 +1,12 @@
 package org.javarosa.core.model;
 
-import java.time.LocalTime;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.debug.Event;
 import org.javarosa.debug.EventNotifier;
+import org.joda.time.LocalTime;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -381,7 +381,7 @@ public class Safe2014DagImplTest {
         }
 
         // Then
-        LocalTime duration = LocalTime.ofNanoOfDay(System.nanoTime() - start);
+        LocalTime duration = LocalTime.fromMillisOfDay((System.nanoTime() - start) / 1_000_000);
         logger.info("Deletion of {} repeats took {}", numberOfRepeats, duration.toString());
     }
 

--- a/test/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/test/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -19,8 +19,6 @@ package org.javarosa.core.model.utils.test;
 import static org.junit.Assert.assertEquals;
 
 import java.text.DateFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -28,6 +26,7 @@ import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.DateUtils.DateFields;
+import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -44,8 +43,8 @@ public class DateUtilsTests {
     public void setUp() {
         backupLocale = Locale.getDefault();
         backupZone = TimeZone.getDefault();
-        testLocalDateTime = LocalDateTime.of(2018, 1, 1, 10, 20, 30, 400_500_600);
-        testDate = Date.from(testLocalDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        testLocalDateTime = new LocalDateTime(2018, 1, 1, 10, 20, 30, 400);
+        testDate = testLocalDateTime.toDate();
     }
 
     @After
@@ -65,7 +64,7 @@ public class DateUtilsTests {
         assertEquals("The date string was not of the proper length", currentDate.length(), "YYYY-MM-DD".length());
         assertEquals("The date string does not have proper year formatting", currentDate.indexOf("-"), "YYYY-".indexOf("-"));
         assertEquals(testLocalDateTime.getYear(), Integer.parseInt(currentDate.substring(0, 4)));
-        assertEquals(testLocalDateTime.getMonthValue(), Integer.parseInt(currentDate.substring(5, 7)));
+        assertEquals(testLocalDateTime.getMonthOfYear(), Integer.parseInt(currentDate.substring(5, 7)));
         assertEquals(testLocalDateTime.getDayOfMonth(), Integer.parseInt(currentDate.substring(8, 10)));
     }
 


### PR DESCRIPTION
Closes #314

#### What has been done to verify that this works as intended?
- The changes in the implementation have been made **before** the changes in the tests, thus being safe.
- All unit tests are passing
- Searching for imports of `java.time` namespace doesn't show any results

#### Why is this the best possible solution? Were any other approaches considered?
I've just translated to Joda Time every date/time related operation made with Java8's Date/Time API.

#### Are there any risks to merging this code? If so, what are they?
Nope.