### PR TITLE
Consider instance name in TreeReference comparison

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -16,14 +16,8 @@
 
 package org.javarosa.core.model.instance;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.javarosa.core.util.DataUtil;
+import org.javarosa.core.util.Objects;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
@@ -31,6 +25,13 @@ import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.expr.XPathExpression;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TreeReference implements Externalizable, Serializable {
     /** @deprecated replaced by {@link #DEFAULT_MULTIPLICITY} */
@@ -402,6 +403,10 @@ public class TreeReference implements Externalizable, Serializable {
             return true;
         } else if (o instanceof TreeReference) {
             TreeReference ref = (TreeReference)o;
+
+            if (!Objects.equals(getInstanceName(), ref.getInstanceName())) {
+                return false;
+            }
 
             if (this.refLevel == ref.refLevel && this.size() == ref.size()) {
                 for (int i = 0; i < this.size(); i++) {

--- a/src/main/java/org/javarosa/core/util/Objects.java
+++ b/src/main/java/org/javarosa/core/util/Objects.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.util;
+
+public class Objects {
+    /**
+     * Null-safe equivalent of {@code a.equals(b)}.
+     */
+    public static boolean equals(Object a, Object b) {
+        return (a == null) ? (b == null) : a.equals(b);
+    }
+}

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceEqualsTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceEqualsTest.java
@@ -1,0 +1,50 @@
+package org.javarosa.core.model.instance;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.instance.TestHelpers.buildRef;
+
+@RunWith(Parameterized.class)
+public class TreeReferenceEqualsTest {
+    @Parameterized.Parameter(value = 0)
+    public String testCase;
+
+    @Parameterized.Parameter(value = 1)
+    public String pathA;
+
+    @Parameterized.Parameter(value = 2)
+    public String pathB;
+
+    @Parameterized.Parameter(value = 3)
+    public boolean expectToBeEqual;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> testCases() {
+        return Arrays.asList(new Object[][]{
+            // region Equality across same or different instances
+
+            // Prior to JR 1.15, the instance was not taken into account when comparing two TreeReferences. That meant
+            // two references representing the same path in two different instances would be considered the same reference.
+            {"same path in primary instance are equal", "/foo/bar", "/foo/bar", true},
+            {"same path in secondary instance are equal", "instance('foo')/bar/baz", "instance('foo')/bar/baz", true},
+            {"same path in primary and secondary instance are not equal", "/foo/bar", "instance('foo')/foo/bar", false},
+            {"same path in secondary and primary instance are not equal", "instance('foo')/foo/bar", "/foo/bar", false},
+            {"same path in different secondary instances are not equal", "instance('foo')/foo/bar", "instance('bar')/foo/bar", false},
+            {"different paths in primary instance are not equal", "/foo/bar", "/foo/bar/quux", false},
+            {"different paths in secondary instance are not equal", "instance('foo')/foo/bar", "instance('foo')/foo/bar/quux", false}
+            //endregion
+        });
+    }
+
+    @Test
+    public void treeReferenceEqualsTest() {
+        assertThat(buildRef(pathA).equals(buildRef(pathB)), is(expectToBeEqual));
+    }
+}


### PR DESCRIPTION
Closes #449 

<details>
<summary> Initial description</summary>
I see two testing options: 
* create `TreeReference`s and verify the result of testing for equality between them
* add a simple form that exhibits this problem

I don't like the first because we don't have tests of that kind. I could target just the new behavior which would lead to trivial tests. Or I could try to fully test the equals method which is likely to be a bit of a mess with all the multiplicity and predicate options. Admittedly, maybe the latter is a reason to write those tests but I ran into this by accident and don't want to rathole here.

I don't love the second because I don't think that form would really augment the test suite in a meaningful way.

That said, I can be convinced that I have a bad attitude and should Do The Right Thing™️. (CC @seadowg) 

#### What has been done to verify that this works as intended?
Tried form from issue in Collect.

#### Why is this the best possible solution? Were any other approaches considered?
This is the simplest possible way to compare two objects that can be null.

</details>

#### What has been done to verify that this works as intended?
Tried form from issue in Collect and added a test (thank you @ggalmazor and @seadowg).

#### Why is this the best possible solution? Were any other approaches considered?
I would have liked to use Java's `Objects.equals` but that's not available in Android API levels < 19. See https://github.com/opendatakit/collect/issues/3192.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intent is for this to have no user impact other than enabling previously impossible behavior. If I messed this up and equality of `TreeReference`s has changed in an unexpected way, it could lead to problems with any kind of form, though.

#### Do we need any specific form for testing your changes? If so, please attach one.
[dont-show-options-selected-in-other-instances.xml.txt](https://github.com/opendatakit/javarosa/files/3336961/dont-show-options-selected-in-other-instances.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.