### PR TITLE
Add tests for "logical group" bindings

### DIFF
--- a/resources/group-with-ref-attr.xml
+++ b/resources/group-with-ref-attr.xml
@@ -1,0 +1,29 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>group with ref attribute</h:title>
+        <model>
+            <instance>
+                <data id="group-with-ref-attr">
+                    <G1>
+                        <G2>
+                            <Q1/>
+                        </G2>
+                        <G3>
+                            <Q2/>
+                        </G3>
+                    </G1>
+                </data>
+            </instance>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/G1">
+            <group>
+                <input ref="/data/G1/G2/Q1"/>
+            </group>
+            <group ref="/data/G1/G3">
+                <input ref="/data/G1/G3/Q2"/>
+            </group>
+        </group>
+    </h:body>
+</h:html>

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -414,6 +414,41 @@ public class XFormParserTest {
         assertThat(groupElement.getBind(), is(expectedXPathReference));
     }
 
+    @Test public void parseGroupWithRefAttrForm() throws IOException, XPathSyntaxException {
+        // Given & When
+        FormDef formDef = parse(r("group-with-ref-attr.xml"));
+
+        // Then
+        assertEquals(formDef.getTitle(), "group with ref attribute");
+        assertEquals("Number of error messages", 0, formDef.getParseErrors().size());
+
+        final TreeReference g2TreeRef = new TreeReference();
+        g2TreeRef.setRefLevel(-1); // absolute reference
+        g2TreeRef.add("data", -1); // the instance root
+        g2TreeRef.add("G1", -1); // the outer group
+        g2TreeRef.add("G2", -1); // the inner group
+
+        // G2 does NOT have a `ref`.
+        // Collect implicitly assumes the TreeReference will be created like this.
+        IDataReference g2AbsRef = FormDef.getAbsRef(null, g2TreeRef.getParentRef());
+
+        IFormElement g2Element = formDef.getChild(0).getChild(0);
+        assertThat(g2Element.getBind(), is(g2AbsRef));
+
+        final TreeReference g3TreeRef = new TreeReference();
+        g3TreeRef.setRefLevel(-1); // absolute reference
+        g3TreeRef.add("data", -1); // the instance root
+        g3TreeRef.add("G1", -1); // the outer group
+        g3TreeRef.add("G3", -1); // the inner group
+
+        // G3 has a `ref`.
+        // Collect implicitly assumes the TreeReference will be created like this.
+        IDataReference g3AbsRef = FormDef.getAbsRef(new XPathReference(g3TreeRef), g3TreeRef.getParentRef());
+
+        IFormElement g3Element = formDef.getChild(0).getChild(1);
+        assertThat(g3Element.getBind(), is(g3AbsRef));
+    }
+
     private TreeElement findDepthFirst(TreeElement parent, String name) {
         int len = parent.getNumChildren();
         for (int i = 0; i < len; ++i) {


### PR DESCRIPTION
As discussed with @yanokwa, this PR adds unit tests for the `isLogicalGroup` logic that was added in https://github.com/opendatakit/collect/pull/2764.

It was originally intended to be removed in https://github.com/opendatakit/collect/pull/2815, but that would have been problematic because after JavaRosa parses a form, it doesn't parse it again unless the XML itself changes, thus many existing users wouldn't be able to see the new "visible groups" feature.

Instead, this PR simply adds unit tests for the logic that Collect depends on until https://github.com/opendatakit/collect/issues/2818 can be addressed.