### PR TITLE
Upgrade mvn plugins to fix Javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.8.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -108,7 +108,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -119,7 +119,7 @@
               <!-- Fix for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
               <source>8</source>
               <!-- Turn off doclint in JDK 8 because it errors instead of warns -->
-              <additionalparam>-Xdoclint:none</additionalparam>
+              <doclint>none</doclint>
             </configuration>
           </execution>
         </executions>
@@ -128,7 +128,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>copy-installed</id>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
* Ran `mvn clean package` on my local machine to ensure the JavaDoc build works.
* Ran `mvn -s secrets.xml clean deploy` and made sure the snapshot worked (which maybe I should have waited to get this PR approved first, but there's no easy way to test).

#### Why is this the best possible solution? Were any other approaches considered?
We could upgrade to latest point releases, but I figured I'd jump to the latest versions and get that working. If we can't ship to the maven repo for some reason, we'll see this in Collect immediately and roll back.

Useful links: 
* How I knew an upgrade would help: https://github.com/eclipse/xtext-maven/issues/47#issuecomment-416027182
* How I knew about the doclint fix: https://github.com/twitter/hraven/issues/162#issuecomment-433941617

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Should have no user facing changes. This is just the scripts that go to the maven repo. Worst case, JavaDoc will be broken, but I'm pretty sure no one uses that.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.