### PR TITLE
[WIP] Fix current() expansion in selects

### DIFF
--- a/resources/org/javarosa/xpath/expr/relative-current-ref-itemset-nodeset.xml
+++ b/resources/org/javarosa/xpath/expr/relative-current-ref-itemset-nodeset.xml
@@ -1,0 +1,51 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Untitled Form</h:title>
+        <model>
+            <instance>
+                <data id="relative-current-ref-repeat">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                    <people>
+                        <count/>
+                        <person/>
+                    </people>
+
+                    <selected_person/>
+                </data>
+            </instance>
+            <itext>
+                <translation lang="English">
+                    <text id="/data/people:label">
+                        <value>People</value>
+                    </text>
+                    <text id="/data/people/person:label">
+                        <value>Person</value>
+                    </text>
+                </translation>
+            </itext>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+            <bind nodeset="/data/people/count" type="int" calculate="position(..)"/>
+            <bind nodeset="/data/people/person" type="string"/>
+            <bind nodeset="/data/selected_person" type="select1"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group>
+            <label ref="jr:itext('/data/people:label')"/>
+            <repeat nodeset="/data/people">
+                <input ref="/data/people/person">
+                    <label ref="jr:itext('/data/people/person:label')"/>
+                </input>
+            </repeat>
+
+            <select1 ref="/data/selected_person">
+                <itemset nodeset="current()/../people">
+                    <value ref="count"/>
+                    <label ref="person"/>
+                </itemset>
+            </select1>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/xpath/expr/relative-current-ref.xml
+++ b/resources/org/javarosa/xpath/expr/relative-current-ref.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>relative-current-ref</h:title>
+        <model>
+            <itext>
+                <translation default="true()" lang="default">
+                    <text id="static_instance-variety-3">
+                        <value>Collins</value>
+                    </text>
+                    <text id="static_instance-fruit-0">
+                        <value>Apple</value>
+                    </text>
+                    <text id="static_instance-variety-2">
+                        <value>Blueray</value>
+                    </text>
+                    <text id="static_instance-fruit-1">
+                        <value>Blueberry</value>
+                    </text>
+                    <text id="static_instance-fruit-2">
+                        <value>Cherimoya</value>
+                    </text>
+                    <text id="static_instance-variety-5">
+                        <value>Booth</value>
+                    </text>
+                    <text id="static_instance-variety-4">
+                        <value>Behl</value>
+                    </text>
+                    <text id="static_instance-variety-0">
+                        <value>Granny Smith</value>
+                    </text>
+                    <text id="static_instance-variety-1">
+                        <value>Gala</value>
+                    </text>
+                    <text id="static_instance-variety-6">
+                        <value>Duke</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <data id="relative-current-ref">
+                    <my_group>
+                        <name/>
+                        <name_relative/>
+                        <name_note/>
+                    </my_group>
+                    <fruit/>
+                    <variety/>
+                    <my_repeat jr:template="">
+                        <repeat_name/>
+                        <repeat_name_relative/>
+                        <repeat_name_note/>
+                        <repeat_fruit/>
+                        <repeat_variety/>
+                    </my_repeat>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <instance id="variety">
+                <root>
+                    <item>
+                        <itextId>static_instance-variety-0</itextId>
+                        <fruit>apple</fruit>
+                        <name>granny_smith</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-variety-1</itextId>
+                        <fruit>apple</fruit>
+                        <name>gala</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-variety-2</itextId>
+                        <fruit>blueberry</fruit>
+                        <name>blueray</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-variety-3</itextId>
+                        <fruit>blueberry</fruit>
+                        <name>collins</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-variety-6</itextId>
+                        <fruit>blueberry</fruit>
+                        <name>duke</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-variety-4</itextId>
+                        <fruit>cherimoya</fruit>
+                        <name>behl</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-variety-5</itextId>
+                        <fruit>cherimoya</fruit>
+                        <name>booth</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="fruit">
+                <root>
+                    <item>
+                        <itextId>static_instance-fruit-0</itextId>
+                        <name>apple</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-fruit-1</itextId>
+                        <name>blueberry</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-fruit-2</itextId>
+                        <name>cherimoya</name>
+                    </item>
+                </root>
+            </instance>
+            <bind nodeset="/data/my_group/name" type="string"/>
+            <bind calculate="current()/../name" nodeset="/data/my_group/name_relative" type="string"/>
+            <bind nodeset="/data/my_group/name_note" readonly="true()" type="string"/>
+            <bind nodeset="/data/fruit" type="select1"/>
+            <bind nodeset="/data/variety" type="select1"/>
+            <bind nodeset="/data/my_repeat/repeat_name" type="string"/>
+            <bind calculate="current()/../repeat_name" nodeset="/data/my_repeat/repeat_name_relative" type="string"/>
+            <bind nodeset="/data/my_repeat/repeat_name_note" readonly="true()" type="string"/>
+            <bind nodeset="/data/my_repeat/repeat_fruit" type="select1"/>
+            <bind nodeset="/data/my_repeat/repeat_variety" type="select1"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/my_group">
+            <label>My group</label>
+            <input ref="/data/my_group/name">
+                <label>Name</label>
+            </input>
+            <input ref="/data/my_group/name_note">
+                <label>Your name is
+                    <output value=" /data/my_group/name_relative "/></label>
+            </input>
+        </group>
+        <select1 ref="/data/fruit">
+            <label>Fruit</label>
+            <item>
+                <label>Apple</label>
+                <value>apple</value>
+            </item>
+            <item>
+                <label>Blueberry</label>
+                <value>blueberry</value>
+            </item>
+            <item>
+                <label>Cherimoya</label>
+                <value>cherimoya</value>
+            </item>
+        </select1>
+        <select1 ref="/data/variety">
+            <label>Variety</label>
+            <itemset nodeset="instance('variety')/root/item[fruit = current()/../fruit]">
+                <value ref="name"/>
+                <label ref="jr:itext(itextId)"/>
+            </itemset>
+        </select1>
+        <group ref="/data/my_repeat">
+            <label>My repeat</label>
+            <repeat nodeset="/data/my_repeat">
+                <input ref="/data/my_repeat/repeat_name">
+                    <label>Name</label>
+                </input>
+                <input ref="/data/my_repeat/repeat_name_note">
+                    <label>Your name is
+                        <output value=" /data/my_repeat/repeat_name_relative "/></label>
+                </input>
+                <select1 ref="/data/my_repeat/repeat_fruit">
+                    <label>Fruit</label>
+                    <item>
+                        <label>Apple</label>
+                        <value>apple</value>
+                    </item>
+                    <item>
+                        <label>Blueberry</label>
+                        <value>blueberry</value>
+                    </item>
+                    <item>
+                        <label>Cherimoya</label>
+                        <value>cherimoya</value>
+                    </item>
+                </select1>
+                <select1 ref="/data/my_repeat/repeat_variety">
+                    <label>Variety</label>
+                    <itemset nodeset="instance('variety')/root/item[fruit = current()/../repeat_fruit]">
+                        <value ref="name"/>
+                        <label ref="jr:itext(itextId)"/>
+                    </itemset>
+                </select1>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -122,7 +122,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             tref = TreeReference.selfRef(); //only happens for <group>s with no binding
         }
 
-        tref = tref.parent(parentRef);
+        tref = tref.anchor(parentRef);
         if (tref == null) {
             throw new XFormParseException("Binding path [" + tref + "] not allowed with parent binding of [" + parentRef + "]");
         }

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -353,6 +353,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         return ref;
     }
 
+    public TreeElement getFirstDescendantWithName(String name) {
+        return mainInstance.getRoot().getFirstDescendantWithName(name);
+    }
+
     public void setLocalizer(Localizer l) {
         if (this.localizer != null) {
             this.localizer.unregisterLocalizable(this);

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -36,6 +36,7 @@ import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
 import org.javarosa.core.model.instance.utils.IAnswerResolver;
 import org.javarosa.core.model.instance.utils.ITreeVisitor;
 import org.javarosa.core.model.instance.utils.TreeElementChildrenList;
+import org.javarosa.core.model.instance.utils.TreeElementNameComparator;
 import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -225,6 +226,28 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
     @Override
     public List<TreeElement> getChildrenWithName(String name) {
         return children.get(name);
+    }
+
+    /** Returns the first element across descendants that has the specified name. Useful for testing. **/
+    public TreeElement getFirstDescendantWithName(String name) {
+        return getFirstDescendantWithName(this, name);
+    }
+
+    private TreeElement getFirstDescendantWithName(TreeElement node, String name) {
+        if (node.getMultiplicity() != TreeReference.INDEX_TEMPLATE &&
+                TreeElementNameComparator.elementMatchesName(node, name)) {
+            return node;
+        }
+
+        for (TreeElement child : node.children) {
+            TreeElement result = getFirstDescendantWithName(child, name);
+
+            if (result != null) {
+                return result;
+            }
+        }
+
+        return null;
     }
 
     private int getNumChildrenWithName(String name) {

--- a/src/org/javarosa/form/api/FormEntryController.java
+++ b/src/org/javarosa/form/api/FormEntryController.java
@@ -21,6 +21,7 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,6 +214,28 @@ public class FormEntryController {
     public int jumpToIndex(FormIndex index) {
         model.setQuestionIndex(index);
         return model.getEvent(index);
+    }
+
+    /**
+     * Jump to the first node with the given name. Useful for testing.
+     */
+    public int jumpToFirstQuestionWithName(String name) {
+        return jumpToReference(getModel().getForm().getFirstDescendantWithName(name).getRef());
+    }
+
+    private int jumpToReference(TreeReference reference) {
+        jumpToIndex(FormIndex.createBeginningOfFormIndex());
+        FormIndex index = model.getFormIndex();
+
+        do {
+            if (index.getReference() != null && index.getReference().equals(reference)) {
+                return jumpToIndex(index);
+            }
+
+            index = model.incrementIndex(index);
+        } while (index.isInForm());
+
+        return jumpToIndex(index);
     }
 
     public FormIndex descendIntoRepeat (int n) {

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -1320,7 +1320,7 @@ public class XFormParser implements IXFormParserFunctions {
 
         XPathPathExpr path = XPathReference.getPathExpr(nodesetStr);
         itemset.nodesetExpr = new XPathConditional(path);
-        itemset.contextRef = getFormElementRef(qparent);
+        itemset.contextRef = getFormElementRef(q);
         // this is not valid yet...
         itemset.nodesetRef = null;
         // itemset.nodesetRef = FormInstance.unpackReference(getAbsRef(new XPathReference(path.getReference(true)), itemset.contextRef));

--- a/test/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
+++ b/test/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.ItemsetBinding;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+
+public class XPathPathExprCurrentItemsetNodesetTest {
+    private FormDef formDef;
+    private FormEntryController formEntryController;
+
+    @Before
+    public void setUp() {
+        FormParseInit fpi = new FormParseInit(r("relative-current-ref-itemset-nodeset.xml"));
+        formDef = fpi.getFormDef();
+        formDef.initialize(true, new InstanceInitializationFactory());
+        FormEntryModel formEntryModel = new FormEntryModel(formDef);
+        formEntryController = new FormEntryController(formEntryModel);
+    }
+
+    /**
+     * current() in an itemset nodeset expression should refer to the select node. This is verified by building an
+     * itemset from a repeat which is a sibling of the select.
+     */
+    @Test
+    public void current_in_itemset_nodeset_should_refer_to_node() {
+        // don't know how to jump to repeat directly so jump to following question and step backwards
+        formEntryController.jumpToFirstQuestionWithName("selected_person");
+        formEntryController.stepToPreviousEvent(); // repeat
+        formEntryController.descendIntoRepeat(0);
+        formEntryController.stepToNextEvent(); // person
+
+        StringData nameValue = new StringData("Bob");
+        formEntryController.answerQuestion(nameValue, true);
+
+        formEntryController.stepToNextEvent();
+        formEntryController.descendIntoNewRepeat();
+        formEntryController.stepToNextEvent(); // person
+
+        StringData nameValue2 = new StringData("Janet");
+        formEntryController.answerQuestion(nameValue2, true);
+
+        formEntryController.jumpToFirstQuestionWithName("selected_person");
+        FormEntryPrompt personPrompt = formEntryController.getModel().getQuestionPrompt();
+        personPrompt.getAnswerValue();
+        ItemsetBinding dynamicChoices = personPrompt.getQuestion().getDynamicChoices();
+
+        SelectChoice personChoice = dynamicChoices.getChoices().get(1);
+        assertEquals("Janet", personPrompt.getSelectChoiceText(personChoice));
+        SelectOneData personSelection = new SelectOneData(new Selection(personChoice));
+        formEntryController.answerQuestion(personSelection, true);
+
+        SelectOneData personSelectionValue = (SelectOneData) formDef.getFirstDescendantWithName("selected_person")
+                .getValue();
+        assertEquals("2", personSelectionValue.getDisplayText());
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathPathExprCurrentTest.java
+++ b/test/org/javarosa/xpath/expr/XPathPathExprCurrentTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.ItemsetBinding;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+
+public class XPathPathExprCurrentTest {
+    private FormDef formDef;
+    private FormEntryController formEntryController;
+
+    @Before
+    public void setUp() {
+        FormParseInit fpi = new FormParseInit(r("relative-current-ref.xml"));
+        formDef = fpi.getFormDef();
+        formDef.initialize(true, new InstanceInitializationFactory());
+        FormEntryModel formEntryModel = new FormEntryModel(formDef);
+        formEntryController = new FormEntryController(formEntryModel);
+    }
+
+    /**
+     * current() in a calculate should refer to the node it is in (in this case, /data/my_group/name_relative).
+     * This means that to refer to a sibling node, the path should be current()/../<name of sibling node>. This is
+     * verified by changing the value of the node that the calculate is supposed to refer to
+     * (/data/my_group/name) and seeing that the dependent calculate is updated accordingly.
+     */
+    @Test
+    public void current_in_calculate_should_refer_to_node() {
+        formEntryController.jumpToFirstQuestionWithName("name");
+        StringData nameValue = new StringData("Bob");
+        formEntryController.answerQuestion(nameValue, true);
+
+        StringData relativeName = (StringData) formDef.getFirstDescendantWithName("name").getValue();
+        assertEquals(nameValue.getValue(), relativeName.getValue());
+    }
+
+    /**
+     * current() in a choice filter should refer to the select node the choice filter is called from, NOT the expression
+     * it is in. See https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/current -- this is the difference
+     * between current() and .
+     *
+     * The behavior of current() in a choice filter is verified by selecting a value for a first, static select and then
+     * using that value to filter a second, dynamic select.
+     */
+    @Test
+    public void current_in_choice_filter_should_refer_to_node() {
+        formEntryController.jumpToFirstQuestionWithName("fruit");
+        Selection fruitSelection = new Selection(1);
+        fruitSelection.attachChoice(formEntryController.getModel().getQuestionPrompt().getQuestion());
+        formEntryController.answerQuestion(new SelectOneData(fruitSelection), true);
+
+        SelectOneData fruitSelectionValue = (SelectOneData) formDef.getFirstDescendantWithName("fruit").getValue();
+        assertEquals("blueberry", fruitSelectionValue.getDisplayText());
+
+        // === Variety question ===
+        formEntryController.stepToNextEvent();
+        // Collect calls getAnswerValue to populate dynamic choices
+        FormEntryPrompt varietyPrompt = formEntryController.getModel().getQuestionPrompt();
+        varietyPrompt.getAnswerValue();
+        ItemsetBinding dynamicChoices = varietyPrompt.getQuestion().getDynamicChoices();
+
+        // There are three blueberry varieties defined by the form
+        assertEquals(dynamicChoices.getChoices().size(), 3);
+
+        SelectChoice varietyChoice = dynamicChoices.getChoices().get(1);
+        SelectOneData varietySelection = new SelectOneData(new Selection(varietyChoice));
+        assertEquals("Collins", varietyPrompt.getSelectChoiceText(varietyChoice));
+        formEntryController.answerQuestion(varietySelection, true);
+
+        SelectOneData variety = (SelectOneData) formDef.getFirstDescendantWithName("variety").getValue();
+        assertEquals("collins", variety.getDisplayText());
+    }
+}


### PR DESCRIPTION
Closes #293

TODO:
- [ ] clean up comments around `contextRef`
- [ ] possibly add more tests for `current()` usage in other contexts?

#### What has been done to verify that this works as intended?
Ran automated tests and tried form in Collect. To understand what's going on, I recommend pulling each commit in order, reading the commit comment and running the tests.

#### Why is this the best possible solution? Were any other approaches considered?
The changes themselves are very small and surgical. The biggest question is whether the tests are sufficient to feel confident that they don't result in regressions. I'd love your feedback on this, @dcbriccetti and @ggalmazor. In particular, I don't think there's yet enough testing to feel confident in 507f56d.

I considered removing `contextRef` altogether but I'd rather do that once we have confidence in the approach either in more commits here or in a future PR.

#### Are there any risks to merging this code? If so, what are they?
I'm fairly confident that the tests for the change to validate 20e357f are exhaustive. I think we've identified all the places `contextRef` is used in the discussion at #293 and tested all such cases. 

`getAbsRef` is used more broadly so I'm less confident in the change in 507f56d. Risks include other relative expressions using `..` or `current()` or `.` not being expanded properly.