### PR TITLE
Setlocation action

### DIFF
--- a/src/main/java/org/javarosa/core/model/CoreModelModule.java
+++ b/src/main/java/org/javarosa/core/model/CoreModelModule.java
@@ -49,7 +49,8 @@ public class CoreModelModule implements IModule {
             "org.javarosa.core.model.data.TimeData",
             "org.javarosa.core.model.data.UncastData",
             "org.javarosa.core.model.data.helper.BasicDataPointer",
-            "org.javarosa.core.model.actions.SetValueAction"
+            "org.javarosa.core.model.actions.SetValueAction",
+            "org.javarosa.core.model.actions.setlocation.StubSetLocationAction"
     };
 
     @Override

--- a/src/main/java/org/javarosa/core/model/actions/Action.java
+++ b/src/main/java/org/javarosa/core/model/actions/Action.java
@@ -49,6 +49,10 @@ public abstract class Action implements Externalizable {
         this.name = name;
     }
 
+    public String getName() {
+        return name;
+    }
+
     /**
      * Process actions that were triggered in the form.
      *

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationAction.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationAction.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model.actions.setlocation;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.actions.Action;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.condition.Recalculate;
+import org.javarosa.core.model.data.AnswerDataFactory;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.instance.AbstractTreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Abstract implementation of odk:setlocation action. Concrete implementations must:
+ * - provide a way to request location updates when the action is triggered
+ * - use {@link #saveLocationValue(String)} to write a location to the model
+ * - provide a no-argument constructor with no body for serialization
+ * - get registered by the {@link org.javarosa.core.services.PrototypeManager}
+ */
+public abstract class SetLocationAction extends Action {
+    private TreeReference targetReference;
+    private TreeReference contextualizedTargetReference;
+
+    private FormDef formDef;
+
+    public SetLocationAction() {
+        // empty body for serialization
+    }
+
+    SetLocationAction(TreeReference targetReference) {
+        super(SetLocationActionHandler.ELEMENT_NAME);
+        setTargetReference(targetReference);
+    }
+
+    public TreeReference getTargetReference() {
+        return targetReference;
+    }
+
+    public void setTargetReference(TreeReference targetReference) {
+        this.targetReference = targetReference;
+    }
+
+    @Override
+    public final TreeReference processAction(FormDef model, TreeReference contextRef) {
+        this.formDef = model;
+        contextualizedTargetReference = contextRef == null ? this.targetReference
+            : this.targetReference.contextualize(contextRef);
+
+        requestLocationUpdates();
+
+        return contextualizedTargetReference;
+    }
+
+    /**
+     * Client-specific location request. Implementations could immediately read a location and write it to the model if
+     * available or could initiate a request and asynchronously write the location when available.
+     */
+    public abstract void requestLocationUpdates();
+
+    /**
+     * Save the location to the model.
+     */
+    public final void saveLocationValue(String location) {
+        EvaluationContext context = new EvaluationContext(formDef.getEvaluationContext(), contextualizedTargetReference);
+        AbstractTreeElement node = context.resolveReference(contextualizedTargetReference);
+        if (node != null) {
+            int dataType = node.getDataType();
+            IAnswerData val = Recalculate.wrapData(location, dataType);
+            if (val == null) {
+                formDef.setValue(null, contextualizedTargetReference, true);
+            } else {
+                IAnswerData answer = AnswerDataFactory.templateByDataType(dataType).cast(val.uncast());
+                formDef.setValue(answer, contextualizedTargetReference, true);
+            }
+        }
+    }
+
+    //region serialization
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        super.readExternal(in, pf);
+
+        targetReference = (TreeReference) ExtUtil.read(in, new ExtWrapNullable(TreeReference.class), pf);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        super.writeExternal(out);
+
+        ExtUtil.write(out, new ExtWrapNullable(targetReference));
+    }
+    //endregion
+}

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationAction.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationAction.java
@@ -93,12 +93,11 @@ public abstract class SetLocationAction extends Action {
         if (node != null) {
             int dataType = node.getDataType();
             IAnswerData val = Recalculate.wrapData(location, dataType);
-            if (val == null) {
-                formDef.setValue(null, contextualizedTargetReference, true);
-            } else {
-                IAnswerData answer = AnswerDataFactory.templateByDataType(dataType).cast(val.uncast());
-                formDef.setValue(answer, contextualizedTargetReference, true);
-            }
+
+            IAnswerData answer = val != null
+                ? AnswerDataFactory.templateByDataType(dataType).cast(val.uncast())
+                : null;
+            formDef.setValue(answer, contextualizedTargetReference, true);
         }
     }
 

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationAction.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationAction.java
@@ -50,13 +50,17 @@ public abstract class SetLocationAction extends Action {
         // empty body for serialization
     }
 
-    SetLocationAction(TreeReference targetReference) {
+    public SetLocationAction(TreeReference targetReference) {
         super(SetLocationActionHandler.ELEMENT_NAME);
         setTargetReference(targetReference);
     }
 
     public TreeReference getTargetReference() {
         return targetReference;
+    }
+
+    public TreeReference getContextualizedTargetReference() {
+        return contextualizedTargetReference;
     }
 
     public void setTargetReference(TreeReference targetReference) {

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationActionHandler.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationActionHandler.java
@@ -36,7 +36,6 @@ public abstract class SetLocationActionHandler implements IElementHandler {
             throw new XFormParseException("setlocation action must be in http://www.opendatakit.org/xforms namespace");
         }
 
-        TreeReference target;
         String ref = e.getAttributeValue(null, "ref");
 
         if (ref == null) {
@@ -44,7 +43,7 @@ public abstract class SetLocationActionHandler implements IElementHandler {
         }
 
         IDataReference dataRef = FormDef.getAbsRef(new XPathReference(ref), TreeReference.rootRef());
-        target = FormInstance.unpackReference(dataRef);
+        TreeReference target = FormInstance.unpackReference(dataRef);
         p.registerActionTarget(target);
 
         SetLocationAction action = getSetLocationAction();

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationActionHandler.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/SetLocationActionHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model.actions.setlocation;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.IDataReference;
+import org.javarosa.core.model.IFormElement;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.model.xform.XPathReference;
+import org.javarosa.xform.parse.IElementHandler;
+import org.javarosa.xform.parse.XFormParseException;
+import org.javarosa.xform.parse.XFormParser;
+import org.kxml2.kdom.Element;
+
+public abstract class SetLocationActionHandler implements IElementHandler {
+    public static final String ELEMENT_NAME = "setlocation";
+
+    @Override
+    public final void handle(XFormParser p, Element e, Object parent) {
+        if (!e.getNamespace().equals(XFormParser.NAMESPACE_ODK)) {
+            throw new XFormParseException("setlocation action must be in http://www.opendatakit.org/xforms namespace");
+        }
+
+        TreeReference target;
+        String ref = e.getAttributeValue(null, "ref");
+
+        if (ref == null) {
+            throw new XFormParseException("odk:setlocation action must specify a ref");
+        }
+
+        IDataReference dataRef = FormDef.getAbsRef(new XPathReference(ref), TreeReference.rootRef());
+        target = FormInstance.unpackReference(dataRef);
+        p.registerActionTarget(target);
+
+        SetLocationAction action = getSetLocationAction();
+        action.setTargetReference(target);
+
+        String event = e.getAttributeValue(null, "event");
+        // XFormParser.parseAction already ensures parent is an IFormElement so we can safely cast
+        ((IFormElement) parent).getActionController().registerEventListener(event, action);
+    }
+
+    /**
+     * Returns an implementation for the odk:setlocation action.
+     */
+    public abstract SetLocationAction getSetLocationAction();
+}

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/StubSetLocationAction.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/StubSetLocationAction.java
@@ -1,0 +1,24 @@
+package org.javarosa.core.model.actions.setlocation;
+
+import org.javarosa.core.model.instance.TreeReference;
+
+/**
+ * An odk:setlocation implementation that immediately writes that no implementation is available when the action is
+ * triggered.
+ */
+public final class StubSetLocationAction extends SetLocationAction {
+    private static final String NO_IMPLEMENTATION_MESSAGE = "no client implementation";
+
+    public StubSetLocationAction() {
+        // empty body for serialization
+    }
+
+    public StubSetLocationAction(TreeReference targetReference) {
+        super(targetReference);
+    }
+
+    @Override
+    public void requestLocationUpdates() {
+        saveLocationValue(NO_IMPLEMENTATION_MESSAGE);
+    }
+}

--- a/src/main/java/org/javarosa/core/model/actions/setlocation/StubSetLocationActionHandler.java
+++ b/src/main/java/org/javarosa/core/model/actions/setlocation/StubSetLocationActionHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model.actions.setlocation;
+
+/**
+ * Registering this stub allows for clients that only read forms such as ODK Validate to recognize the action. However,
+ * acquiring location requires a platform-specific implementation so clients that enable form filling must provide a
+ * subclass implementation that actually provides location information.
+ */
+public final class StubSetLocationActionHandler extends SetLocationActionHandler {
+    @Override
+    public SetLocationAction getSetLocationAction() {
+        // We'd like to use the default constructor but then the name wouldn't be set because the default constructor
+        // has to have an empty body for serialization. Instead, set a null reference and let handle set the target.
+        return new StubSetLocationAction(null);
+    }
+}

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -16,48 +16,6 @@
 
 package org.javarosa.xform.parse;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
-import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
-import static org.javarosa.core.model.Constants.CONTROL_INPUT;
-import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_RANGE;
-import static org.javarosa.core.model.Constants.CONTROL_RANK;
-import static org.javarosa.core.model.Constants.CONTROL_SECRET;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
-import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
-import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
-import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
-import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
-import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
-import static org.javarosa.core.services.ProgramFlow.die;
-import static org.javarosa.xform.parse.Constants.ID_ATTR;
-import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
-import static org.javarosa.xform.parse.Constants.RANK;
-import static org.javarosa.xform.parse.Constants.SELECT;
-import static org.javarosa.xform.parse.Constants.SELECTONE;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
-import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.GroupDef;
@@ -111,6 +69,49 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
+import static org.javarosa.core.model.Constants.CONTROL_INPUT;
+import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_RANK;
+import static org.javarosa.core.model.Constants.CONTROL_SECRET;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
+import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
+import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
+import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
+import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
+import static org.javarosa.core.services.ProgramFlow.die;
+import static org.javarosa.xform.parse.Constants.ID_ATTR;
+import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
+import static org.javarosa.xform.parse.Constants.RANK;
+import static org.javarosa.xform.parse.Constants.SELECT;
+import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
+import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 /* droos: i think we need to start storing the contents of the <bind>s in the formdef again */
 
@@ -702,6 +703,8 @@ public class XFormParser implements IXFormParserFunctions {
             throw new XFormParseException("An action element occurred in an invalid location. " +
                     "Must be either a child of a control element, or a child of the <model>");
         }
+        
+        _f.registerAction(e.getName());
 
         specificHandler.handle(this, e, parent);
     }

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -71,6 +71,8 @@ import org.javarosa.core.model.SubmissionProfile;
 import org.javarosa.core.model.actions.Action;
 import org.javarosa.core.model.actions.ActionController;
 import org.javarosa.core.model.actions.SetValueAction;
+import org.javarosa.core.model.actions.setlocation.SetLocationActionHandler;
+import org.javarosa.core.model.actions.setlocation.StubSetLocationActionHandler;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -306,6 +308,10 @@ public class XFormParser implements IXFormParserFunctions {
     private static void setUpActionHandlers() {
         actionHandlers = new HashMap<>();
         registerActionHandler(SetValueAction.ELEMENT_NAME, SetValueAction.getHandler());
+
+        // Register a stub odk:setlocation action handler. Clients that want to actually collect location need to
+        // register their own subclass handler which will replace this one.
+        registerActionHandler(SetLocationActionHandler.ELEMENT_NAME, new StubSetLocationActionHandler());
     }
 
     private void initState() {
@@ -696,6 +702,7 @@ public class XFormParser implements IXFormParserFunctions {
             throw new XFormParseException("An action element occurred in an invalid location. " +
                     "Must be either a child of a control element, or a child of the <model>");
         }
+
         specificHandler.handle(this, e, parent);
     }
 

--- a/src/test/java/org/javarosa/core/model/actions/SetLocationActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetLocationActionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model.actions;
+
+import org.hamcrest.Matcher;
+import org.javarosa.core.model.actions.setlocation.StubSetLocationAction;
+import org.javarosa.core.model.data.StringData;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.xform.parse.XFormParseException;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.core.test.Scenario.absoluteRef;
+import static org.javarosa.core.util.externalizable.ExtUtil.defaultPrototypes;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertThat;
+
+public class SetLocationActionTest {
+    private static final Matcher<StringData> EXPECTED_STUB_ANSWER =
+        stringAnswer("no client implementation");
+
+    @Test(expected = XFormParseException.class)
+    public void when_namespaceIsNotOdk_exceptionIsThrown() throws IOException {
+        Scenario.init(r("setlocation-action-bad-namespace.xml"));
+    }
+
+    @Test
+    public void when_instanceIsLoaded_locationIsSetAtTarget() throws IOException {
+        Scenario scenario = Scenario.init(r("setlocation-action-instance-load.xml"));
+
+        assertThat(scenario.answerOf("/data/location"), is(EXPECTED_STUB_ANSWER));
+    }
+
+    @Test
+    public void when_triggerNodeIsUpdated_locationIsSetAtTarget() throws IOException {
+        Scenario scenario = Scenario.init(r("setlocation-action-value-changed.xml"));
+
+        // The test form has no default value at /data/location, and
+        // no other event sets any value on it
+        assert scenario.answerOf("/data/location") == null;
+
+        // Answering a question triggers its "xforms-value-changed" event
+        scenario.answer("/data/text", "some answer");
+
+        assertThat(scenario.answerOf("/data/location"), is(EXPECTED_STUB_ANSWER));
+    }
+
+    @Test
+    public void testSerializationAndDeserialization() throws IOException, DeserializationException {
+        StubSetLocationAction originalAction = new StubSetLocationAction(absoluteRef("/data/text"));
+
+        Path ser = Files.createTempFile("serialized-object", null);
+        try (DataOutputStream dos = new DataOutputStream(Files.newOutputStream(ser))) {
+            originalAction.writeExternal(dos);
+        }
+
+        StubSetLocationAction deserializedAction = new StubSetLocationAction(null);
+        try (DataInputStream dis = new DataInputStream(Files.newInputStream(ser))) {
+            deserializedAction.readExternal(dis, defaultPrototypes());
+        }
+
+        // SetLocationAction only serializes the targetReference (and name, from its superclass) members
+        assertThat(deserializedAction.getName(), is(originalAction.getName()));
+
+        assertThat(deserializedAction.getTargetReference(), equalTo(originalAction.getTargetReference()));
+
+        Files.delete(ser);
+    }
+}

--- a/src/test/java/org/javarosa/core/model/actions/SetLocationActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetLocationActionTest.java
@@ -17,9 +17,9 @@
 package org.javarosa.core.model.actions;
 
 import org.hamcrest.Matcher;
+import org.javarosa.core.model.actions.setlocation.SetLocationAction;
 import org.javarosa.core.model.actions.setlocation.StubSetLocationAction;
 import org.javarosa.core.model.data.StringData;
-
 import org.javarosa.core.test.Scenario;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.xform.parse.XFormParseException;
@@ -78,7 +78,7 @@ public class SetLocationActionTest {
             originalAction.writeExternal(dos);
         }
 
-        StubSetLocationAction deserializedAction = new StubSetLocationAction(null);
+        SetLocationAction deserializedAction = new StubSetLocationAction(null);
         try (DataInputStream dis = new DataInputStream(Files.newInputStream(ser))) {
             deserializedAction.readExternal(dis, defaultPrototypes());
         }

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -29,6 +29,7 @@ import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
 import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -97,8 +98,12 @@ public class Scenario {
      * Creates and prepares the test scenario loading and parsing the given form
      */
     public static Scenario init(String formFileName) {
+        return init(r(formFileName));
+    }
+
+    public static Scenario init(Path formFile) {
         // TODO explain why this sequence of calls
-        FormParseInit fpi = new FormParseInit(r(formFileName));
+        FormParseInit fpi = new FormParseInit(formFile);
         FormDef formDef = fpi.getFormDef();
         formDef.initialize(true, new InstanceInitializationFactory());
         FormEntryModel formEntryModel = new FormEntryModel(formDef);
@@ -281,7 +286,7 @@ public class Scenario {
      * Returns an absolute reference of the given xPath taking multiplicity of each
      * xPath part into account.
      */
-    private TreeReference absoluteRef(String xPath) {
+    public static TreeReference absoluteRef(String xPath) {
         TreeReference tr = new TreeReference();
         tr.setRefLevel(REF_ABSOLUTE);
         tr.setContext(CONTEXT_ABSOLUTE);
@@ -292,11 +297,11 @@ public class Scenario {
         return tr;
     }
 
-    private String parseName(String xPathPart) {
+    private static String parseName(String xPathPart) {
         return xPathPart.contains("[") ? xPathPart.substring(0, xPathPart.indexOf("[")) : xPathPart;
     }
 
-    private int parseMultiplicity(String xPathPart) {
+    private static int parseMultiplicity(String xPathPart) {
         return xPathPart.contains("[") ? Integer.parseInt(xPathPart.substring(xPathPart.indexOf("[") + 1, xPathPart.indexOf("]"))) : 0;
     }
 

--- a/src/test/resources/org/javarosa/core/model/actions/setlocation-action-bad-namespace.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/setlocation-action-bad-namespace.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>setlocation-action-bad-namespace</h:title>
+        <model>
+            <instance>
+                <data id="setlocation-action-bad-namespace">
+                    <location/>
+                </data>
+            </instance>
+            <bind nodeset="/data/location" type="string" />
+            <setlocation ref="/data/location" event="odk-instance-first-load" />
+        </model>
+    </h:head>
+    <h:body />
+</h:html>

--- a/src/test/resources/org/javarosa/core/model/actions/setlocation-action-instance-load.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/setlocation-action-instance-load.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>setlocation-action-instance-load</h:title>
+        <model>
+            <instance>
+                <data id="setlocation-action-instance-load">
+                    <location/>
+                </data>
+            </instance>
+            <bind nodeset="/data/location" type="string" />
+            <odk:setlocation ref="/data/location" event="odk-instance-first-load" />
+        </model>
+    </h:head>
+    <h:body />
+</h:html>

--- a/src/test/resources/org/javarosa/core/model/actions/setlocation-action-value-changed.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/setlocation-action-value-changed.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>setlocation-action-value-changed</h:title>
+        <model>
+            <instance>
+                <data id="setlocation-action-value-changed">
+                    <text/>
+                    <location/>
+                </data>
+            </instance>
+            <bind nodeset="/data/text" type="string" />
+            <bind nodeset="/data/location" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/text">
+            <odk:setlocation ref="/data/location" event="xforms-value-changed" />
+        </input>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #430 

@ggalmazor would be great to get a sanity check on the approach and the question about tests before I go deeper in the Collect implementation. 🙏 

#### What has been done to verify that this works as intended?
Ran tests with forms. Started a Collect implementation at https://github.com/opendatakit/collect/compare/master...lognaturel:setlocation-action (the location-getting part works but there's still work to do to notify the user and allow them to override background GPS).

#### Why is this the best possible solution? Were any other approaches considered?
I first considered doing everything in Collect since `registerActionHandler` makes that easily possible. However, that would mean any client that uses JavaRosa would need to register its own handler. This would lead to duplicate code and likelihood that the action wouldn't be recognized somewhere it should.

Providing a stub implementation at the JavaRosa level means Briefcase, Validate, Aggregate and any other client will easily be able to read form definitions that include the action. Clients like Collect that need to actually populate form instances with locations can override the `requestLocationUpdates` method. They can use the `saveLocationValue` method so that they don't need to know about messy JR implementation details. The `getSetLocationAction` factory method lets clients simply build handlers for their custom implementations.

I also considered subclassing `SetValueAction` because arguably location is just a specialized value we're setting. I chose not to do that because I don't understand why `parseSetValueAction` is in `XFormParser` rather than in the action definition and the code in that method for supporting `bind` and predicates looks smelly to me. I decided to go for a simpler (but similar) implementation. That means predicates aren't supported but they won't be in XLSForm anyway and while I can think of uses in the setvalue case, I can't really in this one.

This is the first namespaced action to be introduced. I considered changing the key for the `actionHandlers` map to include namespace information but that ended up feeling like a heavy change. Instead, I throw a parse exception if the incorrect namespace is provided. This approach would only be an issue if there's a future need to introduce actions with matching names in different namespaces. This would be a really unfortunate state of affairs and very unlikely so I think this approach is sufficient.

Clients that get location updates may need to let users know about it in the user interface. That means they need to be able to identify form definitions that include the `odk:setlocation` action. 
10bc803 is the best way I could come up with for doing that.

I'm not sure about how I've structured the tests and have some questions inline for @ggalmazor.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is an additive change that is isolated in new classes so regression risks should be nil (for real!). The only affect on users should be enabling use of the `odk:setlocation` action. 

#### Do we need any specific form for testing your changes? If so, please attach one.
In addition to the forms in the tests, I used [setlocation-action-with-repeats.xml.zip](https://github.com/opendatakit/javarosa/files/3129864/setlocation-action-with-repeats.xml.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
https://github.com/opendatakit/xforms-spec/issues/172