### PR TITLE
Improve parent and anchor tests

### DIFF
--- a/test/org/javarosa/core/model/instance/TreeReferenceAnchorTest.java
+++ b/test/org/javarosa/core/model/instance/TreeReferenceAnchorTest.java
@@ -9,6 +9,14 @@ import org.junit.Test;
 
 public class TreeReferenceAnchorTest {
 
+    @Test
+    public void a_relative_ref_can_be_anchored_to_an_absolute_ref() {
+        // 'baz'.anchor('/foo/bar') -> '/foo/bar/baz'
+        TreeReference tr = buildRef("baz");
+        TreeReference base = buildRef("/foo/bar");
+        assertThat(tr.anchor(base), is(buildRef("/foo/bar/baz")));
+    }
+
     @Test(expected = XPathException.class)
     public void anchoring_to_a_relative_ref_throws() {
         TreeReference tr = buildRef("some/relative/path");

--- a/test/org/javarosa/core/model/instance/TreeReferenceParentTest.java
+++ b/test/org/javarosa/core/model/instance/TreeReferenceParentTest.java
@@ -33,9 +33,7 @@ public class TreeReferenceParentTest {
             {"Parenting to an empty ref doesn't change them", "../foo", "", "../foo"},
             {"foo.parent(bar) gives bar/foo", "foo", "bar", "bar/foo"},
             {"foo.parent(../bar) gives ../bar/foo", "foo", "../bar", "../bar/foo"},
-            // TODO review this. Shouldn't this resolve to "bar/foo"?
-            {"../foo.parent(bar/baz) gives null", "../foo", "bar/baz", null},
-
+            {"../foo.parent(bar/baz) gives null", "../foo", "bar/baz", null}
         });
     }
 

--- a/test/org/javarosa/core/model/instance/TreeReferenceParentTest.java
+++ b/test/org/javarosa/core/model/instance/TreeReferenceParentTest.java
@@ -33,7 +33,8 @@ public class TreeReferenceParentTest {
             {"Parenting to an empty ref doesn't change them", "../foo", "", "../foo"},
             {"foo.parent(bar) gives bar/foo", "foo", "bar", "bar/foo"},
             {"foo.parent(../bar) gives ../bar/foo", "foo", "../bar", "../bar/foo"},
-            {"../foo.parent(bar/baz) gives null", "../foo", "bar/baz", null}
+            {"../foo.parent(bar/baz) gives null", "../foo", "bar/baz", null},
+            {"../../a.parent(..) gives ../../../a", "../../a", "..", "../../../a"}
         });
     }
 


### PR DESCRIPTION
Addresses feedback from  https://github.com/opendatakit/javarosa/pull/350#issuecomment-415514714

This PR adds some meaningful test cases that help understand how `TreeReference.parent()` and `TreeReference.anchor()` work.

#### What has been done to verify that this works as intended?
Run automated tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
Nope.