### PR TITLE
Address warning about unknown attributes

### DIFF
--- a/src/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/org/javarosa/xform/parse/FormInstanceParser.java
@@ -63,7 +63,8 @@ class FormInstanceParser {
         FormInstance instanceModel = new FormInstance(root);
         instanceModel.setName(isMainInstance ? formDef.getTitle() : name);
 
-        final List<String> usedAtts = Collections.unmodifiableList(Arrays.asList("id", "version", "uiVersion", "name"));
+        final List<String> usedAtts = Collections.unmodifiableList(Arrays.asList("id", "version", "uiVersion", "name",
+                "prefix", "delimiter"));
 
         String schema = e.getNamespace();
         if (schema != null && schema.length() > 0 && !schema.equals(defaultNamespace)) {


### PR DESCRIPTION
Prior to this change, we got the following warning:

```
16:54:36.449 [main] WARN org.javarosa.xform.parse.FormInstanceParser - XForm Parse Warning: Warning: 2 Unrecognized attributes found in Element [data] and will be ignored: [delimiter,prefix] 
    Problem found at nodeset: /html/head/model/instance/data
    With element <data id="build_SMS-Tester-Form_1524097605" delimiter=";" prefix="FORM232"><meta><instanceID/>
```

The change adds `prefix` and `delimiter` to known attributes for the primary instance.

I've verified this by running the SMS test and seeing that there is no warning.