### PR TITLE
Allow a guidance hint in the absense of a regular hint

### DIFF
--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -1185,7 +1185,7 @@ public class XFormParser implements IXFormParserFunctions {
             if (ref.startsWith(ITEXT_OPEN) && ref.endsWith(ITEXT_CLOSE)) {
                 String textRef = ref.substring(ITEXT_OPEN.length(), ref.lastIndexOf(ITEXT_CLOSE));
 
-                verifyTextMappings(textRef, "<hint>", false);
+                verifyTextMappings(textRef, "<hint>", true);
                 q.setHelpTextID(textRef);
             } else {
                 throw new RuntimeException("malformed ref [" + ref + "] for <hint>");


### PR DESCRIPTION
Closes #373 

#### What has been done to verify that this works as intended?
The ultimate goal is to address https://github.com/XLSForm/pyxform/issues/225. I verified that Validate fails with [guidance.xml.txt](https://github.com/opendatakit/javarosa/files/2406768/guidance.xml.txt) on master, built javarosa on this branch, put it in Validate and verified that the form validates.

#### Why is this the best possible solution? Were any other approaches considered?
This is the same approach that labels and other elements that can be translated and have variants ("forms") use.

#### Are there any risks to merging this code? If so, what are they?
This doesn't enforce any particular variant name so I suppose it leaves the door open for a variant name that clients don't recognize. Since hints are optional anyway, this seems ok. It's what labels do.