### PR TITLE
Test helper methods

### DIFF
--- a/src/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/org/javarosa/core/model/ItemsetBinding.java
@@ -6,7 +6,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
-
 import org.javarosa.core.model.condition.IConditionExpr;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
@@ -37,8 +36,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public TreeReference nodesetRef;   //absolute ref of itemset source nodes
     public IConditionExpr nodesetExpr; //path expression for source nodes; may be relative, may contain predicates
     public TreeReference contextRef;   //context ref for nodesetExpr; ref of the control parent (group/formdef) of itemset question
-       //note: this is only here because its currently impossible to both (a) get a form control's parent, and (b)
-       //convert expressions into refs while preserving predicates. once these are fixed, this field can go away
+    //note: this is only here because its currently impossible to both (a) get a form control's parent, and (b)
+    //convert expressions into refs while preserving predicates. once these are fixed, this field can go away
 
     public TreeReference labelRef;     //absolute ref of label
     public IConditionExpr labelExpr;   //path expression for label; may be relative, no predicates
@@ -51,17 +50,17 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public IConditionExpr valueExpr;   //path expression for value; may be relative, no predicates (must be relative if copy mode)
 
     private TreeReference destRef; //ref that identifies the repeated nodes resulting from this itemset
-                                   //not serialized -- set by QuestionDef.setDynamicChoices()
+    //not serialized -- set by QuestionDef.setDynamicChoices()
     private List<SelectChoice> choices; //dynamic choices -- not serialized, obviously
 
     public boolean randomize = false;
     public Long randomSeed = null;
 
-    public List<SelectChoice> getChoices () {
+    public List<SelectChoice> getChoices() {
         return choices;
     }
 
-    public void setChoices (List<SelectChoice> choices, Localizer localizer) {
+    public void setChoices(List<SelectChoice> choices, Localizer localizer) {
         if (this.choices != null) {
             logger.warn("previous choices not cleared out");
             clearChoices();
@@ -83,7 +82,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
         }
     }
 
-    public void clearChoices () {
+    public void clearChoices() {
         this.choices = null;
     }
 
@@ -95,11 +94,11 @@ public class ItemsetBinding implements Externalizable, Localizable {
         }
     }
 
-    public TreeReference getDestRef () {
+    public TreeReference getDestRef() {
         return destRef;
     }
 
-    public IConditionExpr getRelativeValue () {
+    public IConditionExpr getRelativeValue() {
         TreeReference relRef = null;
 
         if (copyRef == null) {
@@ -115,21 +114,21 @@ public class ItemsetBinding implements Externalizable, Localizable {
         // To construct the xxxRef, we need the full model, which wasn't available before now.
         // Compute the xxxRefs now.
         nodesetRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(
-                ((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference()), contextRef));
-        if ( labelExpr != null ) {
+            ((XPathPathExpr) ((XPathConditional) nodesetExpr).getExpr()).getReference()), contextRef));
+        if (labelExpr != null) {
             labelRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) labelExpr).getExpr())),
-                    nodesetRef));
+                nodesetRef));
         }
-        if ( copyExpr != null ) {
+        if (copyExpr != null) {
             copyRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) copyExpr).getExpr())),
-                    nodesetRef));
+                nodesetRef));
         }
-        if ( valueExpr != null ) {
+        if (valueExpr != null) {
             valueRef = FormInstance.unpackReference(FormDef.getAbsRef(new XPathReference(((XPathPathExpr) ((XPathConditional) valueExpr).getExpr())),
-                    nodesetRef));
+                nodesetRef));
         }
 
-        if ( q != null ) {
+        if (q != null) {
             // When loading from XML, the first time through, during verification, q will be null.
             // The second time through, q will be non-null.
             // Otherwise, when loading from binary, this will be called only once with a non-null q.
@@ -141,15 +140,15 @@ public class ItemsetBinding implements Externalizable, Localizable {
     }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        nodesetExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        contextRef = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
-        labelExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        valueExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
-        copyExpr = (IConditionExpr)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+        nodesetExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        contextRef = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
+        labelExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        valueExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+        copyExpr = (IConditionExpr) ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         labelIsItext = ExtUtil.readBool(in);
         copyMode = ExtUtil.readBool(in);
         randomize = ExtUtil.readBool(in);
-        randomSeed = (Long)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()));
+        randomSeed = (Long) ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()));
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -39,8 +39,8 @@ import static org.javarosa.core.model.instance.ExternalDataInstance.getPathIfExt
 import static org.javarosa.core.services.ProgramFlow.die;
 import static org.javarosa.xform.parse.Constants.ID_ATTR;
 import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
-import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.RANK;
+import static org.javarosa.xform.parse.Constants.SELECT;
 import static org.javarosa.xform.parse.Constants.SELECTONE;
 import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
 import static org.javarosa.xform.parse.RandomizeHelper.parseSeed;
@@ -231,7 +231,8 @@ public class XFormParser implements IXFormParserFunctions {
                 }
             });
             put(RANK, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_RANK);
                 }
             });
@@ -977,8 +978,8 @@ public class XFormParser implements IXFormParserFunctions {
 
         boolean isItem =
             controlType == CONTROL_SELECT_MULTI
-            || controlType == CONTROL_RANK
-            || controlType == CONTROL_SELECT_ONE;
+                || controlType == CONTROL_RANK
+                || controlType == CONTROL_SELECT_ONE;
 
         question.setControlType(controlType);
         question.setAppearanceAttr(e.getAttributeValue(null, APPEARANCE_ATTR));

--- a/test/org/javarosa/TestHelper.java
+++ b/test/org/javarosa/TestHelper.java
@@ -1,0 +1,93 @@
+package org.javarosa;
+
+import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_UNBOUND;
+import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+
+import java.util.Arrays;
+import java.util.List;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.form.api.FormEntryPrompt;
+
+public class TestHelper {
+    /**
+     * Builds an absolute {@link TreeReference} from a string path description
+     * like <code>/some/path</code>.
+     * <p>
+     * Can be used in combination of other methods that take {@link TreeReference},
+     * like {@link #getFormIndex(FormDef, TreeReference)} or {@link #getSelectChoices(FormDef, String)}
+     * to make them easier to use. Example:
+     *
+     * <code>FormIndex formIndex = getFormIndex(formDef, absoluteRef("/data/field"));</code>
+     */
+    public static TreeReference absoluteRef(String path) {
+        TreeReference tr = new TreeReference();
+        tr.setRefLevel(REF_ABSOLUTE);
+        tr.setContext(CONTEXT_ABSOLUTE);
+        tr.setInstanceName(null);
+        Arrays.stream(path.split("/"))
+            .filter(s -> !s.isEmpty())
+            .forEach(s -> tr.add(s, INDEX_UNBOUND));
+        return tr;
+    }
+
+    /**
+     * Returns a {@link FormIndex} corresponding to the given string reference.
+     * <p>
+     * The absolute {@link TreeReference} of the question is built with {@link #absoluteRef(String)}.
+     */
+    public static FormIndex getFormIndex(FormDef formDef, String ref) {
+        return getFormIndex(formDef, absoluteRef(ref));
+    }
+
+    /**
+     * Returns a {@link FormIndex} corresponding to the given {@link TreeReference}.
+     */
+    public static FormIndex getFormIndex(FormDef formDef, TreeReference ref) {
+        for (int localIndex = 0, lastIndex = formDef.getChildren().size(); localIndex < lastIndex; localIndex++)
+            if (formDef.getChild(localIndex).getBind().getReference().equals(ref))
+                return new FormIndex(localIndex, 0, ref);
+        throw new IllegalArgumentException("Reference " + ref + " not found");
+    }
+
+    /**
+     * Returns a {@link FormEntryPrompt} corresponding to the given string reference.
+     * <p>
+     * The absolute {@link TreeReference} of the question is built with {@link #absoluteRef(String)}.
+     */
+    public static FormEntryPrompt getFormEntryPrompt(FormDef formDef, String ref) {
+        return new FormEntryPrompt(formDef, getFormIndex(formDef, ref));
+    }
+
+    /**
+     * Returns a {@link List} of {@link SelectChoice} elements of a question at the
+     * given string reference.
+     * <p>
+     * The absolute {@link TreeReference} of the question is built with {@link #absoluteRef(String)}.
+     */
+    public static List<SelectChoice> getSelectChoices(FormDef formDef, String ref) {
+        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
+        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
+        return formEntryPrompt.getSelectChoices();
+    }
+
+    /**
+     * Returns the value of an answer at the given string reference.
+     */
+    public static Object getAnswerValue(FormDef formDef, String ref) {
+        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
+        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
+        return formEntryPrompt.getAnswerValue().getValue();
+    }
+
+    /**
+     * Initializes a new instance in the given {@link FormDef} form.
+     */
+    public static void initializeNewInstance(FormDef formDef) {
+        formDef.initialize(true, new InstanceInitializationFactory());
+    }
+}

--- a/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
+++ b/test/org/javarosa/form/api/OutputInComputedConstraintTextTest.java
@@ -15,15 +15,12 @@
  */
 package org.javarosa.form.api;
 
+import static org.javarosa.TestHelper.getFormEntryPrompt;
+import static org.javarosa.TestHelper.getFormIndex;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.javarosa.core.model.FormDef;
-import org.javarosa.core.model.FormIndex;
-import org.javarosa.core.model.IFormElement;
-import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.LongData;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.test.FormParseInit;
@@ -31,65 +28,40 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class OutputInComputedConstraintTextTest {
-  static {
-    PrototypeManager.registerPrototype("org.javarosa.model.xform.XPathReference");
-  }
+    static {
+        PrototypeManager.registerPrototype("org.javarosa.model.xform.XPathReference");
+    }
 
-  private Map<String, FormIndex> formIndexesById = new HashMap<>();
-  private FormDef formDef;
-  private FormEntryController ctrl;
-  private FormEntryModel model;
+    private FormDef formDef;
+    private FormEntryController ctrl;
 
-  @Before
-  public void setUp() {
-    FormParseInit fpi = new FormParseInit(r("constraint-message-error.xml"));
-    formDef = fpi.getFormDef();
-    formDef.getLocalizer().setLocale("English");
-    ctrl = fpi.getFormEntryController();
-    model = fpi.getFormEntryModel();
-    buildIndexes();
-  }
+    @Before
+    public void setUp() {
+        FormParseInit fpi = new FormParseInit(r("constraint-message-error.xml"));
+        formDef = fpi.getFormDef();
+        formDef.getLocalizer().setLocale("English");
+        ctrl = fpi.getFormEntryController();
+    }
 
-  @Test
-  public void testComputedQuestionText() {
-    // Answer first question to check label and constraint texts on next questions
-    ctrl.answerQuestion(getFormIndex("/constraintMessageError/village:label"), new LongData(1), true);
+    @Test
+    public void testComputedQuestionText() {
+        // Answer first question to check label and constraint texts on next questions
+        ctrl.answerQuestion(getFormIndex(formDef, "/constraintMessageError/village"), new LongData(1), true);
 
-    assertEquals(
-        "Please only conduct this survey with children aged 6 TO 24 MONTHS.",
-        getFormEntryPrompt("/constraintMessageError/ageSetNote:label").getQuestionText()
-    );
-  }
+        assertEquals(
+            "Please only conduct this survey with children aged 6 TO 24 MONTHS.",
+            getFormEntryPrompt(formDef, "/constraintMessageError/ageSetNote").getQuestionText()
+        );
+    }
 
-  @Test
-  public void testComputedConstraintText() {
-    // Answer first question to check label and constraint texts on next questions
-    ctrl.answerQuestion(getFormIndex("/constraintMessageError/village:label"), new LongData(1), true);
+    @Test
+    public void testComputedConstraintText() {
+        // Answer first question to check label and constraint texts on next questions
+        ctrl.answerQuestion(getFormIndex(formDef, "/constraintMessageError/village"), new LongData(1), true);
 
-    assertEquals(
-        "Please only conduct this survey with children aged 6 TO 24 MONTHS.",
-        getFormEntryPrompt("/constraintMessageError/age:label").getConstraintText()
-    );
-  }
-
-  private void buildIndexes() {
-    ctrl.jumpToIndex(FormIndex.createBeginningOfFormIndex());
-    do {
-      FormEntryCaption fep = model.getCaptionPrompt();
-      IFormElement formElement = fep.getFormElement();
-      if (formElement instanceof QuestionDef)
-        formIndexesById.put(formElement.getTextID(), fep.getIndex());
-    } while (ctrl.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
-  }
-
-  private FormIndex getFormIndex(String id) {
-    if (formIndexesById.containsKey(id))
-      return formIndexesById.get(id);
-    throw new RuntimeException("FormIndex with id \"" + id + "\" not found");
-  }
-
-  private FormEntryPrompt getFormEntryPrompt(String id) {
-    return new FormEntryPrompt(formDef, getFormIndex(id));
-  }
-
+        assertEquals(
+            "Please only conduct this survey with children aged 6 TO 24 MONTHS.",
+            getFormEntryPrompt(formDef, "/constraintMessageError/age").getConstraintText()
+        );
+    }
 }

--- a/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/test/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -19,9 +19,9 @@ import static java.nio.file.Files.createTempFile;
 import static java.nio.file.Files.delete;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
-import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
-import static org.javarosa.core.model.instance.TreeReference.INDEX_UNBOUND;
-import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+import static org.javarosa.TestHelper.getAnswerValue;
+import static org.javarosa.TestHelper.getSelectChoices;
+import static org.javarosa.TestHelper.initializeNewInstance;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -31,19 +31,14 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
-import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
-import org.javarosa.core.model.instance.InstanceInitializationFactory;
-import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.core.util.JavaRosaCoreModule;
 import org.javarosa.core.util.externalizable.DeserializationException;
-import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XFormsModule;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +62,7 @@ public class XPathFuncExprRandomizeTest {
         List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/fruit1");
         List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/fruit2");
 
-        assertFalse(nodesEqualInOrder(choices1, choices2));
+        assertFalse(selectChoicesEqualInOrder(choices1, choices2));
     }
 
     @Test
@@ -78,7 +73,7 @@ public class XPathFuncExprRandomizeTest {
         initializeNewInstance(formDef);
         List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/fruit1");
 
-        assertFalse(nodesEqualInOrder(choices1, choices2));
+        assertFalse(selectChoicesEqualInOrder(choices1, choices2));
     }
 
     @Test
@@ -87,7 +82,7 @@ public class XPathFuncExprRandomizeTest {
         List<SelectChoice> choices1 = getSelectChoices(formDef, "/randomize/seededFruit1");
         List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/seededFruit2");
 
-        assertTrue(nodesEqualInOrder(choices1, choices2));
+        assertTrue(selectChoicesEqualInOrder(choices1, choices2));
     }
 
     @Test
@@ -98,7 +93,7 @@ public class XPathFuncExprRandomizeTest {
         initializeNewInstance(formDef);
         List<SelectChoice> choices2 = getSelectChoices(formDef, "/randomize/seededFruit2");
 
-        assertTrue(nodesEqualInOrder(choices1, choices2));
+        assertTrue(selectChoicesEqualInOrder(choices1, choices2));
     }
 
     @Test
@@ -111,7 +106,7 @@ public class XPathFuncExprRandomizeTest {
         initializeNewInstance(formDefAfterSerialization);
         List<SelectChoice> choices2 = getSelectChoices(formDefAfterSerialization, "/randomize/seededFruit2");
 
-        assertTrue(nodesEqualInOrder(choices1, choices2));
+        assertTrue(selectChoicesEqualInOrder(choices1, choices2));
     }
 
     @Test
@@ -149,30 +144,7 @@ public class XPathFuncExprRandomizeTest {
         return deserializedFormDef;
     }
 
-    private static void initializeNewInstance(FormDef formDef) {
-        formDef.initialize(true, new InstanceInitializationFactory());
-    }
-
-    private List<SelectChoice> getSelectChoices(FormDef formDef, String ref) {
-        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
-        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
-        return formEntryPrompt.getSelectChoices();
-    }
-
-    private Object getAnswerValue(FormDef formDef, String ref) {
-        FormIndex formIndex = getFormIndex(formDef, absoluteRef(ref));
-        FormEntryPrompt formEntryPrompt = new FormEntryPrompt(formDef, formIndex);
-        return formEntryPrompt.getAnswerValue().getValue();
-    }
-
-    private FormIndex getFormIndex(FormDef formDef, TreeReference ref) {
-        for (int localIndex = 0, lastIndex = formDef.getChildren().size(); localIndex < lastIndex; localIndex++)
-            if (formDef.getChild(localIndex).getBind().getReference().equals(ref))
-                return new FormIndex(localIndex, 0, ref);
-        throw new IllegalArgumentException("Reference " + ref + " not found");
-    }
-
-    private static boolean nodesEqualInOrder(List<SelectChoice> left, List<SelectChoice> right) {
+    private static boolean selectChoicesEqualInOrder(List<SelectChoice> left, List<SelectChoice> right) {
         if (left.size() != right.size())
             return false;
 
@@ -181,16 +153,5 @@ public class XPathFuncExprRandomizeTest {
                 return false;
 
         return true;
-    }
-
-    private static TreeReference absoluteRef(String path) {
-        TreeReference tr = new TreeReference();
-        tr.setRefLevel(REF_ABSOLUTE);
-        tr.setContext(CONTEXT_ABSOLUTE);
-        tr.setInstanceName(null);
-        Arrays.stream(path.split("/"))
-            .filter(s -> !s.isEmpty())
-            .forEach(s -> tr.add(s, INDEX_UNBOUND));
-        return tr;
     }
 }


### PR DESCRIPTION
Per @lognaturel's request, this PR has some minor reformatting changes and a class with useful test helpers.

The code in this PR is a very, very, **very** incipient work in progress. Test helpers should use high-level semantics that explain and give examples of specific form interactions, like creating a new form instance, answering a question, looking what question's label holds, etc.

The test helper methods in this PR reflect my lack of knowledge of how JR works and will probably have sense only in the context of the tests I've written but I'd love to help anyone trying to adapt them for broader use cases.

## Some ideas about testing JR

The rationale behind these test helpers is that, ideally, we could have a single entry point to handle form interaction: a form test driver that could imitate user actions in Collect and provide some introspection API to build meaningful assertions.

JavaRosa can be overwhelmingly complex and the current test code implies a deep knowledge of how JR works, involving classes such as, but not limited to, `FormParseInit`, `FormController`, `FormEntryPoint`, which have to be used in a certain way and provide APIs that cover different testing concerns that can even overlap.

For example, a JR test could have the following structure:

```java
Context(form("the_form.xml"))
  .given(answer("/the/ref/to/question1", "some value"))
  .given(answer("/the/ref/to/question2", "some other value"))

  .when(answer("/the/ref/to/question3", "yet another value"))

  .then(question("/the/ref/to/question4"), contains(choices("a", "b", "c")));
```

- The code for `Context()` and the `form()` factory should explain how the context of a test gets constructed and how a form is loaded and initialized.
- The code for `answer()` should explain how to navigate an instance to search for some question and how those values get bound.
- The code for `choices()` is a standard, composable Hamcrest matcher for `QuestionDef` objects.
- This test structure can seem too simple but thanks to type safe operation and composable matchers, it can be support much more complex interactions. It also enforces a test style that talks about behavior, which helps writers focus on what the users will perceive instead of implementation details.
- This doesn't mean that we have to avoid other tests that focus on implementation details, like when we need to implement a shuffling algorithm, for example.

As a corollary, I'd strongly suggest adding Hamcrest to the list of test dependencies in the project to start building a library of composable `Matcher`s that would greatly improve reuse of test code and expressiveness.

#### What has been done to verify that this works as intended?
Run the tests

#### Why is this the best possible solution? Were any other approaches considered?
This PR is a straightforward extraction of methods to their own class using IntelliJ's safe refactors.

#### Are there any risks to merging this code? If so, what are they?
Nope.
