### PR TITLE
Add normalize-space function and tests.

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -391,6 +391,9 @@ public class XPathFuncExpr extends XPathExpression {
         } else if (name.equals("string-length")) {
             assertArgsCount(name, args, 1);
             return stringLength(argVals[0]);
+        } else if (name.equals("normalize-space")) {
+            assertArgsCount(name, args, 1);
+            return normalizeSpace(argVals[0]);
         } else if (name.equals("checklist") && args.length >= 2) { //non-standard
             if (args.length == 3 && argVals[2] instanceof XPathNodeset) {
                 return checklist(argVals[0], argVals[1], ((XPathNodeset) argVals[2]).toArgList());
@@ -607,6 +610,12 @@ public class XPathFuncExpr extends XPathExpression {
             return 0.0;
         }
         return (double) s.length();
+    }
+
+    public static String normalizeSpace (Object o) {
+        String s = toString(o);
+        String normalized = s.trim().replaceAll("\\s+", " ");
+        return normalized;
     }
 
     /**

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -281,6 +281,19 @@ public class XPathEvalTest extends TestCase {
         testEval("ends-with('abc', 'c')",   true);
         testEval("ends-with('', '')",       true);
 
+        logTestCategory("other string functions");
+        testEval("normalize-space('')", "");
+        testEval("normalize-space('  ')", "");
+        testEval("normalize-space(' \t\n ')", "");
+        testEval("normalize-space(' a')", "a");
+        testEval("normalize-space(' a   ')", "a");
+        testEval("normalize-space(' ab ')", "ab");
+        testEval("normalize-space(' a    b ')", "a b");
+        testEval("normalize-space(' a\nb\n')", "a b");
+        testEval("normalize-space('\na\nb\n')", "a b");
+        testEval("normalize-space('\nab')", "ab");
+        testEval("normalize-space(' \ta\n\t  b \n\t c   \n')", "a b c");
+
         logTestCategory("date functions");
         testEval("date('2000-01-01')", DateUtils.getDate(2000, 1, 1));
         testEval("date('1945-04-26')", DateUtils.getDate(1945, 4, 26));


### PR DESCRIPTION
Closes #460 

#### What has been done to verify that this works as intended?
I added tests in the source code to verify functionality.

#### Why is this the best possible solution? Were any other approaches considered?
The Javarosa ecosystem has demand for the `normalize-space` feature. The functionality is described at https://www.w3.org/TR/1999/REC-xpath-19991116/#function-string-length. This solution implements the one-argument form only, similar to `string-length`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Allows users to use a new XPath function when authoring XForms.

#### Do we need any specific form for testing your changes? If so, please attach one.
Test form attached:
[normalize-space-test.xlsx](https://github.com/opendatakit/javarosa/files/3408870/normalize-space-test.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Documentation links:
https://github.com/opendatakit/docs/issues/1070
https://github.com/opendatakit/xforms-spec/issues/242