### PR TITLE
Revert namespace to the one set in Aggregate years ago

### DIFF
--- a/resources/sms_form.xml
+++ b/resources/sms_form.xml
@@ -1,7 +1,7 @@
 <h:html xmlns="http://www.w3.org/2002/xforms"
     xmlns:h="http://www.w3.org/1999/xhtml"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:odk="http://opendatakit.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms"
     xmlns:jr="http://openrosa.org/javarosa">
   <h:head>
     <h:title>SMS Tester Form</h:title>

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -121,7 +121,7 @@ public class XFormParser implements IXFormParserFunctions {
     private static final Logger logger = LoggerFactory.getLogger(XFormParser.class);
 
     public static final String NAMESPACE_JAVAROSA = "http://openrosa.org/javarosa";
-    public static final String NAMESPACE_ODK = "http://opendatakit.org/xforms";
+    public static final String NAMESPACE_ODK = "http://www.opendatakit.org/xforms";
 
     //Constants to clean up code and prevent user error
     private static final String FORM_ATTR = "form";


### PR DESCRIPTION
Addresses https://github.com/opendatakit/xforms-spec/issues/203

Reverts df7c725e3cc6ec44febeb425a5be166a5564186a
Reverts e441a66e35dbab6939b4a32523fc208b8da24bf1

#### What has been done to verify that this works as intended?
Visual inspection.

#### Why is this the best possible solution? Were any other approaches considered?
I searched for `opendatakit.org/xforms` in the repo and replaced them. 

#### Are there any risks to merging this code? If so, what are they?
Yes, my visual inspection could have missed something.