### PR TITLE
Add odk-instance-first-load event and deprecate xforms-ready

### DIFF
--- a/resources/form-with-setvalue-action.xml
+++ b/resources/form-with-setvalue-action.xml
@@ -9,7 +9,7 @@
                 </data>
             </instance>
             <bind id="text-data-binding" nodeset="/data/text" type="string"/>
-            <setvalue bind="text-data-binding" event="xforms-ready" >Test Value</setvalue>
+            <setvalue bind="text-data-binding" event="odk-instance-first-load" >Test Value</setvalue>
         </model>
     </h:head>
     <h:body />

--- a/resources/org/javarosa/xform/parse/last-saved-blank.xml
+++ b/resources/org/javarosa/xform/parse/last-saved-blank.xml
@@ -12,7 +12,7 @@
             </instance>
             <instance id="last-saved" src="jr://instance/last-saved"/>
             <bind nodeset="/data/item" type="string"/>
-            <setvalue event="xforms-ready" ref="/data/item" value="instance('last-saved')/data/item"/>
+            <setvalue event="odk-instance-first-load" ref="/data/item" value="instance('last-saved')/data/item"/>
         </model>
     </h:head>
 

--- a/resources/org/javarosa/xform/parse/last-saved-filled.xml
+++ b/resources/org/javarosa/xform/parse/last-saved-filled.xml
@@ -12,7 +12,7 @@
             </instance>
             <instance id="last-saved" src="jr://instance/last-saved"/>
             <bind nodeset="/data/item" type="string"/>
-            <setvalue event="xforms-ready" ref="/data/item" value="instance('last-saved')/data/item"/>
+            <setvalue event="odk-instance-first-load" ref="/data/item" value="instance('last-saved')/data/item"/>
         </model>
     </h:head>
 

--- a/src/org/javarosa/core/model/FormDef.java
+++ b/src/org/javarosa/core/model/FormDef.java
@@ -1227,10 +1227,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             getLocalizer().setToDefault();
         }
 
-        // TODO: Hm, not 100% sure that this is right. Maybe we should be
-        // using a slightly different event for "First Load" which doesn't
-        // get fired again, but always fire this one?
         if (newInstance) {
+            actionController.triggerActionsFromEvent(Action.EVENT_ODK_INSTANCE_FIRST_LOAD, this);
+
+            // xforms-ready is marked as deprecated as of JavaRosa 2.14.0 but is still dispatched for compatibility with
+            // old form definitions
             actionController.triggerActionsFromEvent(Action.EVENT_XFORMS_READY, this);
         }
 

--- a/src/org/javarosa/core/model/actions/Action.java
+++ b/src/org/javarosa/core/model/actions/Action.java
@@ -20,11 +20,23 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  */
 public abstract class Action implements Externalizable {
     // Events that can trigger an action
+
+    /**
+     * Dispatched the first time a form instance is loaded.
+     */
+    public static final String EVENT_ODK_INSTANCE_FIRST_LOAD = "odk-instance-first-load";
+
+    /**
+     * @deprecated because as W3C XForms defines it, it should be dispatched any time the XForms engine is ready. In
+     * JavaRosa, it was dispatched only on first load of a form instance. Use
+     * {@link #EVENT_ODK_INSTANCE_FIRST_LOAD} instead.
+     */
+    @Deprecated
     public static final String EVENT_XFORMS_READY = "xforms-ready";
     public static final String EVENT_XFORMS_REVALIDATE = "xforms-revalidate";
     public static final String EVENT_JR_INSERT = "jr-insert";
     public static final String EVENT_QUESTION_VALUE_CHANGED = "xforms-value-changed";
-    private static final String[] allEvents = new String[]{EVENT_JR_INSERT,
+    private static final String[] allEvents = new String[]{EVENT_ODK_INSTANCE_FIRST_LOAD, EVENT_JR_INSERT,
                         EVENT_QUESTION_VALUE_CHANGED, EVENT_XFORMS_READY, EVENT_XFORMS_REVALIDATE};
 
     private String name;

--- a/test/org/javarosa/xform/parse/XFormParserTest.java
+++ b/test/org/javarosa/xform/parse/XFormParserTest.java
@@ -428,13 +428,13 @@ public class XFormParserTest {
         // Given & When
         FormDef formDef = parse(r("form-with-setvalue-action.xml"));
 
-        // dispatch 'xforms-ready' action (Action.EVENT_XFORMS_READY)
+        // dispatch 'odk-instance-first-load' event (Action.EVENT_ODK_INSTANCE_FIRST_LOAD)
         formDef.initialize(true, new InstanceInitializationFactory());
 
         // Then
         assertEquals(formDef.getTitle(), "SetValue action");
         assertNoParseErrors(formDef);
-        assertEquals(1, formDef.getActionController().getListenersForEvent(Action.EVENT_XFORMS_READY).size());
+        assertEquals(1, formDef.getActionController().getListenersForEvent(Action.EVENT_ODK_INSTANCE_FIRST_LOAD).size());
 
         TreeElement textNode =
                 formDef.getMainInstance().getRoot().getChildrenWithName("text").get(0);


### PR DESCRIPTION
Closes #412

#### What has been done to verify that this works as intended?
Changed the test forms to use `odk-instance-first-load` event and verified that tests still pass.

#### Why is this the best possible solution? Were any other approaches considered?
I considered adding a `FormEvent` enum to do some cleanup while I was here but since we'd like to release this very soon I went for the easiest diff to review and verify. I searched the codebase for `"xforms-ready"` and `XFORMS_READY` and made additions and substitutions as needed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This doesn't change any existing behavior and only adds a new event. I'm not seeing regression risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
https://github.com/lognaturel/javarosa/blob/b30ce18c876045b3508716ba5f7359ede303af91/resources/form-with-setvalue-action.xml and https://github.com/lognaturel/javarosa/blob/b30ce18c876045b3508716ba5f7359ede303af91/resources/org/javarosa/xform/parse/last-saved-filled.xml are verified by the test suite but it wouldn't be a bad idea to verify in Collect as well.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
This only affects XML form definitions so doesn't need to be part of user-facing docs. https://github.com/opendatakit/xforms-spec/issues/223 has been filed.

CC @cooperka 