### PR TITLE
Clear select answers that are no longer part of the choice list

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -79,7 +79,7 @@ import org.javarosa.core.model.instance.TreeReference;
  *
  * To go from a {@code FormIndex} to a form element in a blank form, {@link FormDef#getChild(FormIndex)} can be used.
  * To go from a {@code FormIndex} to a node in a filled form, 
- * {@link org.javarosa.core.model.instance.FormInstance#resolveReference(TreeReference) FormInstance#resolveReference(TreeReference)} can
+ * {@link org.javarosa.core.model.instance.FormInstance#resolveReference(TreeReference)} can
  * be used along with {@link #getReference()}.
  *
  * No circularity is allowed. That is, no {@code FormIndex}'s ancestor can be itself.

--- a/src/test/java/org/javarosa/core/model/ItemsetBindingTest.java
+++ b/src/test/java/org/javarosa/core/model/ItemsetBindingTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.model;
+
+import org.javarosa.core.test.Scenario;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.javarosa.core.test.SelectChoiceMatchers.choice;
+
+public class ItemsetBindingTest {
+    private Scenario scenario;
+
+    @Before
+    public void setUp() {
+        scenario = Scenario.init("three-level-cascading-select.xml");
+    }
+
+    @Test
+    public void dependentLevelsInBlankInstance_ShouldHaveNoChoices() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+    }
+
+    @Test
+    public void selectingValueAtLevel1_ShouldFilterChoicesAtLevel2() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+
+        scenario.answer("/data/level1", "b");
+
+        assertThat(scenario.choicesOf("/data/level2"), containsInAnyOrder(
+            choice("b1"),
+            choice("b2"),
+            choice("b3")));
+    }
+
+    @Test
+    public void selectingValuesAtLevels1And2_ShouldFilterChoicesAtLevel3() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+
+        scenario.answer("/data/level1", "b");
+        scenario.answer("/data/level2", "b1");
+        assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
+            choice("b1a"),
+            choice("b1b")));
+    }
+
+    @Test
+    public void clearingValueAtLevel2_ShouldClearChoicesAtLevel3() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+
+        scenario.answer("/data/level1", "a");
+        scenario.answer("/data/level2", "a1");
+        assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
+            choice("a1a"),
+            choice("a1b")));
+        scenario.answer("/data/level2", "");
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+    }
+
+    @Test
+    public void clearingValueAtLevel1_ShouldClearChoicesAtLevels2And3() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+
+        scenario.answer("/data/level1", "a");
+        scenario.answer("/data/level2", "a1");
+        assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
+            choice("a1a"),
+            choice("a1b")));
+
+        scenario.answer("/data/level1", "");
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+    }
+}

--- a/src/test/java/org/javarosa/core/model/ItemsetBindingTest.java
+++ b/src/test/java/org/javarosa/core/model/ItemsetBindingTest.java
@@ -21,8 +21,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.test.SelectChoiceMatchers.choice;
 
 public class ItemsetBindingTest {
@@ -95,6 +98,7 @@ public class ItemsetBindingTest {
 
         scenario.answer("/data/level1", "");
         assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.answerOf("/data/level2"), is(stringAnswer("")));
         assertThat(scenario.choicesOf("/data/level3"), empty());
     }
 }

--- a/src/test/java/org/javarosa/core/model/ItemsetBindingTest.java
+++ b/src/test/java/org/javarosa/core/model/ItemsetBindingTest.java
@@ -51,9 +51,9 @@ public class ItemsetBindingTest {
         scenario.answer("/data/level1", "b");
 
         assertThat(scenario.choicesOf("/data/level2"), containsInAnyOrder(
-            choice("b1"),
-            choice("b2"),
-            choice("b3")));
+            choice("ba"),
+            choice("bb"),
+            choice("bc")));
     }
 
     @Test
@@ -63,10 +63,10 @@ public class ItemsetBindingTest {
         assertThat(scenario.choicesOf("/data/level3"), empty());
 
         scenario.answer("/data/level1", "b");
-        scenario.answer("/data/level2", "b1");
+        scenario.answer("/data/level2", "ba");
         assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
-            choice("b1a"),
-            choice("b1b")));
+            choice("baa"),
+            choice("bab")));
     }
 
     @Test
@@ -76,10 +76,10 @@ public class ItemsetBindingTest {
         assertThat(scenario.choicesOf("/data/level3"), empty());
 
         scenario.answer("/data/level1", "a");
-        scenario.answer("/data/level2", "a1");
+        scenario.answer("/data/level2", "aa");
         assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
-            choice("a1a"),
-            choice("a1b")));
+            choice("aaa"),
+            choice("aab")));
         scenario.answer("/data/level2", "");
         assertThat(scenario.choicesOf("/data/level3"), empty());
     }
@@ -91,14 +91,57 @@ public class ItemsetBindingTest {
         assertThat(scenario.choicesOf("/data/level3"), empty());
 
         scenario.answer("/data/level1", "a");
-        scenario.answer("/data/level2", "a1");
+        scenario.answer("/data/level2", "aa");
         assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
-            choice("a1a"),
-            choice("a1b")));
+            choice("aaa"),
+            choice("aab")));
 
         scenario.answer("/data/level1", "");
         assertThat(scenario.choicesOf("/data/level2"), empty());
+        // this next assertion is only true because the one before called populateDynamic choices
+        // TODO: make clearing out answers that are no longer available choices part of the form re-evaluation
         assertThat(scenario.answerOf("/data/level2"), is(stringAnswer("")));
         assertThat(scenario.choicesOf("/data/level3"), empty());
+    }
+
+    @Test
+    public void changingValueAtLevel2_ShouldClearLevel3_IfChoiceNoLongerAvailable() {
+        scenario.newInstance();
+
+        scenario.answer("/data/level1_contains", "a");
+        scenario.answer("/data/level2_contains", "aa");
+        assertThat(scenario.choicesOf("/data/level3_contains"), containsInAnyOrder(
+            choice("aaa"),
+            choice("aab"),
+            choice("baa")));
+        scenario.answer("/data/level3_contains", "aaa");
+        scenario.answer("/data/level2_contains", "ab");
+        assertThat(scenario.choicesOf("/data/level3_contains"), containsInAnyOrder(
+            choice("aab"),
+            choice("bab")));
+        // this next assertion is only true because the one before called populateDynamicChoices
+        // TODO: make clearing out answers that are no longer available choices part of the form re-evaluation
+        assertThat(scenario.answerOf("/data/level3_contains"), is(stringAnswer("")));
+    }
+
+    @Test
+    public void changingValueAtLevel2_ShouldNotClearLevel3_IfChoiceStillAvailable() {
+        scenario.newInstance();
+
+        scenario.answer("/data/level1_contains", "a");
+        scenario.answer("/data/level2_contains", "aa");
+        assertThat(scenario.choicesOf("/data/level3_contains"), containsInAnyOrder(
+            choice("aaa"),
+            choice("aab"),
+            choice("baa")));
+        scenario.answer("/data/level3_contains", "aab");
+        scenario.answer("/data/level2_contains", "ab");
+        assertThat(scenario.answerOf("/data/level3_contains"), is(stringAnswer("aab")));
+
+        // Since populateDynamicChoices can change answers, verify it doesn't in this case
+        assertThat(scenario.choicesOf("/data/level3_contains"), containsInAnyOrder(
+            choice("aab"),
+            choice("bab")));
+        assertThat(scenario.answerOf("/data/level3_contains"), is(stringAnswer("aab")));
     }
 }

--- a/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
+++ b/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
@@ -1,4 +1,4 @@
-package org.javarosa.xpath.expr;
+package org.javarosa.core.test;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;

--- a/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
+++ b/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
@@ -6,7 +6,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 
-class AnswerDataMatchers {
+public class AnswerDataMatchers {
     public static Matcher<StringData> stringAnswer(String expectedAnswer) {
         return new TypeSafeMatcher<StringData>() {
             @Override

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -221,7 +221,7 @@ public class Scenario {
 
     /**
      * Returns the list of choices of the &lt;select&gt; or &lt;select1&gt; form controls.
-     * This method ensures that any dynamic choce lists are populated to reflect the status
+     * This method ensures that any dynamic choice lists are populated to reflect the status
      * of the form (already answered questions, etc.).
      */
     public List<SelectChoice> choicesOf(String xPath) {

--- a/src/test/java/org/javarosa/core/test/SelectChoiceMatchers.java
+++ b/src/test/java/org/javarosa/core/test/SelectChoiceMatchers.java
@@ -1,12 +1,12 @@
-package org.javarosa.xpath.expr;
+package org.javarosa.core.test;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.javarosa.core.model.SelectChoice;
 
-class SelectChoiceMatchers {
-    static Matcher<SelectChoice> choice(String expectedValue) {
+public class SelectChoiceMatchers {
+    public static Matcher<SelectChoice> choice(String expectedValue) {
         return new TypeSafeMatcher<SelectChoice>() {
 
             @Override
@@ -26,7 +26,7 @@ class SelectChoiceMatchers {
         };
     }
 
-    static Matcher<SelectChoice> choice(String expectedValue, String expectedDisplayText) {
+    public static Matcher<SelectChoice> choice(String expectedValue, String expectedDisplayText) {
         return new TypeSafeMatcher<SelectChoice>() {
 
             @Override

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentFieldRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentFieldRefTest.java
@@ -16,7 +16,7 @@
 package org.javarosa.xpath.expr;
 
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.xpath.expr.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.junit.Assert.assertThat;
 
 import org.javarosa.core.test.Scenario;

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentGroupCountRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentGroupCountRefTest.java
@@ -17,7 +17,7 @@ package org.javarosa.xpath.expr;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.xpath.expr.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.junit.Assert.assertThat;
 
 import org.javarosa.core.test.Scenario;

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentItemsetNodesetTest.java
@@ -16,7 +16,7 @@
 package org.javarosa.xpath.expr;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.javarosa.xpath.expr.SelectChoiceMatchers.choice;
+import static org.javarosa.core.test.SelectChoiceMatchers.choice;
 import static org.junit.Assert.assertThat;
 
 import org.javarosa.core.test.Scenario;

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentTest.java
@@ -18,7 +18,7 @@ package org.javarosa.xpath.expr;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.xpath.expr.AnswerDataMatchers.answer;
-import static org.javarosa.xpath.expr.SelectChoiceMatchers.choice;
+import static org.javarosa.core.test.SelectChoiceMatchers.choice;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprCurrentTest.java
@@ -17,7 +17,7 @@ package org.javarosa.xpath.expr;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.xpath.expr.AnswerDataMatchers.answer;
+import static org.javarosa.core.test.AnswerDataMatchers.answer;
 import static org.javarosa.core.test.SelectChoiceMatchers.choice;
 import static org.junit.Assert.assertThat;
 

--- a/src/test/resources/org/javarosa/core/model/three-level-cascading-select.xml
+++ b/src/test/resources/org/javarosa/core/model/three-level-cascading-select.xml
@@ -3,66 +3,14 @@
     <h:head>
         <h:title>Three level cascading select</h:title>
         <model>
-            <itext>
-                <translation default="true()" lang="default">
-                    <text id="static_instance-level1-0">
-                        <value>A</value>
-                    </text>
-                    <text id="static_instance-level1-1">
-                        <value>B</value>
-                    </text>
-                    <text id="static_instance-level1-2">
-                        <value>C</value>
-                    </text>
-                    <text id="static_instance-level2-0">
-                        <value>A1</value>
-                    </text>
-                    <text id="static_instance-level2-1">
-                        <value>A2</value>
-                    </text>
-                    <text id="static_instance-level2-2">
-                        <value>A3</value>
-                    </text>
-                    <text id="static_instance-level2-3">
-                        <value>B1</value>
-                    </text>
-                    <text id="static_instance-level2-4">
-                        <value>B2</value>
-                    </text>
-                    <text id="static_instance-level2-5">
-                        <value>B3</value>
-                    </text>
-                    <text id="static_instance-level2-6">
-                        <value>C1</value>
-                    </text>
-                    <text id="static_instance-level2-7">
-                        <value>C2</value>
-                    </text>
-                    <text id="static_instance-level2-8">
-                        <value>C3</value>
-                    </text>
-                    <text id="static_instance-level2-9">
-                        <value>C4</value>
-                    </text>
-                    <text id="static_instance-level3-0">
-                        <value>A1A</value>
-                    </text>
-                    <text id="static_instance-level3-1">
-                        <value>A1B</value>
-                    </text>
-                    <text id="static_instance-level3-2">
-                        <value>B1A</value>
-                    </text>
-                    <text id="static_instance-level3-3">
-                        <value>B1B</value>
-                    </text>
-                </translation>
-            </itext>
             <instance>
                 <data id="three-level-cascading-select">
                     <level1/>
                     <level2/>
                     <level3/>
+                    <level1_contains/>
+                    <level2_contains/>
+                    <level3_contains/>
                     <meta>
                         <instanceID/>
                     </meta>
@@ -71,15 +19,15 @@
             <instance id="level1">
                 <root>
                     <item>
-                        <itextId>static_instance-level1-0</itextId>
+                        <label>A</label>
                         <name>a</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level1-1</itextId>
+                        <label>B</label>
                         <name>b</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level1-2</itextId>
+                        <label>C</label>
                         <name>c</name>
                     </item>
                 </root>
@@ -87,84 +35,87 @@
             <instance id="level2">
                 <root>
                     <item>
-                        <itextId>static_instance-level2-0</itextId>
+                        <label>AA</label>
                         <level1>a</level1>
-                        <name>a1</name>
+                        <name>aa</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-1</itextId>
+                        <label>AB</label>
                         <level1>a</level1>
-                        <name>a2</name>
+                        <name>ab</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-2</itextId>
+                        <label>AC</label>
                         <level1>a</level1>
-                        <name>a3</name>
+                        <name>ac</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-3</itextId>
+                        <label>BA</label>
                         <level1>b</level1>
-                        <name>b1</name>
+                        <name>ba</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-4</itextId>
+                        <label>BB</label>
                         <level1>b</level1>
-                        <name>b2</name>
+                        <name>bb</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-5</itextId>
+                        <label>BC</label>
                         <level1>b</level1>
-                        <name>b3</name>
+                        <name>bc</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-6</itextId>
+                        <label>CA</label>
                         <level1>c</level1>
-                        <name>c1</name>
+                        <name>ca</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-7</itextId>
+                        <label>CB</label>
                         <level1>c</level1>
-                        <name>c2</name>
+                        <name>cb</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-8</itextId>
+                        <label>CC</label>
                         <level1>c</level1>
-                        <name>c3</name>
+                        <name>cc</name>
                     </item>
                     <item>
-                        <itextId>static_instance-level2-9</itextId>
+                        <label>CD</label>
                         <level1>c</level1>
-                        <name>c4</name>
+                        <name>cd</name>
                     </item>
                 </root>
             </instance>
             <instance id="level3">
                 <root>
                     <item>
-                        <itextId>static_instance-level3-0</itextId>
-                        <level2>a1</level2>
-                        <name>a1a</name>
+                        <label>AAA</label>
+                        <name>aaa</name>
+                        <level2>aa</level2>
                     </item>
                     <item>
-                        <itextId>static_instance-level3-1</itextId>
-                        <level2>a1</level2>
-                        <name>a1b</name>
+                        <label>AAB</label>
+                        <name>aab</name>
+                        <level2>aa</level2>
                     </item>
                     <item>
-                        <itextId>static_instance-level3-2</itextId>
-                        <level2>b1</level2>
-                        <name>b1a</name>
+                        <label>BAA</label>
+                        <name>baa</name>
+                        <level2>ba</level2>
                     </item>
                     <item>
-                        <itextId>static_instance-level3-3</itextId>
-                        <level2>b1</level2>
-                        <name>b1b</name>
+                        <label>BAB</label>
+                        <name>bab</name>
+                        <level2>ba</level2>
                     </item>
                 </root>
             </instance>
             <bind nodeset="/data/level1" type="select1"/>
             <bind nodeset="/data/level2" type="select1"/>
             <bind nodeset="/data/level3" type="select1"/>
+            <bind nodeset="/data/level1_contains" type="select1"/>
+            <bind nodeset="/data/level2_contains" type="select1"/>
+            <bind nodeset="/data/level3_contains" type="select1"/>
             <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
         </model>
     </h:head>
@@ -188,14 +139,43 @@
             <label>Level2</label>
             <itemset nodeset="instance('level2')/root/item[level1 =  /data/level1 ]">
                 <value ref="name"/>
-                <label ref="jr:itext(itextId)"/>
+                <label ref="label"/>
             </itemset>
         </select1>
         <select1 ref="/data/level3">
             <label>Level3</label>
             <itemset nodeset="instance('level3')/root/item[level2 =  /data/level2 ]">
                 <value ref="name"/>
-                <label ref="jr:itext(itextId)"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/data/level1_contains">
+            <label>Level1 contains</label>
+            <item>
+                <label>A</label>
+                <value>a</value>
+            </item>
+            <item>
+                <label>B</label>
+                <value>b</value>
+            </item>
+            <item>
+                <label>C</label>
+                <value>c</value>
+            </item>
+        </select1>
+        <select1 ref="/data/level2_contains">
+            <label>Level2 contains</label>
+            <itemset nodeset="instance('level2')/root/item[contains(name,  /data/level1_contains )]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/data/level3_contains">
+            <label>Level3 contains</label>
+            <itemset nodeset="instance('level3')/root/item[contains(name,  /data/level2_contains )]">
+                <value ref="name"/>
+                <label ref="label"/>
             </itemset>
         </select1>
     </h:body>

--- a/src/test/resources/org/javarosa/core/model/three-level-cascading-select.xml
+++ b/src/test/resources/org/javarosa/core/model/three-level-cascading-select.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Three level cascading select</h:title>
+        <model>
+            <itext>
+                <translation default="true()" lang="default">
+                    <text id="static_instance-level1-0">
+                        <value>A</value>
+                    </text>
+                    <text id="static_instance-level1-1">
+                        <value>B</value>
+                    </text>
+                    <text id="static_instance-level1-2">
+                        <value>C</value>
+                    </text>
+                    <text id="static_instance-level2-0">
+                        <value>A1</value>
+                    </text>
+                    <text id="static_instance-level2-1">
+                        <value>A2</value>
+                    </text>
+                    <text id="static_instance-level2-2">
+                        <value>A3</value>
+                    </text>
+                    <text id="static_instance-level2-3">
+                        <value>B1</value>
+                    </text>
+                    <text id="static_instance-level2-4">
+                        <value>B2</value>
+                    </text>
+                    <text id="static_instance-level2-5">
+                        <value>B3</value>
+                    </text>
+                    <text id="static_instance-level2-6">
+                        <value>C1</value>
+                    </text>
+                    <text id="static_instance-level2-7">
+                        <value>C2</value>
+                    </text>
+                    <text id="static_instance-level2-8">
+                        <value>C3</value>
+                    </text>
+                    <text id="static_instance-level2-9">
+                        <value>C4</value>
+                    </text>
+                    <text id="static_instance-level3-0">
+                        <value>A1A</value>
+                    </text>
+                    <text id="static_instance-level3-1">
+                        <value>A1B</value>
+                    </text>
+                    <text id="static_instance-level3-2">
+                        <value>B1A</value>
+                    </text>
+                    <text id="static_instance-level3-3">
+                        <value>B1B</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <data id="three-level-cascading-select">
+                    <level1/>
+                    <level2/>
+                    <level3/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <instance id="level1">
+                <root>
+                    <item>
+                        <itextId>static_instance-level1-0</itextId>
+                        <name>a</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level1-1</itextId>
+                        <name>b</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level1-2</itextId>
+                        <name>c</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="level2">
+                <root>
+                    <item>
+                        <itextId>static_instance-level2-0</itextId>
+                        <level1>a</level1>
+                        <name>a1</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-1</itextId>
+                        <level1>a</level1>
+                        <name>a2</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-2</itextId>
+                        <level1>a</level1>
+                        <name>a3</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-3</itextId>
+                        <level1>b</level1>
+                        <name>b1</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-4</itextId>
+                        <level1>b</level1>
+                        <name>b2</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-5</itextId>
+                        <level1>b</level1>
+                        <name>b3</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-6</itextId>
+                        <level1>c</level1>
+                        <name>c1</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-7</itextId>
+                        <level1>c</level1>
+                        <name>c2</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-8</itextId>
+                        <level1>c</level1>
+                        <name>c3</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level2-9</itextId>
+                        <level1>c</level1>
+                        <name>c4</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="level3">
+                <root>
+                    <item>
+                        <itextId>static_instance-level3-0</itextId>
+                        <level2>a1</level2>
+                        <name>a1a</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level3-1</itextId>
+                        <level2>a1</level2>
+                        <name>a1b</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level3-2</itextId>
+                        <level2>b1</level2>
+                        <name>b1a</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-level3-3</itextId>
+                        <level2>b1</level2>
+                        <name>b1b</name>
+                    </item>
+                </root>
+            </instance>
+            <bind nodeset="/data/level1" type="select1"/>
+            <bind nodeset="/data/level2" type="select1"/>
+            <bind nodeset="/data/level3" type="select1"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/level1">
+            <label>Level1</label>
+            <item>
+                <label>A</label>
+                <value>a</value>
+            </item>
+            <item>
+                <label>B</label>
+                <value>b</value>
+            </item>
+            <item>
+                <label>C</label>
+                <value>c</value>
+            </item>
+        </select1>
+        <select1 ref="/data/level2">
+            <label>Level2</label>
+            <itemset nodeset="instance('level2')/root/item[level1 =  /data/level1 ]">
+                <value ref="name"/>
+                <label ref="jr:itext(itextId)"/>
+            </itemset>
+        </select1>
+        <select1 ref="/data/level3">
+            <label>Level3</label>
+            <itemset nodeset="instance('level3')/root/item[level2 =  /data/level2 ]">
+                <value ref="name"/>
+                <label ref="jr:itext(itextId)"/>
+            </itemset>
+        </select1>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Partially addresses #436

#### What has been done to verify that this works as intended?
I have added a series of tests that ensure the answer is only cleared when the choice is no longer available.

#### Why is this the best possible solution? Were any other approaches considered?
This is not a complete fix for the long term but I think it's valuable and should be relatively low-risk and quick to review. I considered doing nothing for now but decided this was worth doing because:
- without this change, it's possible for data collectors to accidentally save incoherent values. For example, imagine a cascading select that first asks for country and then for city. The user could select "France", then "Paris", then change the country to "Spain", jump to the end and unintentionally submit Paris, Spain. 
- we are now supporting cascading selects on a single screen in Collect. Without this change, clearing the first level after answering subsequent levels would leave choices and selections in those subsequent levels. We believe cascading selects on a single screen will be used commonly and so this is a pretty annoying bug.

I don't love adding a side-effect to `populateDynamicChoices` but I think it is expected that the choice selected should always be part of the available choices.

I spent about an hour trying to figure out what a more complete fix might look like and concluded that it would be a fairly big lift for me given that I don't know the details of the DAG/Triggerable implementation. This kind of clearing would need to happen anyway.

@ggalmazor I'll definitely want your feedback on the tests. Specifically:
- I recognize there's a lot of redundancy between them. I wrote them to be independent from each other and to verify each assumption I might make. Do you think I should cut them down to just the bit that is not verified in other tests?
- I use a different naming convention than you do. You use `some_precondition_should_lead_to_this` and I use `somePrecondition_ShouldLeadToThis`. I have a slight preference for the later but I don't know where I picked up that convention so maybe it's a weird one. Should we enforce a convention? I don't mind adopting yours or being loose about it as long as the naming is clear.
- The tests "cheat" since this solution is incomplete. Do the `TODO`s make that clear enough?
- Does moving the Matchers to core.test make sense to you or is there another place you think we should put them?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It clears out a user's answer if that answer is no longer available to be chosen. If I got the logic wrong, there could be a risk of data loss when using selects with choice filters.

#### Do we need any specific form for testing your changes? If so, please attach one.
See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.