### PR TITLE
Use custom Objects class for clients that use Java <1.7

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -16,12 +16,12 @@
 
 package org.javarosa.core.model;
 
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.Objects;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
-import org.javarosa.core.model.instance.TreeReference;
 
 /**
  * {@code FormIndex} is an immutable index which is structured to provide quick access to a specific node in a

--- a/src/main/java/org/javarosa/core/util/Objects.java
+++ b/src/main/java/org/javarosa/core/util/Objects.java
@@ -16,11 +16,25 @@
 
 package org.javarosa.core.util;
 
+import java.util.Arrays;
+
+/**
+ * TODO: replace with java.util.Objects once all clients use Java 1.7+ (for Android, that means a minSDK of 19+).
+ */
 public class Objects {
     /**
      * Null-safe equivalent of {@code a.equals(b)}.
      */
     public static boolean equals(Object a, Object b) {
         return (a == null) ? (b == null) : a.equals(b);
+    }
+
+    /**
+     * Convenience wrapper for {@link Arrays#hashCode}, adding varargs.
+     * This can be used to compute a hash code for an object's fields as follows:
+     * {@code Objects.hash(a, b, c)}.
+     */
+    public static int hash(Object... values) {
+        return Arrays.hashCode(values);
     }
 }


### PR DESCRIPTION
Addresses https://github.com/opendatakit/collect/issues/3192

Adds a `hash` implementation to the custom `Objects` class introduced in https://github.com/opendatakit/javarosa/pull/450 to support clients that use Java <1.7.