### PR TITLE
Include multiplicities only for repeatable groups in TreeReference.toString() method

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -368,6 +368,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             IFormElement temp = elements.get(i);
             if (temp instanceof GroupDef && ((GroupDef) temp).getRepeat()) {
                 TreeReference repRef = FormInstance.unpackReference(temp.getBind());
+                ref.markAsRepeatable(repRef.size() - 1);
                 if (repRef.isParentOf(ref, false)) {
                     int repMult = multiplicities.get(i);
                     ref.setMultiplicity(repRef.size() - 1, repMult);

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -512,8 +512,10 @@ public class TreeReference implements Externalizable, Serializable {
                     case INDEX_TEMPLATE: sb.append("[@template]"); break;
                     case INDEX_REPEAT_JUNCTURE: sb.append("[@juncture]"); break;
                     default:
-                        if ((i > 0 || mult != 0) && mult !=-4) {
-                            sb.append("[").append(mult + (zeroIndexMult ? 0 : 1)).append("]");
+                        if (data.get(i).isRepeatable()) {
+                            if ((i > 0 || mult != 0) && mult !=-4) {
+                                sb.append("[").append(mult + (zeroIndexMult ? 0 : 1)).append("]");
+                            }
                         }
                         break;
                 }
@@ -671,5 +673,9 @@ public class TreeReference implements Externalizable, Serializable {
             predicateless.data.set(i, predicateless.data.get(i).setPredicates(null));
         }
         return predicateless;
+    }
+
+    public void markAsRepeatable(int i) {
+        data.get(i).markAsRepeatable();
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -24,6 +24,7 @@ public class TreeReferenceLevel implements Externalizable, Serializable {
     private String name;
     private int multiplicity = MULT_UNINIT;
     private List<XPathExpression> predicates;
+    private boolean isRepeatable;
 
     /** A cache for reference levels, to avoid keeping a bunch of the same levels floating around at run-time. */
     private static CacheTable<TreeReferenceLevel> refs;
@@ -36,14 +37,15 @@ public class TreeReferenceLevel implements Externalizable, Serializable {
         // for externalization
     }
 
-    public TreeReferenceLevel(String name, int multiplicity, List<XPathExpression> predicates) {
+    public TreeReferenceLevel(String name, int multiplicity, List<XPathExpression> predicates, boolean isRepeatable) {
         this.name = name;
         this.multiplicity = multiplicity;
         this.predicates = predicates;
+        this.isRepeatable = isRepeatable;
     }
 
     public TreeReferenceLevel(String name, int multiplicity) {
-        this(name, multiplicity, null);
+        this(name, multiplicity, null, false);
     }
 
 
@@ -56,11 +58,11 @@ public class TreeReferenceLevel implements Externalizable, Serializable {
     }
 
     public TreeReferenceLevel setMultiplicity(int mult) {
-        return new TreeReferenceLevel(name, mult, predicates).intern();
+        return new TreeReferenceLevel(name, mult, predicates, isRepeatable).intern();
     }
 
     public TreeReferenceLevel setPredicates(List<XPathExpression> xpe) {
-        return new TreeReferenceLevel(name, multiplicity, xpe).intern();
+        return new TreeReferenceLevel(name, multiplicity, xpe, isRepeatable).intern();
     }
 
     public List<XPathExpression> getPredicates() {
@@ -68,11 +70,11 @@ public class TreeReferenceLevel implements Externalizable, Serializable {
     }
 
     public TreeReferenceLevel shallowCopy() {
-        return new TreeReferenceLevel(name, multiplicity, ArrayUtilities.listCopy(predicates)).intern();
+        return new TreeReferenceLevel(name, multiplicity, ArrayUtilities.listCopy(predicates), isRepeatable).intern();
     }
 
     public TreeReferenceLevel setName(String name) {
-        return new TreeReferenceLevel(name, multiplicity, predicates).intern();
+        return new TreeReferenceLevel(name, multiplicity, predicates, isRepeatable).intern();
     }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
@@ -131,5 +133,16 @@ public class TreeReferenceLevel implements Externalizable, Serializable {
         } else{
             return refs.intern(this);
         }
+    }
+
+    void markAsRepeatable() {
+        isRepeatable = true;
+    }
+
+    /**
+     * @return true if the current level represents a repeatable group, otherwise false
+     */
+    boolean isRepeatable() {
+        return isRepeatable;
     }
 }


### PR DESCRIPTION
Closes https://github.com/opendatakit/collect/issues/3126

#### What has been done to verify that this works as intended?
I tested the attached form with changes on the Collect side.

#### Why is this the best possible solution? Were any other approaches considered?
I decided to the safer option. I don't change setting multiplicities (what is used in multiple classes) I just include them in TreeReference.toString() if a level represents a repeatable group.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As I said above I decided to use the safer solution so I don't think it's risky. Generally, I changed that toString method only so testing it would be fine.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used this one:
[test.xml.txt](https://github.com/opendatakit/javarosa/files/3417581/test.xml.txt)
but any form with regular groups and repeatable groups is fine.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No, I thought that we have some samples in the [doc](https://docs.opendatakit.org/form-audit-log/) that we would need to fix but looks as if I was wrong.
