### PR TITLE
Make uid preload generate an RFC 4122 UUID

### DIFF
--- a/src/org/javarosa/core/model/utils/QuestionPreloader.java
+++ b/src/org/javarosa/core/model/utils/QuestionPreloader.java
@@ -109,8 +109,10 @@ public class QuestionPreloader {
             public String preloadHandled() {
                 return "uid";
             }
+
+            // Generates an RFC 4122 UUID with a "uuid:" prefix
             public IAnswerData handlePreload(String preloadParams) {
-                return new StringData(PropertyUtils.genGUID(25));
+                return new StringData("uuid:" + PropertyUtils.genUUID());
             }
 
             public boolean handlePostProcess(TreeElement node, String params) {

--- a/src/org/javarosa/core/util/PropertyUtils.java
+++ b/src/org/javarosa/core/util/PropertyUtils.java
@@ -42,7 +42,7 @@ public class PropertyUtils {
 
 
     /**
-     * Generate an RFC 1422 Version 4 UUID.
+     * Generate an RFC 4122 Version 4 UUID.
      *
      * @return a uuid
      */


### PR DESCRIPTION
Changed in preparation for form builders to use a preload instead of call on uuid() to generate instanceID.

Closes #378

#### What has been done to verify that this works as intended?
Built a jar, put it in Collect and verified that [uid-preload.xml.txt](https://github.com/opendatakit/javarosa/files/2516146/uid-preload.xml.txt) generates a UUID in the expected format (e.g. `uuid:c58ea42f-f361-444e-8fb2-ed2f689d2094`).

#### Why is this the best possible solution? Were any other approaches considered?
If we do want to make this change, I don't see any alternative. It's minimally invasive and uses existing functionality.

#### Are there any risks to merging this code? If so, what are they?
If users use the `uid` preload and for some reason depend on it having a certain format, this could be disruptive. I think that's pretty unlikely.