### PR TITLE
WIP - Micro-benchmarks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.21'
+    testCompile group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.21'
 }
 
 jacocoTestReport {
@@ -54,7 +56,7 @@ jacocoTestReport {
 
 // Required to use fileExtensions property in checkstyle file
 checkstyle {
-    toolVersion = '7.6.1' 
+    toolVersion = '7.6.1'
 }
 
 jar {

--- a/test/org/javarosa/core/TestBenchmark.java
+++ b/test/org/javarosa/core/TestBenchmark.java
@@ -1,0 +1,77 @@
+package org.javarosa.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+public class TestBenchmark {
+
+    @Test
+    public void
+    launchBenchmark() throws Exception {
+        Options opt = new OptionsBuilder()
+            // Specify which benchmarks to run.
+            // You can be more specific if you'd like to run only one benchmark per test.
+            .include(this.getClass().getName() + ".*")
+            // Set the following options as needed
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .warmupTime(TimeValue.seconds(1))
+            .warmupIterations(2)
+            .measurementTime(TimeValue.seconds(1))
+            .measurementIterations(2)
+            .threads(2)
+            .forks(1)
+            .shouldFailOnError(true)
+            .shouldDoGC(true)
+            //.jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining")
+            //.addProfiler(WinPerfAsmProfiler.class)
+            .build();
+
+        RunResult run = new Runner(opt).run().iterator().next();
+        run.
+    }
+
+    // The JMH samples are the best documentation for how to use it
+    // http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        List<Integer> list;
+
+        @Setup(Level.Trial)
+        public void
+        initialize() {
+
+            Random rand = new Random();
+
+            list = new ArrayList<>();
+            for (int i = 0; i < 1000; i++)
+                list.add(rand.nextInt());
+        }
+    }
+
+    @Benchmark
+    public void
+    benchmark1(BenchmarkState state, Blackhole bh) {
+
+        List<Integer> list = state.list;
+
+        for (int i = 0; i < 1000; i++)
+            bh.consume(list.get(i));
+    }
+}

--- a/test/org/javarosa/core/model/instance/test/TreeElementBenchmark.java
+++ b/test/org/javarosa/core/model/instance/test/TreeElementBenchmark.java
@@ -1,0 +1,84 @@
+package org.javarosa.core.model.instance.test;
+
+
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import org.javarosa.core.PathConst;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+public class TreeElementBenchmark {
+    @Test
+    public void launchBenchmark() throws Exception {
+        Options opt = new OptionsBuilder()
+            // Specify which benchmarks to run.
+            // You can be more specific if you'd like to run only one benchmark per test.
+            .include(this.getClass().getName() + ".*")
+            // Set the following options as needed
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .warmupTime(TimeValue.seconds(1))
+            .warmupIterations(2)
+            .measurementTime(TimeValue.seconds(1))
+            .measurementIterations(2)
+            .threads(2)
+            .forks(1)
+            .shouldFailOnError(true)
+            .shouldDoGC(true)
+            //.jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining")
+            //.addProfiler(WinPerfAsmProfiler.class)
+            .build();
+
+        new Runner(opt).run().iterator().next();
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        private TreeElement dataRootNode;
+        private TreeElement savedRoot;
+        private FormDef formDef;
+
+        @Setup(Level.Trial)
+        public void
+        initialize() {
+            FormParseInit formParseInit = new FormParseInit(r("populate-nodes-attributes.xml"));
+
+            FormEntryController formEntryController = formParseInit.getFormEntryController();
+
+            byte[] formInstanceAsBytes = null;
+            try {
+                formInstanceAsBytes = Files.readAllBytes(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "populate-nodes-attributes-instance.xml"));
+            } catch (IOException e) {
+                fail("There was a problem with reading the test data.\n" + e.getMessage());
+            }
+            savedRoot = XFormParser.restoreDataModel(formInstanceAsBytes, null).getRoot();
+            formDef = formEntryController.getModel().getForm();
+            dataRootNode = formDef.getInstance().getRoot().deepCopy(true);
+        }
+    }
+
+    @Benchmark
+    public void benchmark_1(BenchmarkState state, Blackhole bh) {
+        state.dataRootNode.populate(state.savedRoot, state.formDef);
+    }
+}


### PR DESCRIPTION
This PR explores options to add micro-benchmarks to JavaRosa. See [forum conversation](https://forum.opendatakit.org/t/automated-benchmarks-in-javarosa/18808/3).

Exploration guide:
- Benchmarks running inside jUnit4 tests
  Examples: 
  - ...

  Questions:
  - Do we create a separate test suite, or do we integrate benchmarks in current build workflow, or both?
- Standalone execution of benchmarks
  Examples: 
  - ...

  Questions:
  - Can they be integrated into the current build workflow?
- Low-level benchmarks for specific functions, XML parsing...
  Examples: 
  - `org.javarosa.core.TestBenchmark`
- Benchmarks for high-level stuff: parse a form, save a filled submission
  Examples: 
  - ...
- Benchmarks targetting specific forms that we know are problematic
  Examples: 
  - ...