### PR TITLE
Split select multi answer to verify if each still in choices

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1106,10 +1106,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      *                            or not it should be kept
      * @return a copy of {@code selections} without the values that were mapped to false in {@code shouldKeepSelection}
      */
-    private MultipleItemsData getFilteredSelections(MultipleItemsData selections, Map<String, Boolean> shouldKeepSelection) {
+    private static MultipleItemsData getFilteredSelections(MultipleItemsData selections, Map<String, Boolean> shouldKeepSelection) {
         List<Selection> newSelections = new ArrayList<>();
         for (Selection oldSelection : (List<Selection>) selections.getValue()) {
-            if (shouldKeepSelection.get(oldSelection.choice != null ? oldSelection.choice.getValue() : oldSelection.xmlValue)) {
+            String key = oldSelection.choice != null ? oldSelection.choice.getValue() : oldSelection.xmlValue;
+            if (shouldKeepSelection.get(key)) {
                 newSelections.add(oldSelection);
             }
         }

--- a/src/test/java/org/javarosa/core/model/SelectMultipleChoiceFilterTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectMultipleChoiceFilterTest.java
@@ -1,11 +1,8 @@
 package org.javarosa.core.model;
 
-import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.test.Scenario;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -20,6 +17,8 @@ import static org.javarosa.core.test.SelectChoiceMatchers.choice;
  * cascading pattern, updating selections at root levels correctly updates the choices available in dependent selects
  * all the way down the cascade.  They also verify that if an answer that is no longer part of the available choices was
  * previously selected, that selection is removed from the answer.
+ *
+ * Select ones use the same code paths so see also {@link SelectOneChoiceFilterTest} for more explicit cases at each level.
  */
 public class SelectMultipleChoiceFilterTest {
     private Scenario scenario;
@@ -34,14 +33,11 @@ public class SelectMultipleChoiceFilterTest {
         assertThat(scenario.choicesOf("/data/level3"), empty());
     }
 
-    /**
-     * Level 1 is a static choice list.
-     */
     @Test public void selectingValueAtLevel1_filtersChoicesAtLevel2() {
         scenario.newInstance();
         assertThat(scenario.choicesOf("/data/level2"), empty());
 
-        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("b")));
+        scenario.answer("/data/level1", "a", "b");
 
         assertThat(scenario.choicesOf("/data/level2"), containsInAnyOrder(
             choice("aa"),
@@ -57,18 +53,13 @@ public class SelectMultipleChoiceFilterTest {
         assertThat(scenario.choicesOf("/data/level2"), empty());
         assertThat(scenario.choicesOf("/data/level3"), empty());
 
-        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("b")));
-        scenario.answer("/data/level2", Arrays.asList(new Selection("aa"), new Selection("ba")));
+        scenario.answer("/data/level1", "a", "b");
+        scenario.answer("/data/level2", "aa", "ba");
         assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
             choice("aaa"),
             choice("aab"),
             choice("baa"),
             choice("bab")));
-
-        // Force populateDynamicChoices to run again
-        scenario.choicesOf("/data/level2");
-
-        assertThat(scenario.answerOf("/data/level2"), is(answerText("aa, ba")));
     }
 
     @Test public void newChoiceFilterEvaluation_removesIrrelevantAnswersAtAllLevels_withoutChangingOrder() {
@@ -76,23 +67,52 @@ public class SelectMultipleChoiceFilterTest {
         assertThat(scenario.choicesOf("/data/level2"), empty());
         assertThat(scenario.choicesOf("/data/level3"), empty());
 
-        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("b"), new Selection("c")));
-        scenario.answer("/data/level2", Arrays.asList(new Selection("aa"), new Selection("ba"), new Selection("ca")));
-        scenario.answer("/data/level3", Arrays.asList(new Selection("aab"), new Selection("baa"), new Selection("aaa")));
+        scenario.answer("/data/level1", "a", "b", "c");
+        scenario.answer("/data/level2", "aa", "ba", "ca");
+        scenario.answer("/data/level3", "aab", "baa", "aaa");
 
-        // Remove b from the level1 answer
-        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("c")));
+        // Remove b from the level1 answer; this should filter out b-related answers and choices at levels 2 and 3
+        scenario.answer("/data/level1", "a", "c");
 
-        // Force populateDynamicChoices to run again
+        // Force populateDynamicChoices to run again which is what filters out irrelevant answers
         scenario.choicesOf("/data/level2");
 
         assertThat(scenario.answerOf("/data/level2"), is(answerText("aa, ca")));
 
+        // This also runs populateDynamicChoices and filters out irrelevant answers
         assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
             choice("aaa"),
-            choice("aab")));
+            choice("aab"),
+            choice("caa"),
+            choice("cab")));
 
         assertThat(scenario.answerOf("/data/level3"), is(answerText("aab, aaa")));
+    }
 
+    @Test public void newChoiceFilterEvaluation_leavesAnswerUnchangedIfAllSelectionsStillInChoices() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+
+        scenario.answer("/data/level1", "a", "b", "c");
+        scenario.answer("/data/level2", "aa", "ba", "bb", "ab");
+        scenario.answer("/data/level3", "aab", "baa", "aaa");
+
+        // Remove c from the level1 answer; this should have no effect on levels 2 and 3
+        scenario.answer("/data/level1", "a", "b");
+
+        // Force populateDynamicChoices to run again which is what filters out irrelevant answers
+        scenario.choicesOf("/data/level2");
+
+        assertThat(scenario.answerOf("/data/level2"), is(answerText("aa, ba, bb, ab")));
+
+        // This also runs populateDynamicChoices and filters out irrelevant answers
+        assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
+            choice("aaa"),
+            choice("aab"),
+            choice("baa"),
+            choice("bab")));
+
+        assertThat(scenario.answerOf("/data/level3"), is(answerText("aab, baa, aaa")));
     }
 }

--- a/src/test/java/org/javarosa/core/model/SelectMultipleChoiceFilterTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectMultipleChoiceFilterTest.java
@@ -1,0 +1,98 @@
+package org.javarosa.core.model;
+
+import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.test.Scenario;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.answerText;
+import static org.javarosa.core.test.SelectChoiceMatchers.choice;
+
+/**
+ * When itemsets are dynamically generated, the choices available to a user in a select multiple question can change
+ * based on the answers given to other questions. These tests verify that when several select multiples are chained in a
+ * cascading pattern, updating selections at root levels correctly updates the choices available in dependent selects
+ * all the way down the cascade.  They also verify that if an answer that is no longer part of the available choices was
+ * previously selected, that selection is removed from the answer.
+ */
+public class SelectMultipleChoiceFilterTest {
+    private Scenario scenario;
+
+    @Before public void setUp() {
+        scenario = Scenario.init("three-level-cascading-multi-select.xml");
+    }
+
+    @Test public void dependentLevelsInBlankInstance_haveNoChoices() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+    }
+
+    /**
+     * Level 1 is a static choice list.
+     */
+    @Test public void selectingValueAtLevel1_filtersChoicesAtLevel2() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+
+        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("b")));
+
+        assertThat(scenario.choicesOf("/data/level2"), containsInAnyOrder(
+            choice("aa"),
+            choice("ab"),
+            choice("ac"),
+            choice("ba"),
+            choice("bb"),
+            choice("bc")));
+    }
+
+    @Test public void selectingValuesAtLevels1And2_filtersChoicesAtLevel3() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+
+        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("b")));
+        scenario.answer("/data/level2", Arrays.asList(new Selection("aa"), new Selection("ba")));
+        assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
+            choice("aaa"),
+            choice("aab"),
+            choice("baa"),
+            choice("bab")));
+
+        // Force populateDynamicChoices to run again
+        scenario.choicesOf("/data/level2");
+
+        assertThat(scenario.answerOf("/data/level2"), is(answerText("aa, ba")));
+    }
+
+    @Test public void newChoiceFilterEvaluation_removesIrrelevantAnswersAtAllLevels_withoutChangingOrder() {
+        scenario.newInstance();
+        assertThat(scenario.choicesOf("/data/level2"), empty());
+        assertThat(scenario.choicesOf("/data/level3"), empty());
+
+        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("b"), new Selection("c")));
+        scenario.answer("/data/level2", Arrays.asList(new Selection("aa"), new Selection("ba"), new Selection("ca")));
+        scenario.answer("/data/level3", Arrays.asList(new Selection("aab"), new Selection("baa"), new Selection("aaa")));
+
+        // Remove b from the level1 answer
+        scenario.answer("/data/level1", Arrays.asList(new Selection("a"), new Selection("c")));
+
+        // Force populateDynamicChoices to run again
+        scenario.choicesOf("/data/level2");
+
+        assertThat(scenario.answerOf("/data/level2"), is(answerText("aa, ca")));
+
+        assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
+            choice("aaa"),
+            choice("aab")));
+
+        assertThat(scenario.answerOf("/data/level3"), is(answerText("aab, aaa")));
+
+    }
+}

--- a/src/test/java/org/javarosa/core/model/SelectOneChoiceFilterTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectOneChoiceFilterTest.java
@@ -28,7 +28,14 @@ import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.test.SelectChoiceMatchers.choice;
 
-public class ItemsetBindingTest {
+/**
+ * When itemsets are dynamically generated, the choices available to a user in a select one question can change based on
+ * the answers given to other questions. These tests verify that when several select ones are chained in a cascading
+ * pattern, updating selections at root levels correctly updates the choices available in dependent selects all the way
+ * down the cascade. They also verify that if an answer that is no longer part of the available choices was previously
+ * selected, that answer is cleared.
+ */
+public class SelectOneChoiceFilterTest {
     private Scenario scenario;
 
     @Before

--- a/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
+++ b/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
@@ -44,4 +44,23 @@ public class AnswerDataMatchers {
             }
         };
     }
+
+    public static <T extends IAnswerData> Matcher<T> answerText(String expectedAnswerText) {
+        return new TypeSafeMatcher<T>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("answer " + expectedAnswerText);
+            }
+
+            @Override
+            protected void describeMismatchSafely(T item, Description mismatchDescription) {
+                mismatchDescription.appendText("was answer " + item.getDisplayText() + "(").appendValue(item.getValue()).appendText(")");
+            }
+
+            @Override
+            protected boolean matchesSafely(T item) {
+                return item.getDisplayText().matches(expectedAnswerText);
+            }
+        };
+    }
 }

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -16,6 +16,31 @@
 
 package org.javarosa.core.test;
 
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.MultipleItemsData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
 import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
 import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
@@ -28,28 +53,6 @@ import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
 import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
 import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import org.javarosa.core.model.FormDef;
-import org.javarosa.core.model.FormIndex;
-import org.javarosa.core.model.QuestionDef;
-import org.javarosa.core.model.SelectChoice;
-import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.StringData;
-import org.javarosa.core.model.instance.InstanceInitializationFactory;
-import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.form.api.FormEntryController;
-import org.javarosa.form.api.FormEntryModel;
-import org.javarosa.form.api.FormEntryPrompt;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * <div style="border: 1px 1px 1px 1px; background-color: #556B2F; color: white; padding: 20px">
@@ -132,6 +135,13 @@ public class Scenario {
         // calculate formula depending on this field, or itemsets rendering this
         // field's value as a choice)
         formDef.setValue(new StringData(value), element.getRef(), true);
+    }
+
+    public void answer(String xPath, List<Selection> selections) {
+        createMissingRepeats(xPath);
+        TreeElement element = Objects.requireNonNull(resolve(xPath));
+
+        formDef.setValue(new MultipleItemsData(selections), element.getRef(), true);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -137,10 +137,15 @@ public class Scenario {
         formDef.setValue(new StringData(value), element.getRef(), true);
     }
 
-    public void answer(String xPath, List<Selection> selections) {
+    /**
+     * Sets the value of the element located at the given xPath in the main instance to a multiple select selection
+     * created from the given values.
+     */
+    public void answer(String xPath, String... selectionValues) {
         createMissingRepeats(xPath);
         TreeElement element = Objects.requireNonNull(resolve(xPath));
 
+        List<Selection> selections = Arrays.stream(selectionValues).map(Selection::new).collect(Collectors.toList());
         formDef.setValue(new MultipleItemsData(selections), element.getRef(), true);
     }
 

--- a/src/test/resources/org/javarosa/core/model/three-level-cascading-multi-select.xml
+++ b/src/test/resources/org/javarosa/core/model/three-level-cascading-multi-select.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Three level cascading multi select</h:title>
+        <model>
+            <instance>
+                <data id="three-level-cascading-multi-select">
+                    <level1/>
+                    <level2/>
+                    <level3/>
+                    <level1_contains/>
+                    <level2_contains/>
+                    <level3_contains/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <instance id="level1">
+                <root>
+                    <item>
+                        <label>A</label>
+                        <name>a</name>
+                    </item>
+                    <item>
+                        <label>B</label>
+                        <name>b</name>
+                    </item>
+                    <item>
+                        <label>C</label>
+                        <name>c</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="level2">
+                <root>
+                    <item>
+                        <label>AA</label>
+                        <level1>a</level1>
+                        <name>aa</name>
+                    </item>
+                    <item>
+                        <label>AB</label>
+                        <level1>a</level1>
+                        <name>ab</name>
+                    </item>
+                    <item>
+                        <label>AC</label>
+                        <level1>a</level1>
+                        <name>ac</name>
+                    </item>
+                    <item>
+                        <label>BA</label>
+                        <level1>b</level1>
+                        <name>ba</name>
+                    </item>
+                    <item>
+                        <label>BB</label>
+                        <level1>b</level1>
+                        <name>bb</name>
+                    </item>
+                    <item>
+                        <label>BC</label>
+                        <level1>b</level1>
+                        <name>bc</name>
+                    </item>
+                    <item>
+                        <label>CA</label>
+                        <level1>c</level1>
+                        <name>ca</name>
+                    </item>
+                    <item>
+                        <label>CB</label>
+                        <level1>c</level1>
+                        <name>cb</name>
+                    </item>
+                    <item>
+                        <label>CC</label>
+                        <level1>c</level1>
+                        <name>cc</name>
+                    </item>
+                    <item>
+                        <label>CD</label>
+                        <level1>c</level1>
+                        <name>cd</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="level3">
+                <root>
+                    <item>
+                        <label>AAA</label>
+                        <name>aaa</name>
+                        <level2>aa</level2>
+                    </item>
+                    <item>
+                        <label>AAB</label>
+                        <name>aab</name>
+                        <level2>aa</level2>
+                    </item>
+                    <item>
+                        <label>BAA</label>
+                        <name>baa</name>
+                        <level2>ba</level2>
+                    </item>
+                    <item>
+                        <label>BAB</label>
+                        <name>bab</name>
+                        <level2>ba</level2>
+                    </item>
+                </root>
+            </instance>
+            <bind nodeset="/data/level1" type="select"/>
+            <bind nodeset="/data/level2" type="select"/>
+            <bind nodeset="/data/level3" type="select"/>
+            <bind nodeset="/data/level1_contains" type="select"/>
+            <bind nodeset="/data/level2_contains" type="select"/>
+            <bind nodeset="/data/level3_contains" type="select"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select ref="/data/level1">
+            <label>Level1</label>
+            <item>
+                <label>A</label>
+                <value>a</value>
+            </item>
+            <item>
+                <label>B</label>
+                <value>b</value>
+            </item>
+            <item>
+                <label>C</label>
+                <value>c</value>
+            </item>
+        </select>
+        <select ref="/data/level2">
+            <label>Level2</label>
+            <itemset nodeset="instance('level2')/root/item[selected(/data/level1, level1)]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select>
+        <select ref="/data/level3">
+            <label>Level3</label>
+            <itemset nodeset="instance('level3')/root/item[selected(/data/level2, level2)]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select>
+        <select ref="/data/level1_contains">
+            <label>Level1 contains</label>
+            <item>
+                <label>A</label>
+                <value>a</value>
+            </item>
+            <item>
+                <label>B</label>
+                <value>b</value>
+            </item>
+            <item>
+                <label>C</label>
+                <value>c</value>
+            </item>
+        </select>
+        <select ref="/data/level2_contains">
+            <label>Level2 contains</label>
+            <itemset nodeset="instance('level2')/root/item[contains(name,  /data/level1_contains )]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select>
+        <select ref="/data/level3_contains">
+            <label>Level3 contains</label>
+            <itemset nodeset="instance('level3')/root/item[contains(name,  /data/level2_contains )]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select>
+    </h:body>
+</h:html>

--- a/src/test/resources/org/javarosa/core/model/three-level-cascading-multi-select.xml
+++ b/src/test/resources/org/javarosa/core/model/three-level-cascading-multi-select.xml
@@ -108,6 +108,16 @@
                         <name>bab</name>
                         <level2>ba</level2>
                     </item>
+                    <item>
+                        <label>CAA</label>
+                        <name>caa</name>
+                        <level2>ca</level2>
+                    </item>
+                    <item>
+                        <label>CAB</label>
+                        <name>cab</name>
+                        <level2>ca</level2>
+                    </item>
                 </root>
             </instance>
             <bind nodeset="/data/level1" type="select"/>


### PR DESCRIPTION
Closes #473

I completely forgot that multiple selects use the same code paths as single selects and that dynamic multiple selects are possible/valuable when doing #437. 

#### What has been done to verify that this works as intended?
Added automated tests. Tried the form from the forum post in Collect with patched JavaRosa.

#### Why is this the best possible solution? Were any other approaches considered?
The other solution I seriously considered was reverting #437 and coming back to the issue with a broader fix. I think that if reviewers are not feeling great about this approach, that would still be a reasonable alternative.

I still think that there's value to removing values that are no longer applicable from the answer.

Some decision points that would be good to get a check on:
* How to differentiate between single and multiple selections ([here](https://github.com/opendatakit/javarosa/compare/master...lognaturel:issue-473?expand=1#diff-b60f702426880ccc5f1b079019104bd4R1040) and [here](https://github.com/opendatakit/javarosa/compare/master...lognaturel:issue-473?expand=1#diff-b60f702426880ccc5f1b079019104bd4R1090)). I used `instanceof` which is always a code smell. I think it's possible to use the reference to look up the question type in the formdef but that seemed to me like it would be harder to understand. Other ideas welcome.
* `getFilteredSelections` is an odd method that certainly feels out of place. I think there's a good change that all of this will be changed again soon so I didn't want to change the public interface of `MultipleItemsData`.
* I tried to make sure this would be as fast as possible even with many selections which is why I used a map to represent the original answer and whether its components are still in the choices. Looking things up in the keyset at each iteration is O(1). This is another place where constructing an index of underlying value to choice as (one of the things that) @ggalmazor has proposed in #438 and @JohnTheBeloved is continuing to explore could be beneficial.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should only fix the bug described in #473 and expand the fix from #437 to select multiples. This code affects all selects with choice filters *as well as ranking* so those are at regression risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue and test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.