### PR TITLE
Documentation comments and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ secrets.xml
 # logging
 logback.xml
 logback-test.xml
+
+# macOS
+.DS_Store

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -973,15 +973,16 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     /**
-     * Identifies the itemset in the backend model, and creates a set of
-     * SelectChoice objects at the current question reference based on the data
+     * Identifies the <code>itemset</code> in the backend model, and creates a set of
+     * <code>SelectChoice</code> objects at the current question reference based on the data
      * in the model.
      * <p/>
-     * Will modify the itemset binding to contain the relevant choices
+     * Modifies the <code>itemset</code> object passed by clearing any choices currently on it, and populating with
+     * choices based on the question reference <code>curQRef</code> that was passed.
      *
-     * @param itemset The binding for an itemset, where the choices will be populated
-     * @param curQRef A reference to the current question's element, which will be
-     *                used to determine the values to be chosen from.
+     * @param itemset the binding for an itemset, where the choices will be populated
+     * @param curQRef a reference to the current question's element, which will be
+     *                used to determine the values to be chosen from
      */
     public void populateDynamicChoices(ItemsetBinding itemset, TreeReference curQRef) {
         getEventNotifier().publishEvent(new Event("Dynamic choices", new EvaluationResult(curQRef, null)));
@@ -1117,7 +1118,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     /**
      * Iterates over the form's data bindings, and evaluates all post-processing calls.
      *
-     * @return true if the instance was modified in any way. false otherwise.
+     * @return true if the instance was modified in any way, otherwise false
      */
     private boolean postProcessInstance(TreeElement node) {
         // we might have issues with ordering, for example, a handler that writes
@@ -1163,7 +1164,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * Requires that the instance has been set to a prototype of the instance
      * that should be used for deserialization.
      *
-     * @param dis - the stream to read from.
+     * @param dis - the stream to read from
      * @throws IOException
      * @throws InstantiationException
      * @throws IllegalAccessException
@@ -1237,7 +1238,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     /**
      * Writes the form definition object to the supplied stream.
      *
-     * @param dos - the stream to write to.
+     * @param dos - the stream to write to
      * @throws IOException
      */
     @Override
@@ -1525,6 +1526,17 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         }
     }
 
+    /**
+    * Traverses recursively the given {@link IFormElement} node tree and returns
+    * the first {@link QuestionDef} that matches the binding defined in the
+    * given {@link TreeReference}.
+    *
+    * @param ref reference to a form binding
+    * @param fe  the recursive {@link IFormElement}. The starting call would
+    *            typically receive a {@link FormDef}
+    * @return the question definition, {@code null} if no {@link QuestionDef}
+    *         matches the given binding
+    */
     public static QuestionDef findQuestionByRef(TreeReference ref, IFormElement fe) {
         if (fe instanceof FormDef) {
             ref = ref.genericize();

--- a/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/org/javarosa/core/model/instance/TreeElement.java
@@ -52,19 +52,18 @@ import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.expr.XPathStringLiteral;
 
 /**
- * An element of a FormInstance.
+ * <p>An element of a FormInstance.</p>
  *
- * TreeElements represent an XML node in the instance. It may either have a value (e.g., <name>Drew</name>),
- * a number of TreeElement children (e.g., <meta><device /><timestamp /><user_id /></meta>), or neither (e.g.,
- * <empty_node />)
+ * <p>TreeElements represent an XML node in the instance. It may either have a value (e.g., <name>Drew</name>),
+ * a number of TreeElement children (e.g., <meta><device /><timestamp /><user_id /></meta>), or neither (e.g.,<empty_node />)</p>
  *
- * TreeElements can also represent attributes. Attributes are unique from normal elements in that they are
- * not "children" of their parent, and are always leaf nodes: IE cannot have children.
+ * <p>TreeElements can also represent attributes. Attributes are unique from normal elements in that they are
+ * not "children" of their parent, and are always leaf nodes: IE cannot have children.</p>
  *
- * TODO: Split out the bind-able session data from this class and leave only the mandatory values to speed up
- * new DOM-like models
- *  * @author Clayton Sims
- *
+ * <p>TODO: Split out the bind-able session data from this class and leave only the mandatory values to speed up
+ * new DOM-like models</p>
+ 
+ * @author Clayton Sims
  */
 
  public class TreeElement implements Externalizable, AbstractTreeElement<TreeElement> {
@@ -144,11 +143,11 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
     }
 
     /**
-     * Retrieves the TreeElement representing the attribute for
-     * the provided namespace and name, or null if none exists.
+     * <p>Retrieves the TreeElement representing the attribute for
+     * the provided namespace and name, or null if none exists.</p>
      *
-     * If 'null' is provided for the namespace, it will match the first
-     * attribute with the matching name.
+     * <p>If 'null' is provided for the namespace, it will match the first
+     * attribute with the matching name.</p>
      *
      * @param attributes - list of attributes to search
      * @param namespace
@@ -423,11 +422,11 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
     }
 
     /**
-     * Retrieves the TreeElement representing an arbitrary bind attribute
-     * for this element at the provided namespace and name, or null if none exists.
+     * <p>Retrieves the TreeElement representing an arbitrary bind attribute
+     * for this element at the provided namespace and name, or null if none exists.</p>
      *
-     * If 'null' is provided for the namespace, it will match the first
-     * attribute with the matching name.
+     * <p>If 'null' is provided for the namespace, it will match the first
+     * attribute with the matching name.</p>
      *
      * @return TreeElement
      */
@@ -435,11 +434,19 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
         return getAttribute(bindAttributes, namespace, name);
     }
 
-    /**
-     * get value of the bind attribute with namespace:name' in the list
-     *
-     * @return String
-     */
+   /**
+    * Returns the value of the given bind attribute from the given namespace.
+    * <p>
+    * Example:
+    * <ul>
+    * <li>Given a binding {@code <bind assertion="blah"/>}, calling {@code getBindAttributeValue(null, "assertion")} will return {@code "blah"}
+    * <li>Given a binding {@code <bind odk:assertion="blah"/>}, calling {@code getBindAttributeValue("odk", "assertion")} will return {@code "blah"}
+    * </ul>
+    * </p>
+    *
+    * @param namespace the namespace of the attribute. It can be null
+    * @param name      the name of the attribute
+    */
     public String getBindAttributeValue(String namespace, String name) {
         TreeElement element = getBindAttribute(namespace,name);
         return element == null ? null: getAttributeValue(element);
@@ -576,13 +583,13 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
     /*
      * TODO:
      *
-     * this new serialization scheme is kind of lame. ideally, we shouldn't have
+     * This new serialization scheme is kind of lame. ideally, we shouldn't have
      * to sub-class TreeElement at all; we should have an API that can
      * seamlessly represent complex data model objects (like weight history or
      * immunizations) as if they were explicity XML subtrees underneath the
-     * parent TreeElement
+     * parent TreeElement.
      *
-     * failing that, we should wrap this scheme in an ExternalizableWrapper
+     * Failing that, we should wrap this scheme in an ExternalizableWrapper.
      */
 
     @Override

--- a/src/org/javarosa/form/api/FormEntryController.java
+++ b/src/org/javarosa/form/api/FormEntryController.java
@@ -70,15 +70,27 @@ public class FormEntryController {
         return answerQuestion(model.getFormIndex(), data, midSurvey);
     }
 
-
-    /**
-     * Attempts to save the answer at the specified FormIndex into the
-     * datamodel.
-     *
-     * @param index
-     * @param data
-     * @return OK if save was successful, error if a constraint was violated.
-     */
+   /**
+    * Attempts to save the answer at the given {@link FormIndex} into the instance
+    * and returns one of three possible {@code int} attempt result codes:
+    * <ul>
+    * <li>{@link #ANSWER_OK}
+    * <li>{@link #ANSWER_REQUIRED_BUT_EMPTY}
+    * <li>{@link #ANSWER_CONSTRAINT_VIOLATED}
+    * </ul>
+    * <p>
+    * Side effects: When it returns {@link #ANSWER_OK}, it mutates
+    * the {@link TreeElement} corresponding to the given {@link FormIndex} by
+    * setting its value to the given {@link IAnswerData} or by copying an
+    * itemset answer if the question is complex.
+    *
+    * @param index The index of the question/prompt that is being currently evaluated
+    * @param data  The data to attempt to answer the question with.
+    * @return the attempt's {@code int} result code
+    * @throws RuntimeException when the question is complex and it has constraints.
+    *                          See inline comments.
+    * @see QuestionDef#isComplex()
+    */
     public int answerQuestion(FormIndex index, IAnswerData data, boolean midSurvey) {
         QuestionDef q = model.getQuestionPrompt(index).getQuestion();
         if (model.getEvent(index) != FormEntryController.EVENT_QUESTION) {


### PR DESCRIPTION
#### Change summary
1. Updated gitignore to ignore common OSX file.
2. Some documentation comment updates.

This is a really small PR.

#### Rationale
**1. Updated gitignore to ignore common OSX file.**  
I wasn't sure why `.DS_Store` was missing. Maybe there is a reason?

**2. Some documentation comment updates.**
I could have probably edited a lot more documentation comments (in Python they're called docstrings; not sure what they're typically called in Java; docco?). I probably will do more in the future.

#### What has been done to verify that this works as intended?
n/a

#### Why is this the best possible solution? Were any other approaches considered?
n/a

#### Are there any risks to merging this code? If so, what are they?
n/a