### PR TITLE
Release v2.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ jacocoTestReport {
 
 // Required to use fileExtensions property in checkstyle file
 checkstyle {
-    toolVersion = '7.6.1' 
+    toolVersion = '7.6.1'
 }
 
 jar {
@@ -62,7 +62,7 @@ jar {
     // Be sure to update version in pom.xml to match
     // snapshot release = x.x.x-SNAPSHOT
     // production release = x.x.x
-    version = '2.13.0'
+    version = '2.14.0-SNAPSHOT'
     archiveName = baseName + '-' + version + '.jar'
 
     manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ jar {
     // Be sure to update version in pom.xml to match
     // snapshot release = x.x.x-SNAPSHOT
     // production release = x.x.x
-    version = '2.13.0-SNAPSHOT'
+    version = '2.13.0'
     archiveName = baseName + '-' + version + '.jar'
 
     manifest {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- Be sure to update version in build.gradle to match -->
   <!-- snapshot release = x.x.x-SNAPSHOT -->
   <!-- production release = x.x.x -->
-  <version>2.13.0-SNAPSHOT</version>
+  <version>2.13.0</version>
   <packaging>jar</packaging>
   <name>opendatakit-javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- Be sure to update version in build.gradle to match -->
   <!-- snapshot release = x.x.x-SNAPSHOT -->
   <!-- production release = x.x.x -->
-  <version>2.13.0</version>
+  <version>2.14.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>opendatakit-javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>


### PR DESCRIPTION
This PR sets the versions for the next release and development cycles:
- We're releasing v2.13.0
- Next version will be v2.14.0. 
  Planned new features are: external csv itemsets, preloading last saved answers, benchmarking...