### PR TITLE
Don't consider instances when comparing TreeReferences

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -17,7 +17,6 @@
 package org.javarosa.core.model.instance;
 
 import org.javarosa.core.util.DataUtil;
-import org.javarosa.core.util.Objects;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
@@ -403,10 +402,6 @@ public class TreeReference implements Externalizable, Serializable {
             return true;
         } else if (o instanceof TreeReference) {
             TreeReference ref = (TreeReference)o;
-
-            if (!Objects.equals(getInstanceName(), ref.getInstanceName())) {
-                return false;
-            }
 
             if (this.refLevel == ref.refLevel && this.size() == ref.size()) {
                 for (int i = 0; i < this.size(); i++) {

--- a/src/main/java/org/javarosa/core/util/Objects.java
+++ b/src/main/java/org/javarosa/core/util/Objects.java
@@ -23,13 +23,6 @@ import java.util.Arrays;
  */
 public class Objects {
     /**
-     * Null-safe equivalent of {@code a.equals(b)}.
-     */
-    public static boolean equals(Object a, Object b) {
-        return (a == null) ? (b == null) : a.equals(b);
-    }
-
-    /**
      * Convenience wrapper for {@link Arrays#hashCode}, adding varargs.
      * This can be used to compute a hash code for an object's fields as follows:
      * {@code Objects.hash(a, b, c)}.

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceEqualsTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceEqualsTest.java
@@ -30,13 +30,15 @@ public class TreeReferenceEqualsTest {
         return Arrays.asList(new Object[][]{
             // region Equality across same or different instances
 
-            // Prior to JR 1.15, the instance was not taken into account when comparing two TreeReferences. That meant
-            // two references representing the same path in two different instances would be considered the same reference.
             {"same path in primary instance are equal", "/foo/bar", "/foo/bar", true},
             {"same path in secondary instance are equal", "instance('foo')/bar/baz", "instance('foo')/bar/baz", true},
-            {"same path in primary and secondary instance are not equal", "/foo/bar", "instance('foo')/foo/bar", false},
-            {"same path in secondary and primary instance are not equal", "instance('foo')/foo/bar", "/foo/bar", false},
-            {"same path in different secondary instances are not equal", "instance('foo')/foo/bar", "instance('bar')/foo/bar", false},
+
+            // Prior to JR 1.15, attempted to take the instance into account when comparing two TreeReferences but
+            // this had unintended consequences. See https://github.com/opendatakit/javarosa/issues/475
+            // {"same path in primary and secondary instance are not equal", "/foo/bar", "instance('foo')/foo/bar", false},
+            // {"same path in secondary and primary instance are not equal", "instance('foo')/foo/bar", "/foo/bar", false},
+            // {"same path in different secondary instances are not equal", "instance('foo')/foo/bar", "instance('bar')/foo/bar", false},
+
             {"different paths in primary instance are not equal", "/foo/bar", "/foo/bar/quux", false},
             {"different paths in secondary instance are not equal", "instance('foo')/foo/bar", "instance('foo')/foo/bar/quux", false}
             //endregion


### PR DESCRIPTION
Closes #475

I had trouble hunting this down because I didn't immediately notice that the problem was when loading the form from cache. I did a `git bisect` run but that got me to the wrong commit because of that.

#### What has been done to verify that this works as intended?
Assembled the jar, copied it to Collect v1.23.1, verified that constraints work as expected on every form load. Had @yanokwa verify the same.

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest possible fix. It reverts behavior that is unlikely to be depended on so it should be safe.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I believe that this one is actually low risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.