### PR TITLE
Ensure formatted datetimes follow the ISO8601 #404

### DIFF
--- a/src/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/org/javarosa/core/model/utils/DateUtils.java
@@ -249,7 +249,7 @@ public class DateUtils {
             int value = Math.abs(offset) / 1000 / 60;
 
             String hrs = intPad(value / 60, 2);
-            String mins = value % 60 != 0 ? ":" + intPad(value % 60, 2) :"";
+            String mins = ":" + intPad(value % 60, 2);
 
             time += offsetSign + hrs + mins;
         }

--- a/test/org/javarosa/core/model/utils/test/DateUtilsSCTOTests.java
+++ b/test/org/javarosa/core/model/utils/test/DateUtilsSCTOTests.java
@@ -43,7 +43,7 @@ public class DateUtilsSCTOTests {
         Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
         String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
 
-        assertEquals("2014-10-04T23:03:05.244+0200", str);
+        assertEquals("2014-10-04T23:03:05.244+02:00", str);
     }
 
     @Test
@@ -53,7 +53,7 @@ public class DateUtilsSCTOTests {
         Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
         String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
 
-        assertEquals("2014-10-05T00:03:05.244+0300", str);
+        assertEquals("2014-10-05T00:03:05.244+03:00", str);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DateUtilsSCTOTests {
 
         String formatted = DateUtils.formatTime(date, DateUtils.FORMAT_ISO8601);
 
-        assertEquals("11:03:05.011+0200", formatted);
+        assertEquals("11:03:05.011+02:00", formatted);
     }
 
     @Test

--- a/test/org/javarosa/core/model/utils/test/DateUtilsSCTOTests.java
+++ b/test/org/javarosa/core/model/utils/test/DateUtilsSCTOTests.java
@@ -43,7 +43,7 @@ public class DateUtilsSCTOTests {
         Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
         String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
 
-        assertEquals("2014-10-04T23:03:05.244+02", str);
+        assertEquals("2014-10-04T23:03:05.244+0200", str);
     }
 
     @Test
@@ -53,7 +53,7 @@ public class DateUtilsSCTOTests {
         Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
         String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
 
-        assertEquals("2014-10-05T00:03:05.244+03", str);
+        assertEquals("2014-10-05T00:03:05.244+0300", str);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DateUtilsSCTOTests {
 
         String formatted = DateUtils.formatTime(date, DateUtils.FORMAT_ISO8601);
 
-        assertEquals("11:03:05.011+02", formatted);
+        assertEquals("11:03:05.011+0200", formatted);
     }
 
     @Test


### PR DESCRIPTION
fix for https://github.com/opendatakit/javarosa/issues/404

- always display timezone offset minutes, instead of dropping them if 00

Closes #404 

#### What has been done to verify that this works as intended?
Tested using form containing dateTime user input, now() calculation, and date(decimal-date-time(now)) as different means which generate dateTime results.

Ran 'before' test to confirm all the resulting dateTime strings in the submission instance XML had dropped the minutes:

`<?xml version='1.0' ?><data id="snapshot_xml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><datetime>2019-03-06T12:32:00.000+13</datetime><show_datetime /><now>2019-03-06T12:32:32.387+13</now><show_now /><calc>2019-03-05T00:00:00.000+13</calc><show_calc /><meta><instanceID>uuid:49d1cf07-2644-4653-a2f2-0bac47acde7a</instanceID></meta></data>
`

Then re-ran test using same form after making change to confirm all the resulting dateTime strings in the submission instance XML now correctly showed 00 minutes:

`<?xml version='1.0' ?><data id="snapshot_xml" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms"><datetime>2019-03-06T12:40:00.000+13:00</datetime><show_datetime /><now>2019-03-06T12:40:31.132+13:00</now><show_now /><calc>2019-03-05T00:00:00.000+13:00</calc><show_calc /><meta><instanceID>uuid:79cdb162-077f-419b-861a-631ae4fa008b</instanceID></meta></data>
`

#### Why is this the best possible solution? Were any other approaches considered?

Only obvious place to fix. No other approach considered

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change will result in submitted dateTime being fully iso8601 conformant. Given that tools consuming these dateTime must already have been able to handle timezone offset minutes - because they would previously have been present should the offset have been, say, 30min, then they should already be able to handle 00 minutes.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

I dont believe the dropping of 00 minutes feature was previously documented anywhere, so there should be no doc changes necessary. [@ggalmazor can you confirm?]