### PR TITLE
Added UTF-8 encoding options in compileJava and compileTestJava for I…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ sourceSets {
     test.java.srcDirs = ['src/test/java']
     test.resources.srcDirs = ['src/test/resources']
 }
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
 
 compileJava {
     options.compilerArgs << "-Xlint:deprecation"


### PR DESCRIPTION
Explanation:
When not setting the compiler encoding option explicitly, the problem you can run into is, that the Java compiler uses a different file encoding (in Gradle's case the system's default encoding) than the source code files are encoding in.
It happened to me that I had my Java code files encoded in UTF-8, Intellij IDEA compiling with UTF-8 during development (simply because it's faster), but Gradle compiling with the platform default encoding (e.g. Cp1252) and this results in build-failures(due to presence of greek letters in GeoUtils.java).

Closes #

#### What has been done to verify that this works as intended?
Executed the builds and verified that the build is successful

#### Why is this the best possible solution? Were any other approaches considered?
NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This does not changes anything .This change is made so that IntejiIdea does not pick system default encoding while building the project instead of UTF -8.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No
