### PR TITLE
Add SelectChoices equals and hashCode

### DIFF
--- a/src/org/javarosa/core/model/SelectChoice.java
+++ b/src/org/javarosa/core/model/SelectChoice.java
@@ -3,6 +3,7 @@ package org.javarosa.core.model;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Objects;
 
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
@@ -132,4 +133,27 @@ public class SelectChoice implements Externalizable, Localizable {
         this.textID = textID;
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        SelectChoice otherChoice = (SelectChoice) other;
+
+        return Objects.equals(labelInnerText, otherChoice.labelInnerText)
+            && Objects.equals(textID, otherChoice.textID)
+            && isLocalizable == otherChoice.isLocalizable
+            && Objects.equals(value, otherChoice.value)
+            && index == otherChoice.index
+            && Objects.equals(copyNode, otherChoice.copyNode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labelInnerText, textID, isLocalizable, value, index, copyNode);
+    }
 }


### PR DESCRIPTION
Closes #426

#### What has been done to verify that this works as intended?
Added the https://jqno.nl/equalsverifier/ dependency and ran the verifier. It does flag two issues: the fields are not final and the class is not final. Note in particular that `index` does get changed.

#### Why is this the best possible solution? Were any other approaches considered?
Now that I've done it, I don't know if this is a good idea, honestly. The fact that `index` mutates makes things very odd comparison-wise. It's ok for the use I want to make of it at https://github.com/opendatakit/collect/pull/3023/files#diff-31b495e34e6fbe9464cec0d2e0025770R120 but it would be bad if these were put in sets or used as indexes for maps. Then again, that's not terribly helpful anyway. A better design might have been immutable options with another layer that keeps track of order.

What do reviewers think -- should I just keep comparison in Collect for now?

That aside, the approach is idiomatic, leverages tools the language makes available and is simple to understand. I could probably do something fancier with `hashCode` but it's not necessary. I hesitated between `other == null || getClass() != other.getClass()` and using `instanceOf`. Doing it this way may help remind us there may be issues if ever we subclass.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Clients will be able to identify equal `SelectChoices`. It's imperfect for the reasons listed above.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.