### PR TITLE
Add XPath translate() function

### DIFF
--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -356,6 +356,26 @@ public class XPathFuncExpr extends XPathExpression {
             int pos = str.indexOf(substr);
             // XPath reference states that we should return the empty string when we don't find the substring
             return pos >= 0 ? str.substring(pos + substr.length()) : "";
+        } else if (name.equals("translate") && args.length == 3) {
+            String str = toString(argVals[0]);
+            String fromChars = toString(argVals[1]);
+            String toChars = toString(argVals[2]);
+            StringBuilder result = new StringBuilder();
+            // iterate thru each char in the original string
+            for (int i = 0; i < str.length(); i++) {
+                char from = str.charAt(i);
+                // determine if there is a mapping for this char
+                int fromPos = fromChars.indexOf(from);
+                if (fromPos == -1) {
+                    // no mapping for this char, so just add it to result unchanged
+                    result.append(from);
+                } else if (fromPos < toChars.length()) {
+                    // replace with the corresponding char it is mapped to
+                    result.append(toChars.charAt(fromPos));
+                }
+                // else the char is mapped to nothing, so per XPath definition we 'delete' it from the string by simply not appending it
+            }
+            return result.toString();
         } else if (name.equals("contains") && args.length == 2) {
             return toString(argVals[0]).contains(toString(argVals[1]));
         } else if (name.equals("starts-with") && args.length == 2) {

--- a/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -360,6 +360,7 @@ public class XPathFuncExpr extends XPathExpression {
             String str = toString(argVals[0]);
             String fromChars = toString(argVals[1]);
             String toChars = toString(argVals[2]);
+            int toNumChars = toChars.length();
             StringBuilder result = new StringBuilder();
             // iterate thru each char in the original string
             for (int i = 0; i < str.length(); i++) {
@@ -369,7 +370,7 @@ public class XPathFuncExpr extends XPathExpression {
                 if (fromPos == -1) {
                     // no mapping for this char, so just add it to result unchanged
                     result.append(from);
-                } else if (fromPos < toChars.length()) {
+                } else if (fromPos < toNumChars) {
                     // replace with the corresponding char it is mapped to
                     result.append(toChars.charAt(fromPos));
                 }

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -260,6 +260,15 @@ public class XPathEvalTest extends TestCase {
         testEval("substring-after('hello','')", "hello");
         testEval("substring-after('','')", "");
         testEval("substring-after('','q')", "");
+        testEval("translate('hello','l','L')", "heLLo");
+        testEval("translate('hello','q','Q')", "hello");
+        testEval("translate('hello','','L')", "hello");
+        testEval("translate('hello','l','')", "heo");
+        testEval("translate('','l','L')", "");
+        testEval("translate('hello','lo','LO')", "heLLO");
+        testEval("translate('hello world','hello','')", "wrd");
+        testEval("translate('hello wor,ld',' ,',', ')", "hello,wor ld");
+        testEval("translate('2019/01/02','/','-')", "2019-01-02");
         testEval("contains('a', 'a')",      true);
         testEval("contains('a', 'b')",      false);
         testEval("contains('abc', 'b')",    true);

--- a/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -266,7 +266,7 @@ public class XPathEvalTest extends TestCase {
         testEval("translate('hello','l','')", "heo");
         testEval("translate('','l','L')", "");
         testEval("translate('hello','lo','LO')", "heLLO");
-        testEval("translate('hello world','hello','')", "wrd");
+        testEval("translate('hello world','hello','')", " wrd");
         testEval("translate('hello wor,ld',' ,',', ')", "hello,wor ld");
         testEval("translate('2019/01/02','/','-')", "2019-01-02");
         testEval("contains('a', 'a')",      true);


### PR DESCRIPTION
Closes # https://forum.opendatakit.org/t/add-xpath-translate-function/17017

#### What has been done to verify that this works as intended?

tested under Android Studio simulator running ODK Collect v1.18.0 (dirty), using test examples described on http://www.xsltfunctions.com/xsl/fn_translate.html (and those added to testEval testcases), and compared results running same against Enketo.

#### Why is this the best possible solution? Were any other approaches considered?

Implements XPath standardized function (which is arguably best solution). Implements identical XPath behavior as exists already in Enketo and libxml2.

BTW, I also tried an implementation that avoided using a StringBuilder, and instead tried to exploit existing java String replace()/replaceAll() functions, but this ended up much messier, required multiple re-instantiations of String objects, and ultimately did not handle simultaneous interchanging translations correctly (eg 'x' --> 'y' and 'y' --> 'x').

#### Are there any risks to merging this code? If so, what are they?

Introduces entirely new XPath function and does not touch or modify any existing javaRosa function or behavior. Can only be used by new forms that exploit this new function in their XPath expressions, so no risk to existing forms.