### PR TITLE
ODK namespace and CompactSerializingVisitor NPE fix

### DIFF
--- a/resources/sms_form.xml
+++ b/resources/sms_form.xml
@@ -1,7 +1,7 @@
 <h:html xmlns="http://www.w3.org/2002/xforms"
     xmlns:h="http://www.w3.org/1999/xhtml"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:odk="http://opendatakit.org/xforms"
     xmlns:jr="http://openrosa.org/javarosa">
   <h:head>
     <h:title>SMS Tester Form</h:title>

--- a/src/org/javarosa/model/xform/CompactSerializingVisitor.java
+++ b/src/org/javarosa/model/xform/CompactSerializingVisitor.java
@@ -48,6 +48,10 @@ public class CompactSerializingVisitor implements IInstanceSerializingVisitor {
      */
     private IAnswerDataSerializer serializer;
 
+    public CompactSerializingVisitor() {
+        resultText = "";
+    }
+
     public byte[] serializeInstance(FormInstance model, FormDef formDef) throws IOException {
         return serializeInstance(model);
     }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -120,7 +120,7 @@ public class XFormParser implements IXFormParserFunctions {
     private static final Logger logger = LoggerFactory.getLogger(XFormParser.class);
 
     public static final String NAMESPACE_JAVAROSA = "http://openrosa.org/javarosa";
-    public static final String NAMESPACE_ODK = "http://www.opendatakit.org/xforms";
+    public static final String NAMESPACE_ODK = "http://opendatakit.org/xforms";
 
     //Constants to clean up code and prevent user error
     private static final String FORM_ATTR = "form";

--- a/test/org/javarosa/model/xform/CompactSerializingVisitorTest.java
+++ b/test/org/javarosa/model/xform/CompactSerializingVisitorTest.java
@@ -70,4 +70,17 @@ public class CompactSerializingVisitorTest {
     public void ensureTagWithNoAnswerNotPresent() {
         assertFalse(text.contains("CTY"));
     }
+
+    @Test
+    public void ensureThatFormWithNoSmsTagsIsEmpty() throws IOException {
+        FormParseInit formParser = new FormParseInit(r("simple-form.xml"));
+        FormEntryController formEntryController = formParser.getFormEntryController();
+        formInstance = formEntryController.getModel().getForm().getInstance();
+
+        CompactSerializingVisitor serializer = new CompactSerializingVisitor();
+
+        ByteArrayPayload payload = (ByteArrayPayload) serializer.createSerializedPayload(formInstance);
+
+        assertEquals(payload.toString(), "");
+    }
 }


### PR DESCRIPTION
Closes #330

#### What has been done to verify that this works as intended?
For the namespace, the `CompactSerializingVisitorTest` suite passed when the change took place. 
The `NullPointerException` that was thrown when attempting to concatenate an uninitialized `resultText` was corrected and a test was written to ensure that forms with SMS tags don't cause this exception to be thrown.

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
No.