### PR TITLE
Add methods: isPresentationGroup, isLogicalGroup

### DIFF
--- a/resources/group-with-ref-attr.xml
+++ b/resources/group-with-ref-attr.xml
@@ -1,0 +1,29 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>group with ref attribute</h:title>
+        <model>
+            <instance>
+                <data id="group-with-ref-attr">
+                    <G1>
+                        <G2>
+                            <Q1/>
+                        </G2>
+                        <G3>
+                            <Q2/>
+                        </G3>
+                    </G1>
+                </data>
+            </instance>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/G1">
+            <group>
+                <input ref="/data/G1/G2/Q1"/>
+            </group>
+            <group ref="/data/G1/G3">
+                <input ref="/data/G1/G3/Q2"/>
+            </group>
+        </group>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/core/model/GroupDef.java
+++ b/src/org/javarosa/core/model/GroupDef.java
@@ -70,6 +70,8 @@ public class GroupDef implements IFormElement, Localizable {
     List<FormElementStateListener> observers;
 
     public boolean noAddRemove = false;
+    /** True if the group has a `ref`, i.e. it's a "logical group". */
+    public boolean isLogicalGroup = false;
     public IDataReference count = null;
 
     public GroupDef () {
@@ -209,6 +211,7 @@ public class GroupDef implements IFormElement, Localizable {
             setChildren((List<IFormElement>)ExtUtil.read(dis, new ExtWrapListPoly(), pf));
 
             noAddRemove = ExtUtil.readBool(dis);
+            isLogicalGroup = ExtUtil.readBool(dis);
             count = (IDataReference)ExtUtil.read(dis, new ExtWrapNullable(new ExtWrapTagged()), pf);
 
             chooseCaption = ExtUtil.nullIfEmpty(ExtUtil.readString(dis));
@@ -238,6 +241,7 @@ public class GroupDef implements IFormElement, Localizable {
         ExtUtil.write(dos, new ExtWrapListPoly(getChildren()));
 
         ExtUtil.writeBool(dos, noAddRemove);
+        ExtUtil.writeBool(dos, isLogicalGroup);
         ExtUtil.write(dos, new ExtWrapNullable(count != null ? new ExtWrapTagged(count) : null));
 
         ExtUtil.writeString(dos, ExtUtil.emptyIfNull(chooseCaption));

--- a/src/org/javarosa/form/api/FormEntryCaption.java
+++ b/src/org/javarosa/form/api/FormEntryCaption.java
@@ -379,6 +379,30 @@ public class FormEntryCaption implements FormElementStateListener {
         }
     }
 
+    /**
+     * Returns true if the group has a displayable label,
+     * i.e. it's a "presentation group".
+     */
+    public boolean isPresentationGroup() {
+        if (!(element instanceof GroupDef)) {
+            return false;
+        }
+
+        return getShortText() != null;
+    }
+
+    /**
+     * Returns true if the group has an XML `ref` attribute,
+     * i.e. it's a "logical group".
+     */
+    public boolean isLogicalGroup() {
+        if (!(element instanceof GroupDef)) {
+            return false;
+        }
+
+        return ((GroupDef) element).isLogicalGroup;
+    }
+
     public FormIndex getIndex() {
         return index;
     }

--- a/src/org/javarosa/xform/parse/XFormParser.java
+++ b/src/org/javarosa/xform/parse/XFormParser.java
@@ -1450,6 +1450,8 @@ public class XFormParser implements IXFormParserFunctions {
         String bind = e.getAttributeValue(null, BIND_ATTR);
         group.setAppearanceAttr(e.getAttributeValue(null, APPEARANCE_ATTR));
 
+        group.isLogicalGroup = ref != null;
+
         if (bind != null) {
             DataBinding binding = bindingsByID.get(bind);
             if (binding == null) {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -414,6 +414,24 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
+    @Test public void parseGroupWithRefAttrForm() throws IOException, XPathSyntaxException {
+        // Given & When
+        FormDef formDef = parse(r("group-with-ref-attr.xml"));
+
+        // Then
+        assertEquals(formDef.getTitle(), "group with ref attribute");
+        assertEquals("Number of error messages", 0, formDef.getParseErrors().size());
+
+        IFormElement firstGroup = formDef.getChild(0);
+        assertThat(((GroupDef) firstGroup).isLogicalGroup, is(true));
+
+        IFormElement secondGroup = firstGroup.getChild(0);
+        assertThat(((GroupDef) secondGroup).isLogicalGroup, is(false));
+
+        IFormElement thirdGroup = firstGroup.getChild(1);
+        assertThat(((GroupDef) thirdGroup).isLogicalGroup, is(true));
+    }
+
     private TreeElement findDepthFirst(TreeElement parent, String name) {
         int len = parent.getNumChildren();
         for (int i = 0; i < len; ++i) {


### PR DESCRIPTION
Changes:
- Adds 2 new methods to `FormEntryCaption` in order to determine if a particular group is a "presentation group" and/or a "logical group" (see [docs](https://opendatakit.github.io/xforms-spec/#groups) for definitions).

#### What has been done to verify that this works as intended?
Verified with https://github.com/opendatakit/collect/pull/2815.

#### Why is this the best possible solution? Were any other approaches considered?
This simplifies the logic in Collect previously used to determine group status.

I previously tried using `getAdditionalAttribute(null, "ref")` to see if a group has a `ref`, but `ref` is not available in the list of "additional" attributes because it's used by JR internally (and thus removed from the list).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It adds 2 new methods. `GroupDef` serialization has also been updated accordingly.

❓ Due to serialization, existing forms may **not** be recognized as having "logical groups" until they're re-parsed. I got conflicting results locally, but it seems like `isLogicalGroup` will only be set on re-parse, which will only happen **after the form XML is updated**. Can anyone confirm if that's accurate?

#### Do we need any specific form for testing your changes? If so, please attach one.
See linked Collect PR.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Not that I know of.
