### PR TITLE
Support reading/writing external parameters used in RangeQuestion

### DIFF
--- a/src/org/javarosa/core/model/RangeQuestion.java
+++ b/src/org/javarosa/core/model/RangeQuestion.java
@@ -1,5 +1,14 @@
 package org.javarosa.core.model;
 
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xform.parse.RangeParser;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 
 /** A Range-type question, with information pulled from attributes of the range form element */
@@ -31,5 +40,21 @@ public class RangeQuestion extends QuestionDef {
 
     public BigDecimal getRangeStep() {
         return rangeStep;
+    }
+
+    @Override
+    public void readExternal(DataInputStream dis, PrototypeFactory pf) throws IOException, DeserializationException {
+        super.readExternal(dis, pf);
+        rangeStart = RangeParser.getDecimalValue((String) ExtUtil.read(dis, new ExtWrapNullable(String.class), pf));
+        rangeEnd = RangeParser.getDecimalValue((String) ExtUtil.read(dis, new ExtWrapNullable(String.class), pf));
+        rangeStep = RangeParser.getDecimalValue((String) ExtUtil.read(dis, new ExtWrapNullable(String.class), pf));
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream dos) throws IOException {
+        super.writeExternal(dos);
+        ExtUtil.write(dos, new ExtWrapNullable(rangeStart != null ? rangeStart.toString() : null));
+        ExtUtil.write(dos, new ExtWrapNullable(rangeEnd != null ? rangeEnd.toString() : null));
+        ExtUtil.write(dos, new ExtWrapNullable(rangeStep != null ? rangeStep.toString() : null));
     }
 }

--- a/src/org/javarosa/xform/parse/RangeParser.java
+++ b/src/org/javarosa/xform/parse/RangeParser.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** Features for parsing the range element */
-class RangeParser {
+public class RangeParser {
     static void populateQuestionWithRangeAttributes(RangeQuestion question, Element e) {
         final Set<String> rangeAttributeNames = Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList("start", "end", "step")));
@@ -43,7 +43,7 @@ class RangeParser {
         }
     }
 
-    private static BigDecimal getDecimalValue(String s) {
+    public static BigDecimal getDecimalValue(String s) {
         try {
             return new BigDecimal(s);
         } catch (NumberFormatException nfe) {


### PR DESCRIPTION
Closes #410 

#### What has been done to verify that this works as intended?
I tested this fix with Collect. Here is an apk with this fix:
[collect-debug-v1.20.0-78-gc103044-dirty.apk.zip](https://github.com/opendatakit/javarosa/files/2990550/collect-debug-v1.20.0-78-gc103044-dirty.apk.zip)

#### Why is this the best possible solution? Were any other approaches considered?
We just need to read/write those parameters to use cache files in Collect.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not risky since changes are small. Playing with some forms would be enough here. I implemented changes only for RangeQuestion so we can focus only on that question type.

It would be good to test a case where we have a form used at least once using Collect v1.20.0 and then upgrading to a version with this fix and trying to open the same form again. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with RangeQuestions: 
[range.xml.txt](https://github.com/opendatakit/javarosa/files/2990530/range.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
