### PR TITLE
Register range element into CoreModelModule

### DIFF
--- a/src/org/javarosa/core/model/CoreModelModule.java
+++ b/src/org/javarosa/core/model/CoreModelModule.java
@@ -27,6 +27,7 @@ public class CoreModelModule implements IModule {
             "org.javarosa.core.model.SubmissionProfile",
             "org.javarosa.core.model.FormDef",
             "org.javarosa.core.model.QuestionDef",
+            "org.javarosa.core.model.RangeQuestion",
             "org.javarosa.core.model.GroupDef",
             "org.javarosa.core.model.instance.FormInstance",
             "org.javarosa.core.model.instance.ExternalDataInstance",

--- a/src/org/javarosa/core/util/externalizable/ExtWrapTagged.java
+++ b/src/org/javarosa/core/util/externalizable/ExtWrapTagged.java
@@ -78,7 +78,7 @@ public class ExtWrapTagged extends ExternalizableWrapper {
 
             //find wrapper indicated by code
             ExternalizableWrapper type = null;
-      for (Object key : WRAPPER_CODES.keySet()) {
+            for (Object key : WRAPPER_CODES.keySet()) {
                 Class t = (Class)key;
                 if (WRAPPER_CODES.get(t) == wrapperCode) {
                     try {

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -202,6 +202,14 @@ public class XFormParserTest {
         serAndDeserializeForm(r("Simpler_Cascading_Select_Form.xml"));
     }
 
+    /**
+     * ensure serializing and deserializing a range form is done without errors
+     * see https://github.com/opendatakit/javarosa/issues/245 why this is needed
+     */
+    @Test public void rangeFormSavesAndRestores() throws IOException, DeserializationException {
+        serAndDeserializeForm(r("range-form.xml"));
+    }
+
     @Test public void externalSecondaryInstanceFormSavesAndRestores() throws IOException, DeserializationException {
         Path formPath = EXTERNAL_SECONDARY_INSTANCE_XML;
         mapFileToResourcePath(formPath);


### PR DESCRIPTION
Closes #245 

#### What has been done to verify that this works as intended?
run unit test method provided by @dcbriccetti 

#### Why is this the best possible solution? Were any other approaches considered?
Insted of adding into `CoreModelModule` we can add `RangeQuestion` into another classes: `JavaRosaCoreModule` or `XFormsModule`, but only `CoreModelModule` seems relevant for me as `QuestionDef` is also placed there

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should not, as mentioned in opendatakit/collect#2731 only throw warning

#### Do we need any specific form for testing your changes? If so, please attach one.
yes, i already added the form into `resources` dir. FYI i'm using the `all-widgets.xml` from collect assets not from the issue as it is latest version. Both forms passed the unit test

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No