### PR TITLE
Issue 328 fix randomize with choice filters

### DIFF
--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -16,6 +16,8 @@
 package org.javarosa.xform.parse;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This class contains all the code needed to implement the xform randomize()
@@ -84,6 +86,13 @@ public final class RandomizeHelper {
     private static String[] getArgs(String nodesetStr) {
         if (!nodesetStr.startsWith("randomize(") || !nodesetStr.endsWith(")"))
             throw new IllegalArgumentException("Nodeset definition must use randomize(path, seed?) function");
-        return nodesetStr.substring(10, nodesetStr.length() - 1).split(",");
+        if (!nodesetStr.contains("["))
+            return nodesetStr.substring(10, nodesetStr.length() - 1).split(",");
+        Matcher matcher = Pattern.compile("randomize\\((.+?),?([^,)\\]]+?)?\\)").matcher(nodesetStr);
+        if (!matcher.matches())
+            throw new IllegalArgumentException("Can't parse the Nodeset definition");
+        String nodeset = matcher.group(1);
+        String seed = matcher.group(2);
+        return seed != null ? new String[]{nodeset, seed} : new String[]{nodeset};
     }
 }

--- a/src/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/org/javarosa/xform/parse/RandomizeHelper.java
@@ -24,6 +24,8 @@ import java.util.regex.Pattern;
  * function.
  */
 public final class RandomizeHelper {
+    private static final Pattern CHOICE_FILTER_PATTERN = Pattern.compile("randomize\\((.+?),?([^,)\\]]+?)?\\)");
+
     /**
      * Looks for a seed in an xform randomize() expression. If it is present and
      * it can be parsed into a {@link Long}, it returns it. If it is not present,
@@ -88,7 +90,7 @@ public final class RandomizeHelper {
             throw new IllegalArgumentException("Nodeset definition must use randomize(path, seed?) function");
         if (!nodesetStr.contains("["))
             return nodesetStr.substring(10, nodesetStr.length() - 1).split(",");
-        Matcher matcher = Pattern.compile("randomize\\((.+?),?([^,)\\]]+?)?\\)").matcher(nodesetStr);
+        Matcher matcher = CHOICE_FILTER_PATTERN.matcher(nodesetStr);
         if (!matcher.matches())
             throw new IllegalArgumentException("Can't parse the Nodeset definition");
         String nodeset = matcher.group(1);

--- a/test/org/javarosa/xform/parse/RandomizeHelperTest.java
+++ b/test/org/javarosa/xform/parse/RandomizeHelperTest.java
@@ -34,11 +34,15 @@ public class RandomizeHelperTest {
     @Test
     public void cleans_the_nodeset_definition() {
         // We will try different combinations of whitespace and seed presence around the path
-        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path)"));
-        assertEquals("/some/path", cleanNodesetDefinition("randomize( /some/path )"));
-        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path,33)"));
-        assertEquals("/some/path", cleanNodesetDefinition("randomize(/some/path, 33)"));
-        assertEquals("/some/path", cleanNodesetDefinition("randomize( /some/path , 33)"));
+        assertEquals("/some/path",                              cleanNodesetDefinition("randomize(/some/path)"));
+        assertEquals("/some/path",                              cleanNodesetDefinition("randomize( /some/path )"));
+        assertEquals("/some/path",                              cleanNodesetDefinition("randomize(/some/path,33)"));
+        assertEquals("/some/path",                              cleanNodesetDefinition("randomize(/some/path, 33)"));
+        assertEquals("/some/path",                              cleanNodesetDefinition("randomize( /some/path , 33)"));
+        assertEquals("/some/path[someFilter]",                  cleanNodesetDefinition("randomize(/some/path[someFilter])"));
+        assertEquals("/some/path[someFilter]",                  cleanNodesetDefinition("randomize(/some/path[someFilter], 33)"));
+        assertEquals("/some/path[someFilter(with, commas)]",    cleanNodesetDefinition("randomize(/some/path[someFilter(with, commas)])"));
+        assertEquals("/some/path[someFilter(with, commas)]",    cleanNodesetDefinition("randomize(/some/path[someFilter(with, commas)], 33)"));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -58,6 +62,10 @@ public class RandomizeHelperTest {
         assertEquals(new Long(33), parseSeed("randomize(/some/path,33)"));
         assertEquals(new Long(33), parseSeed("randomize(/some/path, 33)"));
         assertEquals(new Long(33), parseSeed("randomize(/some/path, 33 )"));
+        assertNull(parseSeed("randomize(/some/path[someFilter])"));
+        assertEquals(new Long(33), parseSeed("randomize(/some/path[someFilter], 33)"));
+        assertNull(parseSeed("randomize(/some/path[someFilter(with, commas)])"));
+        assertEquals(new Long(33), parseSeed("randomize(/some/path[someFilter(with, commas)], 33)"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Closes #328

This PR fixes getting the args of a `randomize()` function in a nodeset definition to support commas in the first argument, i.e. using a choice filter with more than one arg.

This PR will still fail if, somehow, the first argument has a comma and doesn't include the `[` character, which is the way it knows it has to run the regexp Pattern instead of the simple split-at-comma procedure.

#### What has been done to verify that this works as intended?
Wrote new unit test cases to verify we support commas in the first argument.

#### Why is this the best possible solution? Were any other approaches considered?
This PR has the narrowest fix to support the use of choice filters, as described in #328.

I considered writing a unique `Pattern` that would cover any `randomize()` args but it turned out to be quite difficult and I opted for introducing an `if` that would run the old code (which is less expensive) when there is no choice filter.


#### Are there any risks to merging this code? If so, what are they?
None.