### PR TITLE
Add FormIndex hashCode method

### DIFF
--- a/src/org/javarosa/core/model/FormIndex.java
+++ b/src/org/javarosa/core/model/FormIndex.java
@@ -19,6 +19,7 @@ package org.javarosa.core.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.javarosa.core.model.instance.TreeReference;
 
@@ -113,7 +114,8 @@ public class FormIndex implements Serializable {
     private FormIndex nextLevel;
 
     /**
-     * The XPath reference this index refers to.
+     * The XPath reference this index refers to. Warning: these are mutable and could conceivably get out of sync with
+     * the index.
      */
     private TreeReference reference;
 
@@ -292,6 +294,7 @@ public class FormIndex implements Serializable {
         return beginningOfForm;
     }
 
+    @Override
     public boolean equals(Object o) {
         if(!(o instanceof FormIndex))
             return false;
@@ -319,6 +322,13 @@ public class FormIndex implements Serializable {
 //            index = index.getNextLevel();
 //        }
 //
+    }
+
+    @Override
+    public int hashCode() {
+        // The reference field is not included. This matches the equals(Object) implementation. TreeReferences are
+        // mutable and are provided as a way to convert between FormIndex and other types.
+        return Objects.hash(beginningOfForm, endOfForm, localIndex, instanceIndex, nextLevel);
     }
 
     public int compareTo(Object o) {


### PR DESCRIPTION
Closes #425 

#### What has been done to verify that this works as intended?
Added the https://jqno.nl/equalsverifier/ dependency and ran the verifier. There are issues with fields being mutable. It's not ideal but the intended usage is for these indexes to be built once and then used. Also, beginningOfForm and endOfForm are used independently of the other fields to determine equality. That is, you could have two `FormIndex` objects with different localIndex values that are considered the same because they both have `beginningOfForm` as true. In practice, as long as clients always use `createBeginningOfFormIndex` and `createEndOfFormIndex`, everything should be consistent.

#### Why is this the best possible solution? Were any other approaches considered?
It's simple to understand and verify.

I considered removing the `beginningOfForm` and `endOfForm` fields and replacing them with special values for `localIndex` but then this change becomes a lot more risky with no real benefit in the short term.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Clients can more correctly use these as map indexes, as Collect already does. There would be problems if they get mutated, though.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.