### PR TITLE
Use latest minor release to provide early warning of potential proble…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: circleci/openjdk:8u171-jdk
+      - image: circleci/openjdk:8-jdk
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Addresses #357 

#### What has been done to verify that this works as intended?
Visual inspection.

#### Why is this the best possible solution? Were any other approaches considered?
I like auto-updating to the latest minor release because that's what we expect from our users. It also feels like it gives us early warning of potential problems we'll run into when we upgrade to a major release.
