### PR TITLE
Issue 349 augment current tests

### DIFF
--- a/resources/org/javarosa/xpath/expr/relative-current-ref-field-ref.xml
+++ b/resources/org/javarosa/xpath/expr/relative-current-ref-field-ref.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>relative-current-ref</h:title>
+        <model>
+            <instance>
+                <data id="relative-current-ref-form-field-bind">
+                    <my_group>
+                        <name/>
+                    </my_group>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/my_group/name" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/my_group">
+            <label>Some label</label>
+            <repeat nodeset="/data/my_group">
+                <input ref="current()/name">
+                    <label>Name</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/xpath/expr/relative-current-ref-group-count-ref.xml
+++ b/resources/org/javarosa/xpath/expr/relative-current-ref-group-count-ref.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>relative-current-ref</h:title>
+        <model>
+            <instance>
+                <data id="relative-current-ref-form-field-bind">
+                    <count>3</count>
+                    <my_group>
+                        <name/>
+                    </my_group>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/count" type="int"/>
+            <bind nodeset="/data/my_group/name" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/my_group">
+            <label>Some label</label>
+            <repeat nodeset="/data/my_group" jr:count="current()/../count">
+                <input ref="name">
+                    <label>Name</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/resources/org/javarosa/xpath/expr/relative-current-ref-itemset-nodeset.xml
+++ b/resources/org/javarosa/xpath/expr/relative-current-ref-itemset-nodeset.xml
@@ -1,4 +1,4 @@
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
     <h:head>
         <h:title>Untitled Form</h:title>
         <model>
@@ -7,45 +7,49 @@
                     <meta>
                         <instanceID/>
                     </meta>
-                    <people>
-                        <count/>
-                        <person/>
-                    </people>
+                    <repeat_group>
+                        <people>
+                            <count/>
+                            <person/>
+                        </people>
 
-                    <selected_person/>
+                        <selected_person/>
+                    </repeat_group>
                 </data>
             </instance>
             <itext>
                 <translation lang="English">
-                    <text id="/data/people:label">
+                    <text id="/data/repeat_group/people:label">
                         <value>People</value>
                     </text>
-                    <text id="/data/people/person:label">
+                    <text id="/data/repeat_group/people/person:label">
                         <value>Person</value>
                     </text>
                 </translation>
             </itext>
             <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
-            <bind nodeset="/data/people/count" type="int" calculate="position(..)"/>
-            <bind nodeset="/data/people/person" type="string"/>
-            <bind nodeset="/data/selected_person" type="select1"/>
+            <bind nodeset="/data/repeat_group/people/count" type="int" calculate="position(..)"/>
+            <bind nodeset="/data/repeat_group/people/person" type="string"/>
+            <bind nodeset="/data/repeat_group/selected_person" type="select1"/>
         </model>
     </h:head>
     <h:body>
-        <group>
-            <label ref="jr:itext('/data/people:label')"/>
-            <repeat nodeset="/data/people">
-                <input ref="/data/people/person">
-                    <label ref="jr:itext('/data/people/person:label')"/>
-                </input>
-            </repeat>
+        <repeat nodeset="/data/repeat_group">
+            <group>
+                <label ref="jr:itext('/data/repeat_group/people:label')"/>
+                <repeat nodeset="/data/repeat_group/people">
+                    <input ref="/data/repeat_group/people/person">
+                        <label ref="jr:itext('/data/repeat_group/people/person:label')"/>
+                    </input>
+                </repeat>
 
-            <select1 ref="/data/selected_person">
-                <itemset nodeset="current()/../people">
-                    <value ref="count"/>
-                    <label ref="person"/>
-                </itemset>
-            </select1>
-        </group>
+                <select1 ref="/data/repeat_group/selected_person">
+                    <itemset nodeset="current()/../people">
+                        <value ref="count"/>
+                        <label ref="person"/>
+                    </itemset>
+                </select1>
+            </group>
+        </repeat>
     </h:body>
 </h:html>

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -357,10 +357,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         return ref;
     }
 
-    public TreeElement getFirstDescendantWithName(String name) {
-        return mainInstance.getRoot().getFirstDescendantWithName(name);
-    }
-
     public void setLocalizer(Localizer l) {
         if (this.localizer != null) {
             this.localizer.unregisterLocalizable(this);

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -36,7 +36,6 @@ import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
 import org.javarosa.core.model.instance.utils.IAnswerResolver;
 import org.javarosa.core.model.instance.utils.ITreeVisitor;
 import org.javarosa.core.model.instance.utils.TreeElementChildrenList;
-import org.javarosa.core.model.instance.utils.TreeElementNameComparator;
 import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -226,30 +225,6 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
     @Override
     public List<TreeElement> getChildrenWithName(String name) {
         return children.get(name);
-    }
-
-    /** Returns the first element across descendants that has the specified name. Useful for testing. **/
-    public TreeElement getFirstDescendantWithName(String name) {
-        return getFirstDescendantWithName(this, name);
-    }
-
-    private TreeElement getFirstDescendantWithName(TreeElement node, String name) {
-        if (node.getMultiplicity() != TreeReference.INDEX_TEMPLATE &&
-            TreeElementNameComparator.elementMatchesName(node, name)) {
-            return node;
-        }
-
-        for (TreeElement child : node.children) {
-            if (child.getMultiplicity() != TreeReference.INDEX_TEMPLATE) {
-                TreeElement result = getFirstDescendantWithName(child, name);
-
-                if (result != null) {
-                    return result;
-                }
-            }
-        }
-
-        return null;
     }
 
     private int getNumChildrenWithName(String name) {

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -235,15 +235,17 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
 
     private TreeElement getFirstDescendantWithName(TreeElement node, String name) {
         if (node.getMultiplicity() != TreeReference.INDEX_TEMPLATE &&
-                TreeElementNameComparator.elementMatchesName(node, name)) {
+            TreeElementNameComparator.elementMatchesName(node, name)) {
             return node;
         }
 
         for (TreeElement child : node.children) {
-            TreeElement result = getFirstDescendantWithName(child, name);
+            if (child.getMultiplicity() != TreeReference.INDEX_TEMPLATE) {
+                TreeElement result = getFirstDescendantWithName(child, name);
 
-            if (result != null) {
-                return result;
+                if (result != null) {
+                    return result;
+                }
             }
         }
 

--- a/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/org/javarosa/core/model/instance/TreeReference.java
@@ -474,6 +474,10 @@ public class TreeReference implements Externalizable, Serializable {
     }
 
     public String toString (boolean includePredicates) {
+        return toString(includePredicates, false);
+    }
+
+    public String toString (boolean includePredicates, boolean zeroIndexMult) {
         StringBuilder sb = new StringBuilder();
         if(instanceName != null) {
             sb.append("instance("+instanceName+")");
@@ -499,13 +503,14 @@ public class TreeReference implements Externalizable, Serializable {
 
             if (includePredicates) {
                 switch (mult) {
-                case INDEX_UNBOUND: break;
-                case INDEX_TEMPLATE: sb.append("[@template]"); break;
-                case INDEX_REPEAT_JUNCTURE: sb.append("[@juncture]"); break;
-                default:
-                    if ((i > 0 || mult != 0) && mult !=-4)
-                        sb.append("[" + (mult + 1) + "]");
-                    break;
+                    case INDEX_UNBOUND: break;
+                    case INDEX_TEMPLATE: sb.append("[@template]"); break;
+                    case INDEX_REPEAT_JUNCTURE: sb.append("[@juncture]"); break;
+                    default:
+                        if ((i > 0 || mult != 0) && mult !=-4) {
+                            sb.append("[").append(mult + (zeroIndexMult ? 0 : 1)).append("]");
+                        }
+                        break;
                 }
             }
 

--- a/src/org/javarosa/form/api/FormEntryController.java
+++ b/src/org/javarosa/form/api/FormEntryController.java
@@ -21,7 +21,6 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.instance.TreeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,28 +213,6 @@ public class FormEntryController {
     public int jumpToIndex(FormIndex index) {
         model.setQuestionIndex(index);
         return model.getEvent(index);
-    }
-
-    /**
-     * Jump to the first node with the given name. Useful for testing.
-     */
-    public int jumpToFirstQuestionWithName(String name) {
-        return jumpToReference(getModel().getForm().getFirstDescendantWithName(name).getRef());
-    }
-
-    private int jumpToReference(TreeReference reference) {
-        jumpToIndex(FormIndex.createBeginningOfFormIndex());
-        FormIndex index = model.getFormIndex();
-
-        do {
-            if (index.getReference() != null && index.getReference().equals(reference)) {
-                return jumpToIndex(index);
-            }
-
-            index = model.incrementIndex(index);
-        } while (index.isInForm());
-
-        return jumpToIndex(index);
     }
 
     public FormIndex descendIntoRepeat (int n) {

--- a/test/org/javarosa/xpath/expr/AnswerDataMatchers.java
+++ b/test/org/javarosa/xpath/expr/AnswerDataMatchers.java
@@ -4,8 +4,28 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.StringData;
 
 class AnswerDataMatchers {
+    public static Matcher<StringData> stringAnswer(String expectedAnswer) {
+        return new TypeSafeMatcher<StringData>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("answer with value " + expectedAnswer);
+            }
+
+            @Override
+            protected void describeMismatchSafely(StringData item, Description mismatchDescription) {
+                mismatchDescription.appendText("was answer " + item.getDisplayText() + "(").appendValue(item.getValue()).appendText(")");
+            }
+
+            @Override
+            protected boolean matchesSafely(StringData item) {
+                return item.getValue().equals(expectedAnswer);
+            }
+        };
+    }
+
     public static <T extends IAnswerData> Matcher<T> answer(T expectedAnswer) {
         return new TypeSafeMatcher<T>() {
             @Override

--- a/test/org/javarosa/xpath/expr/AnswerDataMatchers.java
+++ b/test/org/javarosa/xpath/expr/AnswerDataMatchers.java
@@ -1,0 +1,27 @@
+package org.javarosa.xpath.expr;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.javarosa.core.model.data.IAnswerData;
+
+class AnswerDataMatchers {
+    public static <T extends IAnswerData> Matcher<T> answer(T expectedAnswer) {
+        return new TypeSafeMatcher<T>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("answer " + expectedAnswer.getDisplayText() + "(").appendValue(expectedAnswer.getValue()).appendText(")");
+            }
+
+            @Override
+            protected void describeMismatchSafely(T item, Description mismatchDescription) {
+                mismatchDescription.appendText("was answer " + item.getDisplayText() + "(").appendValue(item.getValue()).appendText(")");
+            }
+
+            @Override
+            protected boolean matchesSafely(T item) {
+                return item.getValue().equals(expectedAnswer.getValue());
+            }
+        };
+    }
+}

--- a/test/org/javarosa/xpath/expr/Scenario.java
+++ b/test/org/javarosa/xpath/expr/Scenario.java
@@ -441,7 +441,7 @@ class Scenario {
     }
 
     private List<TreeElement> childrenOf(TreeElement node) {
-        List<TreeElement> children = new ArrayList<>();
+        List<TreeElement> children = new ArrayList<>(node.getNumChildren());
         for (int i = 0, max = node.getNumChildren(); i < max; i++) {
             children.add(node.getChildAt(i));
         }

--- a/test/org/javarosa/xpath/expr/Scenario.java
+++ b/test/org/javarosa/xpath/expr/Scenario.java
@@ -6,6 +6,7 @@ import static org.javarosa.test.utils.ResourcePathHelper.r;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.QuestionDef;
@@ -18,6 +19,7 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.form.api.FormEntryPrompt;
 
 class Scenario {
     private final FormDef formDef;
@@ -28,7 +30,11 @@ class Scenario {
         this.formEntryController = formEntryController;
     }
 
-    static Scenario init(String formFileName) {
+    /**
+     * Creates and prepares the test scenario loading and parsing the given form
+     */
+    public static Scenario init(String formFileName) {
+        // TODO explain why this sequence of calls
         FormParseInit fpi = new FormParseInit(r(formFileName));
         FormDef formDef = fpi.getFormDef();
         formDef.initialize(true, new InstanceInitializationFactory());
@@ -37,68 +43,183 @@ class Scenario {
         return new Scenario(formDef, formEntryController);
     }
 
-    void answer(String xpath, String value) {
-        createMissingRepeats(xpath);
-        TreeElement resolve = resolve(xpath);
-        formDef.setValue(new StringData(value), resolve.getRef(), true);
+    /**
+     * Sets the value of the element located at the given xPath in the main instance.
+     * <p>
+     * This method supports an enhanced version of xpath with the following perks and
+     * limitations:
+     * <ul>
+     * <li>Only supports absolute xpaths</li>
+     * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
+     * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
+     * repeat: <code>/foo/bar[3]</code></li>
+     * </ul>
+     * <p>
+     * This method ensures that all the repeat instances required by the given xPath
+     * exist. For example: /data/people[1]/name will make sure the second repeat for
+     * /data/people exists.
+     * <p>
+     * This method ensures that any required downstream change after the given value
+     * is set is triggered.
+     */
+    // TODO Make more of these, one for each data type, and use the correct IAnswerData type
+    public void answer(String xPath, String value) {
+        // the xPath could include repeat group indexes, meaning that we expect
+        // some repeat group to exists. We check that and create missing repeats
+        // where they're needed.
+        createMissingRepeats(xPath);
+
+        // The xPath must match a model element. This ensures we can resolve it.
+        TreeElement element = Objects.requireNonNull(resolve(xPath));
+
+        // We wrap the given value and set it through the formDef, which triggers
+        // any downstream change in dependant elements (elements that have a
+        // calculate formula depending on this field, or itemsets rendering this
+        // field's value as a choice)
+        formDef.setValue(new StringData(value), element.getRef(), true);
     }
 
+    /**
+     * Returns the value of the element located at the given xPath in the main instance.
+     * <p>
+     * This method supports an enhanced version of xpath with the following perks and
+     * limitations:
+     * <ul>
+     * <li>Only supports absolute xpaths</li>
+     * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
+     * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
+     * repeat: <code>/foo/bar[3]</code></li>
+     * </ul>
+     * <p>
+     * Answers live in the main instance of a form. We will traverse the main
+     * instance's tree of elements recursively using the xPath as a guide of
+     * steps.
+     * <p>
+     * The starting point will be the NULL node parent of main instance's root,
+     * which corresponds to the root "/" xPath.
+     * <p>
+     * Note that the formDef.getMainInstance().getRoot() call can be misleading
+     * because it would return an element corresponding to the xPath "/data"
+     * ("data" is commonly used as the main instance's xml tag), not the root
+     * element.
+     */
     @SuppressWarnings("unchecked")
-    <T extends IAnswerData> T answerOf(String xpath) {
+    public <T extends IAnswerData> T answerOf(String xPath) {
+        // Get the real root element
         TreeElement root = (TreeElement) formDef.getMainInstance().getRoot().getParent();
-        String relativeXPath = xpath.startsWith("/") ? xpath.substring(1) : xpath;
-        TreeElement resolve = resolve(root, relativeXPath);
-        return resolve != null ? (T) resolve.getValue() : null;
+        // Since we start searching from "/", we make the input xPath relative to that
+        String relativeXPath = xPath.startsWith("/") ? xPath.substring(1) : xPath;
+
+        // We call the recursive resolve algorithm and get the element
+        TreeElement element = resolve(root, relativeXPath);
+
+        // Return the value if the element exists, otherwise return null
+        return element != null ? (T) element.getValue() : null;
     }
 
-    List<SelectChoice> choicesOf(String xpath) {
-        QuestionDef control = formEntryController.getModel().getQuestionPrompt(getIndexOf(xpath)).getQuestion();
-        formDef.populateDynamicChoices(control.getDynamicChoices(), (TreeReference) control.getBind().getReference());
+    /**
+     * Returns the list of choices of the &lt;select&gt; or &lt;select1&gt; form controls.
+     * <p>
+     * This method supports an enhanced version of xpath with the following perks and
+     * limitations:
+     * <ul>
+     * <li>Only supports absolute xpaths</li>
+     * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
+     * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
+     * repeat: <code>/foo/bar[3]</code></li>
+     * </ul>
+     * <p>
+     * This method ensures that any dynamic choce lists are populated to reflect the status
+     * of the form (already answered questions, etc.).
+     */
+    public List<SelectChoice> choicesOf(String xPath) {
+        FormEntryPrompt questionPrompt = formEntryController.getModel().getQuestionPrompt(getIndexOf(xPath));
+        // This call triggers the correct population of dynamic choices.
+        questionPrompt.getAnswerValue();
+        QuestionDef control = questionPrompt.getQuestion();
         return control.getChoices() == null
+            // If the (static) choices is null, that means there is an itemset and choices are dynamic
+            // ItemsetBinding.getChoices() will work because we've called questionPrompt.getAnswerValue()
             ? control.getDynamicChoices().getChoices()
             : control.getChoices();
     }
 
-    private void createMissingRepeats(String xpath) {
-        List<String> parts = Arrays.asList(xpath.substring(1).split("/"));
+    /**
+     * Prepare a new (main) instance in the form, to simulate the user starting to fill a
+     * new form.
+     */
+    public void newInstance() {
+        formDef.initialize(true, new InstanceInitializationFactory());
+    }
+
+    private void createMissingRepeats(String xPath) {
+        // We will be looking to the parts in the xPath from left to right.
+        // xPath.substring(1) makes the first "/" char go away, giving us an xPath relative to the root
+        List<String> parts = Arrays.asList(xPath.substring(1).split("/"));
         String currentXPath = "";
         do {
-            String firstPart = parts.get(0);
-            String name = firstPart.contains("[") ? firstPart.substring(0, firstPart.indexOf("[")) : firstPart;
-            currentXPath = currentXPath.equals("") ? "/" + name : currentXPath + "/" + firstPart;
+            String nextPart = parts.get(0);
+            // nextName holds the next part's name, excluding the multiplicity suffix if it exists.
+            String nextName = parseName(nextPart);
+            String nextXPath = currentXPath + "/" + nextPart;
 
-            boolean isRepeat = isRepeatXPath(currentXPath);
-            boolean isMissingNode = resolve(currentXPath) == null;
-            if (isRepeat && isMissingNode) {
-                formEntryController.newRepeat(getIndexOf(currentXPath + "[-1]"));
+            if (isRepeatXPath(nextXPath) && !elementExists(nextXPath)) {
+                // Jumping to the repeat instance for [0] always works because formEntryController.descendIntoNewRepeat() deals with it:
+                // - if the [0] doesn't exists, it creates it
+                // - if the [0] exists, looks for the next sequential repeat and creates it
+                formEntryController.jumpToIndex(getIndexOf((currentXPath + "/" + nextName) + "[0]"));
+                formEntryController.descendIntoNewRepeat();
             }
+            // Shift the first part of the list, reset the current xPath and loop
             parts = parts.subList(1, parts.size());
+            currentXPath = nextXPath;
         } while (!parts.isEmpty());
     }
 
+    private boolean elementExists(String xPath) {
+        return resolve(xPath) != null;
+    }
+
     private static boolean isRepeatXPath(String xPath) {
-        // We'll only look at the last part
+        // Returns true if the last xPath part contains a multiplicity suffix like "[2]"
         return xPath.substring(xPath.lastIndexOf("/")).contains("[");
     }
 
-    private TreeReference absoluteRef(String xpath) {
+    /**
+     * Returns an absolute reference of the given xPath taking multiplicity of each
+     * xPath part into account.
+     */
+    private TreeReference absoluteRef(String xPath) {
         TreeReference tr = new TreeReference();
         tr.setRefLevel(REF_ABSOLUTE);
         tr.setContext(CONTEXT_ABSOLUTE);
         tr.setInstanceName(null);
-        Arrays.stream(xpath.split("/"))
+        Arrays.stream(xPath.split("/"))
             .filter(s -> !s.isEmpty())
-            .forEach(s -> {
-                int multiplicity = s.contains("[") ? Integer.parseInt(s.substring(s.indexOf("[") + 1, s.indexOf("]"))) : 0;
-                String part = s.contains("[") ? s.substring(0, s.indexOf("[")) : s;
-                tr.add(part, multiplicity);
-            });
+            .forEach(s -> tr.add(parseName(s), parseMultiplicity(s)));
         return tr;
     }
 
-    private FormIndex getIndexOf(String xpath) {
-        // TODO Could this be resolved at initialization time and stored in a map of treereferences and formindexes?
-        TreeReference ref = absoluteRef(xpath);
+    private String parseName(String xPathPart) {
+        return xPathPart.contains("[") ? xPathPart.substring(0, xPathPart.indexOf("[")) : xPathPart;
+    }
+
+    private int parseMultiplicity(String xPathPart) {
+        return xPathPart.contains("[") ? Integer.parseInt(xPathPart.substring(xPathPart.indexOf("[") + 1, xPathPart.indexOf("]"))) : 0;
+    }
+
+    /**
+     * Returns an index to the given xPath. It uses an absolute reference to
+     * the given xPath and traverses all existing indexes until one of them
+     * matches the reference.
+     * <p>
+     * This is possible because the {@link TreeReference#equals(Object)} can
+     * deal with absolute and relative references.
+     * <p>
+     * Returns null if the reference is not found.
+     */
+    private FormIndex getIndexOf(String xPath) {
+        TreeReference ref = absoluteRef(xPath);
         formEntryController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
         FormEntryModel model = formEntryController.getModel();
         FormIndex index = model.getFormIndex();
@@ -111,25 +232,51 @@ class Scenario {
     }
 
 
+    /**
+     * Returns the element corresponding to the given xPath.
+     * <p>
+     * The starting point will be the NULL node parent of main instance's root,
+     * which corresponds to the root "/" xPath.
+     * <p>
+     * Note that the formDef.getMainInstance().getRoot() call can be misleading
+     * because it would return an element corresponding to the xPath "/data"
+     * ("data" is commonly used as the main instance's xml tag), not the root
+     * element.
+     */
     private TreeElement resolve(String xPath) {
+        // Get the real root element
         TreeElement root = (TreeElement) formDef.getMainInstance().getRoot().getParent();
+        // Since we start searching from "/", we make the input xPath relative to that
         String relativeXPath = xPath.startsWith("/") ? xPath.substring(1) : xPath;
+
         return resolve(root, relativeXPath);
     }
 
-    private TreeElement resolve(TreeElement currentElement, String restOfXPath) {
-        List<String> parts = Arrays.asList(restOfXPath.split("/"));
+    /**
+     * Returns the element corresponding to the given xPath.
+     * <p>
+     * It does so by recursively traversing children of the given element and calling
+     * {@link TreeElement#getChild(String, int)} on them.
+     */
+    private TreeElement resolve(TreeElement element, String xPath) {
+        List<String> parts = Arrays.asList(xPath.split("/"));
         String firstPart = parts.get(0);
-        String name = firstPart.contains("[") ? firstPart.substring(0, firstPart.indexOf("[")) : firstPart;
-        int multiplicity = firstPart.contains("[") ? Integer.parseInt(firstPart.substring(firstPart.indexOf("[") + 1, firstPart.indexOf("]"))) : 0;
-        TreeElement nextElement = currentElement.getChild(name, multiplicity);
+        TreeElement nextElement = element.getChild(parseName(firstPart), parseMultiplicity(firstPart));
+
+        // Return null when a child with the given name and multiplicity doesn't exist.
         if (nextElement == null)
             return null;
-        return parts.size() > 1 ? resolve(nextElement, shift(restOfXPath)) : nextElement;
+
+        // If there are more parts to analyze, call recursively on child
+        if (parts.size() > 1)
+            return resolve(nextElement, shift(xPath));
+
+        // If this is the last part in the xPath, we have the element we're looking for
+        return nextElement;
     }
 
-    private static String shift(String xpath) {
-        List<String> parts2 = Arrays.asList(xpath.split("/"));
-        return String.join("/", parts2.subList(1, parts2.size()));
+    private static String shift(String xPath) {
+        List<String> parts = Arrays.asList(xPath.split("/"));
+        return String.join("/", parts.subList(1, parts.size()));
     }
 }

--- a/test/org/javarosa/xpath/expr/Scenario.java
+++ b/test/org/javarosa/xpath/expr/Scenario.java
@@ -1,0 +1,103 @@
+package org.javarosa.xpath.expr;
+
+import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
+import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+
+import java.util.Arrays;
+import java.util.List;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+
+class Scenario {
+    private final FormDef formDef;
+    private final FormEntryController formEntryController;
+
+    private Scenario(FormDef formDef, FormEntryController formEntryController) {
+        this.formDef = formDef;
+        this.formEntryController = formEntryController;
+    }
+
+    static Scenario init(String formFileName) {
+        FormParseInit fpi = new FormParseInit(r(formFileName));
+        FormDef formDef = fpi.getFormDef();
+        formDef.initialize(true, new InstanceInitializationFactory());
+        FormEntryModel formEntryModel = new FormEntryModel(formDef);
+        FormEntryController formEntryController = new FormEntryController(formEntryModel);
+        return new Scenario(formDef, formEntryController);
+    }
+
+    Scenario answer(String xpath, String value) {
+        FormIndex index = getIndexOf(xpath);
+        formEntryController.answerQuestion(index, new StringData(value), true);
+        return this;
+    }
+
+    private TreeReference absoluteRef(String xpath) {
+        TreeReference tr = new TreeReference();
+        tr.setRefLevel(REF_ABSOLUTE);
+        tr.setContext(CONTEXT_ABSOLUTE);
+        tr.setInstanceName(null);
+        Arrays.stream(xpath.split("/"))
+            .filter(s -> !s.isEmpty())
+            .forEach(s -> {
+                int multiplicity = s.contains("[") ? Integer.parseInt(s.substring(s.indexOf("[") + 1, s.indexOf("]"))) : 0;
+                String part = s.contains("[") ? s.substring(0, s.indexOf("[")) : s;
+                tr.add(part, multiplicity);
+            });
+        return tr;
+    }
+
+    private FormIndex getIndexOf(String xpath) {
+        // TODO Could this be resolved at initialization time and stored in a map of treereferences and formindexes?
+        TreeReference ref = absoluteRef(xpath);
+        formEntryController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+        FormEntryModel model = formEntryController.getModel();
+        FormIndex index = model.getFormIndex();
+        do {
+            if (index.getReference() != null && index.getReference().equals(ref))
+                return index;
+            index = model.incrementIndex(index);
+        } while (index.isInForm());
+        throw new IllegalArgumentException("Reference " + ref + " not found");
+    }
+
+    @SuppressWarnings("unchecked")
+    <T extends IAnswerData> T answerOf(String xpath) {
+        TreeElement root = (TreeElement) formDef.getMainInstance().getRoot().getParent();
+        TreeElement resolve = resolve(root, xpath.startsWith("/") ? xpath.substring(1) : xpath);
+        return (T) resolve.getValue();
+    }
+
+    static TreeElement resolve(TreeElement current, String xpath) {
+        List<String> parts = Arrays.asList(xpath.split("/"));
+        String firstPart = parts.get(0);
+        String name = firstPart.contains("[") ? firstPart.substring(0, firstPart.indexOf("[")) : firstPart;
+        int multiplicity = firstPart.contains("[") ? Integer.parseInt(firstPart.substring(firstPart.indexOf("[") + 1, firstPart.indexOf("]"))) : 0;
+        TreeElement nextElement = current.getChild(name, multiplicity);
+        return parts.size() > 1 ? resolve(nextElement, shift(xpath)) : nextElement;
+    }
+
+    private static String shift(String xpath) {
+        List<String> parts2 = Arrays.asList(xpath.split("/"));
+        return String.join("/", parts2.subList(1, parts2.size()));
+    }
+
+    List<SelectChoice> choicesOf(String xpath) {
+        QuestionDef control = formEntryController.getModel().getQuestionPrompt(getIndexOf(xpath)).getQuestion();
+        formDef.populateDynamicChoices(control.getDynamicChoices(), (TreeReference) control.getBind().getReference());
+        return control.getChoices() == null
+            ? control.getDynamicChoices().getChoices()
+            : control.getChoices();
+    }
+}

--- a/test/org/javarosa/xpath/expr/Scenario.java
+++ b/test/org/javarosa/xpath/expr/Scenario.java
@@ -35,6 +35,27 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class helps writing JavaRosa tests. It provides two separate APIs:
+ * <ul>
+ * <li>A static, declarative API that lets the test author to define the state
+ * of a form in a given time.</li>
+ * <li>A dynamic, imperative API that lets the test author fill the form as the
+ * user would do, by controlling the flow while filling questions. These methods
+ * return the {@link Scenario} to be able to chain compatible methods.</li>
+ * </ul>
+ * <p>
+ * All the methods that accept a {@link String} xpath argument, support an enhanced
+ * version of xpath with the following perks and limitations:
+ * <ul>
+ * <li>Only supports absolute xpaths</li>
+ * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
+ * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
+ * repeat: <code>/foo/bar[3]</code></li>
+ * </ul>
+ * <p>
+ */
+// TODO Extract both APIs to two separate contexts so that they can't be mixed, probably best if it's a Scenario steps runner that would have the common .given(setup).when(action).then(assertion)
 class Scenario {
     private static final Logger log = LoggerFactory.getLogger(Scenario.class);
     private final FormDef formDef;
@@ -61,19 +82,6 @@ class Scenario {
     /**
      * Sets the value of the element located at the given xPath in the main instance.
      * <p>
-     * This method supports an enhanced version of xpath with the following perks and
-     * limitations:
-     * <ul>
-     * <li>Only supports absolute xpaths</li>
-     * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
-     * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
-     * repeat: <code>/foo/bar[3]</code></li>
-     * </ul>
-     * <p>
-     * This method ensures that all the repeat instances required by the given xPath
-     * exist. For example: /data/people[1]/name will make sure the second repeat for
-     * /data/people exists.
-     * <p>
      * This method ensures that any required downstream change after the given value
      * is set is triggered.
      */
@@ -96,16 +104,6 @@ class Scenario {
 
     /**
      * Jumps to the first question with the given name.
-     * <p>
-     * This method is part of a set of methods that address form navigation in a dynamic way,
-     * imitating real user interaction with the form:
-     * <ul>
-     * <li>{@link #jumpToFirst(String)}
-     * <li>{@link #answer(String)}
-     * <li>{@link #next()}
-     * <li>{@link #next(String)}
-     * <li>{@link #atTheEndOfForm()}
-     * </ul>
      */
     public Scenario jumpToFirst(String name) {
         jumpToFirstQuestionWithName(name);
@@ -114,16 +112,6 @@ class Scenario {
 
     /**
      * Answers the current question.
-     * <p>
-     * This method is part of a set of methods that address form navigation in a dynamic way,
-     * imitating real user interaction with the form:
-     * <ul>
-     * <li>{@link #jumpToFirst(String)}
-     * <li>{@link #answer(String)}
-     * <li>{@link #next()}
-     * <li>{@link #next(String)}
-     * <li>{@link #atTheEndOfForm()}
-     * </ul>
      */
     public Scenario answer(String value) {
         formEntryController.answerQuestion(formEntryController.getModel().getFormIndex(), new StringData(value), true);
@@ -132,15 +120,6 @@ class Scenario {
 
     /**
      * Jumps to next event
-     * <p>
-     * This method is part of a set of methods that address form navigation in a dynamic way,
-     * imitating real user interaction with the form:
-     * <ul>
-     * <li>{@link #jumpToFirst(String)}
-     * <li>{@link #answer(String, String)}
-     * <li>{@link #next()}
-     * <li>{@link #next(String)}
-     * <li>{@link #atTheEndOfForm()}
      * </ul>
      */
     public void next() {
@@ -149,16 +128,6 @@ class Scenario {
 
     /**
      * Jumps to next event with the given name
-     * <p>
-     * This method is part of a set of methods that address form navigation in a dynamic way,
-     * imitating real user interaction with the form:
-     * <ul>
-     * <li>{@link #jumpToFirst(String)}
-     * <li>{@link #answer(String, String)}
-     * <li>{@link #next()}
-     * <li>{@link #next(String)}
-     * <li>{@link #atTheEndOfForm()}
-     * </ul>
      */
     public Scenario next(String name) {
         next();
@@ -170,16 +139,6 @@ class Scenario {
 
     /**
      * Returns true when the index is at the end of the form, false otherwise
-     * <p>
-     * This method is part of a set of methods that address form navigation in a dynamic way,
-     * imitating real user interaction with the form:
-     * <ul>
-     * <li>{@link #jumpToFirst(String)}
-     * <li>{@link #answer(String, String)}
-     * <li>{@link #next()}
-     * <li>{@link #next(String)}
-     * <li>{@link #atTheEndOfForm()}
-     * </ul>
      */
     public boolean atTheEndOfForm() {
         return formEntryController.getModel().getFormIndex().isEndOfFormIndex();
@@ -187,16 +146,6 @@ class Scenario {
 
     /**
      * Returns the value of the element located at the given xPath in the main instance.
-     * <p>
-     * This method supports an enhanced version of xpath with the following perks and
-     * limitations:
-     * <ul>
-     * <li>Only supports absolute xpaths</li>
-     * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
-     * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
-     * repeat: <code>/foo/bar[3]</code></li>
-     * </ul>
-     * <p>
      * Answers live in the main instance of a form. We will traverse the main
      * instance's tree of elements recursively using the xPath as a guide of
      * steps.
@@ -245,16 +194,6 @@ class Scenario {
 
     /**
      * Returns the list of choices of the &lt;select&gt; or &lt;select1&gt; form controls.
-     * <p>
-     * This method supports an enhanced version of xpath with the following perks and
-     * limitations:
-     * <ul>
-     * <li>Only supports absolute xpaths</li>
-     * <li>Supports adding the index (zero-indexed) of a repeat instance by suffixing it between
-     * brackets. Example that would select the fourth instance of the <code>/foo/bar</code>
-     * repeat: <code>/foo/bar[3]</code></li>
-     * </ul>
-     * <p>
      * This method ensures that any dynamic choce lists are populated to reflect the status
      * of the form (already answered questions, etc.).
      */

--- a/test/org/javarosa/xpath/expr/SelectChoiceMatchers.java
+++ b/test/org/javarosa/xpath/expr/SelectChoiceMatchers.java
@@ -31,7 +31,7 @@ class SelectChoiceMatchers {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("choice with value \"" + expectedValue + "\"");
+                description.appendText("choice " + expectedDisplayText + "(\"" + expectedValue + "\")");
             }
 
             @Override

--- a/test/org/javarosa/xpath/expr/SelectChoiceMatchers.java
+++ b/test/org/javarosa/xpath/expr/SelectChoiceMatchers.java
@@ -25,4 +25,25 @@ class SelectChoiceMatchers {
             }
         };
     }
+
+    static Matcher<SelectChoice> choice(String expectedValue, String expectedDisplayText) {
+        return new TypeSafeMatcher<SelectChoice>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("choice with value \"" + expectedValue + "\"");
+            }
+
+            @Override
+            protected boolean matchesSafely(SelectChoice item) {
+                return item.getValue().equals(expectedValue) &&
+                    item.getLabelInnerText().equals(expectedDisplayText);
+            }
+
+            @Override
+            protected void describeMismatchSafely(SelectChoice item, Description mismatchDescription) {
+                mismatchDescription.appendText("was choice with value \"" + item.getValue() + "\"");
+            }
+        };
+    }
 }

--- a/test/org/javarosa/xpath/expr/SelectChoiceMatchers.java
+++ b/test/org/javarosa/xpath/expr/SelectChoiceMatchers.java
@@ -1,0 +1,28 @@
+package org.javarosa.xpath.expr;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.javarosa.core.model.SelectChoice;
+
+class SelectChoiceMatchers {
+    static Matcher<SelectChoice> choice(String expectedValue) {
+        return new TypeSafeMatcher<SelectChoice>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("choice with value \"" + expectedValue + "\"");
+            }
+
+            @Override
+            protected boolean matchesSafely(SelectChoice item) {
+                return item.getValue().equals(expectedValue);
+            }
+
+            @Override
+            protected void describeMismatchSafely(SelectChoice item, Description mismatchDescription) {
+                mismatchDescription.appendText("was choice with value \"" + item.getValue() + "\"");
+            }
+        };
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathPathExprCurrentFieldRefTest.java
+++ b/test/org/javarosa/xpath/expr/XPathPathExprCurrentFieldRefTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.xpath.expr.AnswerDataMatchers.stringAnswer;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class XPathPathExprCurrentFieldRefTest {
+    private Scenario scenario;
+
+    @Before
+    public void setUp() {
+        scenario = Scenario.init("relative-current-ref-field-ref.xml");
+    }
+
+    @Test
+    public void current_in_a_field_ref_should_be_the_same_as_a_relative_ref() {
+        // The ref on /data/my_group[0]/name uses current()/name instead of an absolute path
+        scenario.answer("/data/my_group[0]/name", "Bob");
+        scenario.answer("/data/my_group[1]/name", "Janet");
+
+        assertThat(
+            scenario.answerOf("/data/my_group[0]/name"),
+            is(stringAnswer("Bob"))
+        );
+
+        assertThat(
+            scenario.answerOf("/data/my_group[1]/name"),
+            is(stringAnswer("Janet"))
+        );
+    }
+}

--- a/test/org/javarosa/xpath/expr/XPathPathExprCurrentGroupCountRefTest.java
+++ b/test/org/javarosa/xpath/expr/XPathPathExprCurrentGroupCountRefTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javarosa.xpath.expr;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.xpath.expr.AnswerDataMatchers.stringAnswer;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class XPathPathExprCurrentGroupCountRefTest {
+    private Scenario scenario;
+
+    @Before
+    public void setUp() {
+        scenario = Scenario.init("relative-current-ref-group-count-ref.xml");
+    }
+
+    @Test
+    public void current_in_repeat_count_should_work_as_expected() {
+        // Since the form sets a count of 3 repeats, we should be at the end of the
+        // form after answering three times
+        scenario
+            .jumpToFirst("name").answer("Janet")
+            .next("name").answer("Bob")
+            .next("name").answer("Kim")
+            .next();
+
+        assertThat(scenario.answerOf("/data/my_group[0]/name"), is(stringAnswer("Janet")));
+        assertThat(scenario.answerOf("/data/my_group[1]/name"), is(stringAnswer("Bob")));
+        assertThat(scenario.answerOf("/data/my_group[2]/name"), is(stringAnswer("Kim")));
+        assertThat(scenario.atTheEndOfForm(), is(true));
+        assertThat(scenario.repeatInstancesOf("/data/my_group"), hasSize(3));
+    }
+
+}

--- a/test/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
+++ b/test/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
@@ -15,10 +15,10 @@
  */
 package org.javarosa.xpath.expr;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.javarosa.xpath.expr.SelectChoiceMatchers.choice;
 import static org.junit.Assert.assertThat;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,16 +34,28 @@ public class XPathPathExprCurrentItemsetNodesetTest {
     public void current_in_itemset_nodeset_should_refer_to_node() {
         // The choices for /data/selected_person are taken from the repeat group at /data/people
         // First We insert two items
-        scenario.answer("/data/people[0]/person", "Bob");
-        scenario.answer("/data/people[1]/person", "Janet");
+        scenario.answer("/data/repeat_group[0]/people[0]/person", "Bob");
+        scenario.answer("/data/repeat_group[0]/people[1]/person", "Janet");
+        scenario.answer("/data/repeat_group[1]/people[0]/person", "Phil");
+        scenario.answer("/data/repeat_group[1]/people[1]/person", "Rose");
+        scenario.answer("/data/repeat_group[1]/people[2]/person", "Ada");
 
         // Then we check that the choices are what we expect
         // The value of each item is the position that item holds inside the repeat group
         assertThat(
-            scenario.choicesOf("/data/selected_person"),
-            Matchers.containsInAnyOrder(
+            scenario.choicesOf("/data/repeat_group[0]/selected_person"),
+            containsInAnyOrder(
                 choice("1", "Bob"),
                 choice("2", "Janet")
+            )
+        );
+
+        assertThat(
+            scenario.choicesOf("/data/repeat_group[1]/selected_person"),
+            containsInAnyOrder(
+                choice("1", "Phil"),
+                choice("2", "Rose"),
+                choice("3", "Ada")
             )
         );
     }

--- a/test/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
+++ b/test/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
@@ -15,70 +15,36 @@
  */
 package org.javarosa.xpath.expr;
 
-import org.javarosa.core.model.FormDef;
-import org.javarosa.core.model.ItemsetBinding;
-import org.javarosa.core.model.SelectChoice;
-import org.javarosa.core.model.data.SelectOneData;
-import org.javarosa.core.model.data.StringData;
-import org.javarosa.core.model.data.helper.Selection;
-import org.javarosa.core.model.instance.InstanceInitializationFactory;
-import org.javarosa.core.test.FormParseInit;
-import org.javarosa.form.api.FormEntryController;
-import org.javarosa.form.api.FormEntryModel;
-import org.javarosa.form.api.FormEntryPrompt;
+import static org.javarosa.xpath.expr.SelectChoiceMatchers.choice;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.javarosa.test.utils.ResourcePathHelper.r;
-
 public class XPathPathExprCurrentItemsetNodesetTest {
-    private FormDef formDef;
-    private FormEntryController formEntryController;
+    private Scenario scenario;
 
     @Before
     public void setUp() {
-        FormParseInit fpi = new FormParseInit(r("relative-current-ref-itemset-nodeset.xml"));
-        formDef = fpi.getFormDef();
-        formDef.initialize(true, new InstanceInitializationFactory());
-        FormEntryModel formEntryModel = new FormEntryModel(formDef);
-        formEntryController = new FormEntryController(formEntryModel);
+        scenario = Scenario.init("relative-current-ref-itemset-nodeset.xml");
     }
 
-    /**
-     * current() in an itemset nodeset expression should refer to the select node. This is verified by building an
-     * itemset from a repeat which is a sibling of the select.
-     */
     @Test
     public void current_in_itemset_nodeset_should_refer_to_node() {
-        // don't know how to jump to repeat directly so jump to following question and step backwards
-        formEntryController.jumpToFirstQuestionWithName("selected_person");
-        formEntryController.stepToPreviousEvent(); // repeat
-        formEntryController.descendIntoRepeat(0);
-        formEntryController.stepToNextEvent(); // person
+        // The choices for /data/selected_person are taken from the repeat group at /data/people
+        // First We insert two items
+        scenario.answer("/data/people[0]/person", "Bob");
+        scenario.answer("/data/people[1]/person", "Janet");
 
-        StringData nameValue = new StringData("Bob");
-        formEntryController.answerQuestion(nameValue, true);
-
-        formEntryController.stepToNextEvent();
-        formEntryController.descendIntoNewRepeat();
-        formEntryController.stepToNextEvent(); // person
-
-        StringData nameValue2 = new StringData("Janet");
-        formEntryController.answerQuestion(nameValue2, true);
-
-        formEntryController.jumpToFirstQuestionWithName("selected_person");
-        FormEntryPrompt personPrompt = formEntryController.getModel().getQuestionPrompt();
-        personPrompt.getAnswerValue();
-        ItemsetBinding dynamicChoices = personPrompt.getQuestion().getDynamicChoices();
-
-        SelectChoice personChoice = dynamicChoices.getChoices().get(1);
-        assertEquals("Janet", personPrompt.getSelectChoiceText(personChoice));
-        SelectOneData personSelection = new SelectOneData(new Selection(personChoice));
-        formEntryController.answerQuestion(personSelection, true);
-
-        SelectOneData personSelectionValue = (SelectOneData) formDef.getFirstDescendantWithName("selected_person")
-                .getValue();
-        assertEquals("2", personSelectionValue.getDisplayText());
+        // Then we check that the choices are what we expect
+        // The value of each item is the position that item holds inside the repeat group
+        assertThat(
+            scenario.choicesOf("/data/selected_person"),
+            Matchers.containsInAnyOrder(
+                choice("1", "Bob"),
+                choice("2", "Janet")
+            )
+        );
     }
 }


### PR DESCRIPTION
Closes #349

~This PR is based on #350. Commit d07de54e is the first commit after that.~ (PR rebased to master)

This PR adds new cases to the test suite around the changes done for `current()`, `parent()`, and `anchor()`.

This PR improves the `Scenario` class for testing purposes which lets test JavaRosa with a high-level testing API. This API offers methods to statically declare the state of a form or to dynamically drive the form filling like a real user would do.

Tests developed with the `Scenario` class should give easy to understand example use cases by describing the state of the form or by sequencing user actions, and by defining high level result expectations.

#### What has been done to verify that this works as intended?
Run the tests

#### Why is this the best possible solution? Were any other approaches considered?
These changes have been worked on top of other lower level test, which are still relevant.

#### Are there any risks to merging this code? If so, what are they?
No, this is just test code and maybe some harmless visibility changes and new utility methods in the implementation codebase.