### PR TITLE
Issue 351 controltype enum

### DIFF
--- a/src/org/javarosa/core/model/Constants.java
+++ b/src/org/javarosa/core/model/Constants.java
@@ -46,26 +46,26 @@ public class Constants {
     /** Over The Air or HTTP Connection */
     public static final int CONNECTION_OTA = 4;
 
-    public static final int DATATYPE_UNSUPPORTED    = -1;
-    public static final int DATATYPE_NULL           = 0;
-    public static final int DATATYPE_TEXT           = 1;
-    public static final int DATATYPE_INTEGER        = 2;
-    public static final int DATATYPE_DECIMAL        = 3;
-    public static final int DATATYPE_DATE           = 4;
-    public static final int DATATYPE_TIME           = 5;
-    public static final int DATATYPE_DATE_TIME      = 6;
-    public static final int DATATYPE_CHOICE         = 7;
+    public static final int DATATYPE_UNSUPPORTED    = DataType.UNSUPPORTED.value;
+    public static final int DATATYPE_NULL           = DataType.NULL.value;
+    public static final int DATATYPE_TEXT           = DataType.TEXT.value;
+    public static final int DATATYPE_INTEGER        = DataType.INTEGER.value;
+    public static final int DATATYPE_DECIMAL        = DataType.DECIMAL.value;
+    public static final int DATATYPE_DATE           = DataType.DATE.value;
+    public static final int DATATYPE_TIME           = DataType.TIME.value;
+    public static final int DATATYPE_DATE_TIME      = DataType.DATE_TIME.value;
+    public static final int DATATYPE_CHOICE         = DataType.CHOICE.value;
     /** A list of items used for selecting multiple answers or ordering them */
-    public static final int DATATYPE_MULTIPLE_ITEMS = 8;
+    public static final int DATATYPE_MULTIPLE_ITEMS = DataType.MULTIPLE_ITEMS.value;
     /** The same as {@link Constants#DATATYPE_MULTIPLE_ITEMS} (for backwards compatibility) */
-    public static final int DATATYPE_CHOICE_LIST    = 8;
-    public static final int DATATYPE_BOOLEAN        = 9;
-    public static final int DATATYPE_GEOPOINT       = 10;
-    public static final int DATATYPE_BARCODE        = 11;
-    public static final int DATATYPE_BINARY         = 12;
-    public static final int DATATYPE_LONG           = 13;
-    public static final int DATATYPE_GEOSHAPE       = 14;
-    public static final int DATATYPE_GEOTRACE       = 15;
+    public static final int DATATYPE_CHOICE_LIST    = DataType.MULTIPLE_ITEMS.value;
+    public static final int DATATYPE_BOOLEAN        = DataType.BOOLEAN.value;
+    public static final int DATATYPE_GEOPOINT       = DataType.GEOPOINT.value;
+    public static final int DATATYPE_BARCODE        = DataType.BARCODE.value;
+    public static final int DATATYPE_BINARY         = DataType.BINARY.value;
+    public static final int DATATYPE_LONG           = DataType.LONG.value;
+    public static final int DATATYPE_GEOSHAPE       = DataType.GEOSHAPE.value;
+    public static final int DATATYPE_GEOTRACE       = DataType.GEOTRACE.value;
 
     public static final int CONTROL_UNTYPED         = ControlType.UNTYPED.value;
     public static final int CONTROL_INPUT           = ControlType.INPUT.value;

--- a/src/org/javarosa/core/model/Constants.java
+++ b/src/org/javarosa/core/model/Constants.java
@@ -67,24 +67,24 @@ public class Constants {
     public static final int DATATYPE_GEOSHAPE       = 14;
     public static final int DATATYPE_GEOTRACE       = 15;
 
-    public static final int CONTROL_UNTYPED = -1;
-    public static final int CONTROL_INPUT = 1;
-    public static final int CONTROL_SELECT_ONE = 2;
-    public static final int CONTROL_SELECT_MULTI = 3;
-    public static final int CONTROL_TEXTAREA = 4;
-    public static final int CONTROL_SECRET = 5;
-    public static final int CONTROL_RANGE = 6;
-    public static final int CONTROL_UPLOAD = 7;
-    public static final int CONTROL_SUBMIT = 8;
-    public static final int CONTROL_TRIGGER = 9;
-    public static final int CONTROL_IMAGE_CHOOSE = 10;
-    public static final int CONTROL_LABEL = 11;
-    public static final int CONTROL_AUDIO_CAPTURE = 12;
-    public static final int CONTROL_VIDEO_CAPTURE = 13;
-    public static final int CONTROL_OSM_CAPTURE = 14;
+    public static final int CONTROL_UNTYPED         = ControlType.UNTYPED.value;
+    public static final int CONTROL_INPUT           = ControlType.INPUT.value;
+    public static final int CONTROL_SELECT_ONE      = ControlType.SELECT_ONE.value;
+    public static final int CONTROL_SELECT_MULTI    = ControlType.SELECT_MULTI.value;
+    public static final int CONTROL_TEXTAREA        = ControlType.TEXTAREA.value;
+    public static final int CONTROL_SECRET          = ControlType.SECRET.value;
+    public static final int CONTROL_RANGE           = ControlType.RANGE.value;
+    public static final int CONTROL_UPLOAD          = ControlType.UPLOAD.value;
+    public static final int CONTROL_SUBMIT          = ControlType.SUBMIT.value;
+    public static final int CONTROL_TRIGGER         = ControlType.TRIGGER.value;
+    public static final int CONTROL_IMAGE_CHOOSE    = ControlType.IMAGE_CHOOSE.value;
+    public static final int CONTROL_LABEL           = ControlType.LABEL.value;
+    public static final int CONTROL_AUDIO_CAPTURE   = ControlType.AUDIO_CAPTURE.value;
+    public static final int CONTROL_VIDEO_CAPTURE   = ControlType.VIDEO_CAPTURE.value;
+    public static final int CONTROL_OSM_CAPTURE     = ControlType.OSM_CAPTURE.value;
     /** generic upload */
-    public static final int CONTROL_FILE_CAPTURE = 15;
-    public static final int CONTROL_RANK = 16;
+    public static final int CONTROL_FILE_CAPTURE    = ControlType.FILE_CAPTURE.value;
+    public static final int CONTROL_RANK            = ControlType.RANK.value;
 
     /* constants for xform tags */
     public static final String XFTAG_UPLOAD = "upload";

--- a/src/org/javarosa/core/model/ControlType.java
+++ b/src/org/javarosa/core/model/ControlType.java
@@ -1,0 +1,27 @@
+package org.javarosa.core.model;
+
+public enum ControlType {
+    UNTYPED       (-1),
+    INPUT         (1),
+    SELECT_ONE    (2),
+    SELECT_MULTI  (3),
+    TEXTAREA      (4),
+    SECRET        (5),
+    RANGE         (6),
+    UPLOAD        (7),
+    SUBMIT        (8),
+    TRIGGER       (9),
+    IMAGE_CHOOSE  (10),
+    LABEL         (11),
+    AUDIO_CAPTURE (12),
+    VIDEO_CAPTURE (13),
+    OSM_CAPTURE   (14),
+    FILE_CAPTURE  (15),
+    RANK          (16);
+
+    public final int value;
+
+    ControlType(int value) {
+        this.value = value;
+    }
+}

--- a/src/org/javarosa/core/model/util/restorable/RestoreUtils.java
+++ b/src/org/javarosa/core/model/util/restorable/RestoreUtils.java
@@ -16,6 +16,8 @@
 
 package org.javarosa.core.model.util.restorable;
 
+import static org.javarosa.core.model.DataType.from;
+
 import java.util.Date;
 import java.util.List;
 
@@ -98,17 +100,17 @@ public class RestoreUtils {
         }
 
         IAnswerData val;
-        switch (dataType) {
-        case -1: val = null; break;
-        case Constants.DATATYPE_TEXT: val = new StringData((String)data); break;
-        case Constants.DATATYPE_INTEGER: val = new IntegerData((Integer)data); break;
-        case Constants.DATATYPE_LONG: val = new LongData((Long)data); break;
-        case Constants.DATATYPE_DECIMAL: val = new DecimalData((Double)data); break;
-        case Constants.DATATYPE_BOOLEAN: val = new StringData(((Boolean)data).booleanValue() ? "t" : "f"); break;
-        case Constants.DATATYPE_DATE: val = new DateData((Date)data); break;
-        case Constants.DATATYPE_DATE_TIME: val = new DateTimeData((Date)data); break;
-        case Constants.DATATYPE_TIME: val = new TimeData((Date)data); break;
-        case Constants.DATATYPE_MULTIPLE_ITEMS: val = (MultipleItemsData)data; break;
+        switch (from(dataType)) {
+        case UNSUPPORTED: val = null; break;
+        case TEXT: val = new StringData((String)data); break;
+        case INTEGER: val = new IntegerData((Integer)data); break;
+        case LONG: val = new LongData((Long)data); break;
+        case DECIMAL: val = new DecimalData((Double)data); break;
+        case BOOLEAN: val = new StringData(((Boolean)data).booleanValue() ? "t" : "f"); break;
+        case DATE: val = new DateData((Date)data); break;
+        case DATE_TIME: val = new DateTimeData((Date)data); break;
+        case TIME: val = new TimeData((Date)data); break;
+        case MULTIPLE_ITEMS: val = (MultipleItemsData)data; break;
         default: throw new IllegalArgumentException("Don't know how to handle data type [" + dataType + "]");
         }
 


### PR DESCRIPTION
Closes #351

This PR extracts to an enum the static members about control type codes in `model.Constants`.

It also binds the values in that class to values from the `ControlType` and `DataType` enums to reduce duplication and the risk of accidental de-synchronization of duplicated values.

#### What has been done to verify that this works as intended?
Run the automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
These changes ensure there's only one definition for the integer codes of JR data types and control types.

They also make the `ControlType` available to be used by third parties like Briefcase

#### Are there any risks to merging this code? If so, what are they?
None that I can think of.