### PR TITLE
add new number-or-zero() XPath function

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -164,7 +164,7 @@ public class XPathFuncExpr extends XPathExpression {
             assertArgsCount(name, args, 1);
             Double val = toNumeric(argVals[0]);
             if (val.isNaN()) {
-                return Double(0);
+                return new Double(0);
             } else {
                 return val;
             }

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -160,6 +160,14 @@ public class XPathFuncExpr extends XPathExpression {
                 argVals[1] = args[1].eval(model, evalContext);
                 return argVals[1];
             }
+        } else if (name.equals("number-or-zero")) {
+            assertArgsCount(name, args, 1);
+            Double val = toNumeric(argVals[0]);
+            if (val.isNaN()) {
+                return Double(0);
+            } else {
+                return val;
+            }
         } else if (name.equals("indexed-repeat")) {
             if ((args.length == 3 || args.length == 5 || args.length == 7 || args.length == 9 || args.length == 11)) {
                 return indexedRepeat(model, evalContext, args, argVals);


### PR DESCRIPTION
Returns 0 instead of NaN if argument is not a valid numeric expression, eg number-or-zero(${foo})

 Specifically intended to replace the more long-winded coalesce(${foo},0) or if(${foo}!='',${foo},0)

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

this solution is intended to make more 'complicated' solutions less necessary or prone to user mistakes.

#### Are there any risks to merging this code? If so, what are they?

Shouldnt be - this new XPath function wont ever get used unless explicitly added to XForm expression by form writer. So will not affect any existing forms.