### PR TITLE
Issue 357 Specify the correct Java image for CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: circleci/openjdk:latest
+      - image: circleci/openjdk:8u171-jdk
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Closes #357 

Force CircleCI to use the latest Java8 image
- Instead of using the lastest "latest" version which at the time of this commit is 10.0.2 (Oracle)
- This is to avoid detected deprecation failures

#### What has been done to verify that this works as intended?
Tested that now the project builds in CircleCI

#### Why is this the best possible solution? Were any other approaches considered?
This is a straightforward change to avoid depending on a CircleCI env that we can't control.

#### Are there any risks to merging this code? If so, what are they?
Nope.