### PR TITLE
Interpret times using the current date rather than January 1, 1970

### DIFF
--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -358,6 +358,14 @@ public class DateUtils {
         return getDate(fields);
     }
 
+
+    public static Date parseTimeWithFixedDate(String str, DateFields fields) {
+        if (!parseTime(str, fields)) {
+            return null;
+        }
+        return getDate(fields);
+    }
+
     private static boolean parseDate (String dateStr, DateFields f) {
       List<String> pieces = split(dateStr, "-", false);
         if (pieces.size() != 3)

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -355,10 +355,6 @@ public class DateUtils {
         if (!parseTime(str, fields)) {
             return null;
         }
-        // time zone may wrap time across midnight. Clear that.
-        fields.year = 1970;
-        fields.month = 1;
-        fields.day = 1;
         return getDate(fields);
     }
 

--- a/src/test/java/org/javarosa/core/model/data/test/TimeDataLimitationsTest.java
+++ b/src/test/java/org/javarosa/core/model/data/test/TimeDataLimitationsTest.java
@@ -1,0 +1,81 @@
+package org.javarosa.core.model.data.test;
+
+import org.javarosa.core.model.data.TimeData;
+import org.javarosa.core.model.utils.DateUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ This test is intended to show the limitation of {@link TimeData}.
+
+ Using this data type in countries which change their time (summer/winter - DST) will cause that forms saved during
+ wintertime and then edited during summertime (and vice versa) will be treated as saved in a neighbor's timezone.
+ It's because we have just time and time offset like: 10:00:00.000+02:00 but we don't know when the form has been
+ saved so we parse it using the current date.
+
+ Example:
+ If we saved 10:00:00.000+02:00 during summertime (in Poland) and we are editing the form during winter time our
+ timezone is +01:00 not +02:00. As mentioned above javarosa doesn't know that the form has been saved in the same location
+ but different timezone because of DST so it treats the value like saved in the neighbor timezone
+ (in Kiev or London for example).
+
+ Related issues:
+ https://github.com/opendatakit/javarosa/pull/478
+ https://github.com/opendatakit/collect/issues/170
+ */
+public class TimeDataLimitationsTest {
+
+    private TimeZone backupTimeZone;
+
+    @Before
+    public void setUp() {
+        backupTimeZone = TimeZone.getDefault();
+    }
+
+    @After
+    public void tearDown() {
+        TimeZone.setDefault(backupTimeZone);
+    }
+
+    @Test
+    public void editingFormsSavedInDifferentTimezoneTest() {
+        // A user is in Warsaw (GMT+2) saved a form with the time question
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
+        String savedTime = "10:00:00.000+02:00";
+
+        // A user opens saved form in Warsaw as well - the hour should be the same
+        TimeData timeData = new TimeData(DateUtils.parseTime(savedTime));
+        assertEquals("10:00", timeData.getDisplayText());
+
+        // A user travels to Kiev (GMT+3) and opens the saved form again - the hour should be edited +1h
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Kiev"));
+        timeData = new TimeData(DateUtils.parseTime(savedTime));
+        assertEquals("11:00", timeData.getDisplayText());
+    }
+
+    @Test
+    public void editingFormsSavedInTheSameLocationButAfterDSTChangeTest() {
+        DateUtils.DateFields dateFields = new DateUtils.DateFields();
+        dateFields.year = 2019;
+        dateFields.month = 8;
+        dateFields.day = 1;
+
+        // A user is in Warsaw (during summer time - GMT+2) and saved a form with the time question
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
+        String savedTime = "10:00:00.000+02:00";
+
+        // A user opens saved form in Warsaw and during summertime as well - the hour should be the same
+        TimeData timeData = new TimeData(DateUtils.parseTimeWithFixedDate(savedTime, dateFields));
+        assertEquals("10:00", timeData.getDisplayText());
+
+        // A user opens saved form in Warsaw as well but during wintertime - the hour is edited -1h (the mentioned limitation)
+        dateFields.month = 12;
+        timeData = new TimeData(DateUtils.parseTimeWithFixedDate(savedTime, dateFields));
+        assertEquals("09:00", timeData.getDisplayText());
+    }
+}

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -129,56 +129,64 @@ public class DateUtilsTests {
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        testTime("10:00", 1000 * 60 * 60 * 10 - getOffset());
-        testTime("10:00Z", 1000 * 60 * 60 * 10);
+        Calendar midnight = Calendar.getInstance();
+        midnight.set(Calendar.HOUR_OF_DAY, 0);
+        midnight.set(Calendar.MINUTE, 0);
+        midnight.set(Calendar.SECOND, 0);
+        midnight.set(Calendar.MILLISECOND, 0);
 
-        testTime("10:00+02", 1000 * 60 * 60 * 8);
-        testTime("10:00-02", 1000 * 60 * 60 * 12);
+        long midnightDate = midnight.getTime().getTime();
 
-        testTime("10:00+02:30", 1000 * 60 * (60 * 10 - 150));
-        testTime("10:00-02:30", 1000 * 60 * (60 * 10 + 150));
+        testTime("10:00", midnightDate + 1000 * 60 * 60 * 10 - getOffset());
+        testTime("10:00Z", midnightDate + 1000 * 60 * 60 * 10);
+
+        testTime("10:00+02", midnightDate + 1000 * 60 * 60 * 8);
+        testTime("10:00-02", midnightDate + 1000 * 60 * 60 * 12);
+
+        testTime("10:00+02:30", midnightDate + 1000 * 60 * (60 * 10 - 150));
+        testTime("10:00-02:30", midnightDate + 1000 * 60 * (60 * 10 + 150));
 
         TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+02");
 
         TimeZone.setDefault(offsetTwoHours);
 
-        testTime("10:00", 1000 * 60 * 60 * 10 - getOffset());
-        testTime("10:00Z", 1000 * 60 * 60 * 10);
+        testTime("10:00", midnightDate + 1000 * 60 * 60 * 10 - getOffset());
+        testTime("10:00Z", midnightDate + 1000 * 60 * 60 * 10);
 
-        testTime("10:00+02", 1000 * 60 * 60 * 8);
-        testTime("10:00-02", 1000 * 60 * 60 * 12);
+        testTime("10:00+02", midnightDate + 1000 * 60 * 60 * 8);
+        testTime("10:00-02", midnightDate + 1000 * 60 * 60 * 12);
 
-        testTime("10:00+02:30", 1000 * 60 * (60 * 10 - 150));
-        testTime("10:00-02:30", 1000 * 60 * (60 * 10 + 150));
+        testTime("10:00+02:30", midnightDate + 1000 * 60 * (60 * 10 - 150));
+        testTime("10:00-02:30", midnightDate + 1000 * 60 * (60 * 10 + 150));
 
         TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-02");
 
         TimeZone.setDefault(offsetMinusTwoHours);
 
-        testTime("14:00", 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", 1000 * 60 * 60 * 14);
+        testTime("14:00", midnightDate + 1000 * 60 * 60 * 14 - getOffset());
+        testTime("14:00Z", midnightDate + 1000 * 60 * 60 * 14);
 
-        testTime("14:00+02", 1000 * 60 * 60 * 12);
-        testTime("14:00-02", 1000 * 60 * 60 * 16);
+        testTime("14:00+02", midnightDate + 1000 * 60 * 60 * 12);
+        testTime("14:00-02", midnightDate + 1000 * 60 * 60 * 16);
 
-        testTime("14:00+02:30", 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", 1000 * 60 * (60 * 14 + 150));
+        testTime("14:00+02:30", midnightDate + 1000 * 60 * (60 * 14 - 150));
+        testTime("14:00-02:30", midnightDate + 1000 * 60 * (60 * 14 + 150));
 
 
         TimeZone offsetPlusHalf = TimeZone.getTimeZone("GMT+0230");
 
         TimeZone.setDefault(offsetPlusHalf);
 
-        testTime("14:00", 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", 1000 * 60 * 60 * 14);
+        testTime("14:00", midnightDate + 1000 * 60 * 60 * 14 - getOffset());
+        testTime("14:00Z", midnightDate + 1000 * 60 * 60 * 14);
 
-        testTime("14:00+02", 1000 * 60 * 60 * 12);
-        testTime("14:00-02", 1000 * 60 * 60 * 16);
+        testTime("14:00+02", midnightDate + 1000 * 60 * 60 * 12);
+        testTime("14:00-02", midnightDate + 1000 * 60 * 60 * 16);
 
-        testTime("14:00+02:30", 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", 1000 * 60 * (60 * 14 + 150));
+        testTime("14:00+02:30", midnightDate + 1000 * 60 * (60 * 14 - 150));
+        testTime("14:00-02:30", midnightDate + 1000 * 60 * (60 * 14 + 150));
 
-        testTime("14:00+04:00", 1000 * 60 * 60 * 10);
+        testTime("14:00+04:00", midnightDate + 1000 * 60 * 60 * 10);
     }
 
     private void testTime(String in, long test) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -129,64 +129,64 @@ public class DateUtilsTests {
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        Calendar midnight = Calendar.getInstance();
-        midnight.set(Calendar.HOUR_OF_DAY, 0);
-        midnight.set(Calendar.MINUTE, 0);
-        midnight.set(Calendar.SECOND, 0);
-        midnight.set(Calendar.MILLISECOND, 0);
+        Calendar startOfDay = Calendar.getInstance();
+        startOfDay.set(Calendar.HOUR_OF_DAY, 0);
+        startOfDay.set(Calendar.MINUTE, 0);
+        startOfDay.set(Calendar.SECOND, 0);
+        startOfDay.set(Calendar.MILLISECOND, 0);
 
-        long midnightDate = midnight.getTime().getTime();
+        long startOfDayDate = startOfDay.getTime().getTime();
 
-        testTime("10:00", midnightDate + 1000 * 60 * 60 * 10 - getOffset());
-        testTime("10:00Z", midnightDate + 1000 * 60 * 60 * 10);
+        testTime("10:00", startOfDayDate + 1000 * 60 * 60 * 10 - getOffset());
+        testTime("10:00Z", startOfDayDate + 1000 * 60 * 60 * 10);
 
-        testTime("10:00+02", midnightDate + 1000 * 60 * 60 * 8);
-        testTime("10:00-02", midnightDate + 1000 * 60 * 60 * 12);
+        testTime("10:00+02", startOfDayDate + 1000 * 60 * 60 * 8);
+        testTime("10:00-02", startOfDayDate + 1000 * 60 * 60 * 12);
 
-        testTime("10:00+02:30", midnightDate + 1000 * 60 * (60 * 10 - 150));
-        testTime("10:00-02:30", midnightDate + 1000 * 60 * (60 * 10 + 150));
+        testTime("10:00+02:30", startOfDayDate + 1000 * 60 * (60 * 10 - 150));
+        testTime("10:00-02:30", startOfDayDate + 1000 * 60 * (60 * 10 + 150));
 
         TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+02");
 
         TimeZone.setDefault(offsetTwoHours);
 
-        testTime("10:00", midnightDate + 1000 * 60 * 60 * 10 - getOffset());
-        testTime("10:00Z", midnightDate + 1000 * 60 * 60 * 10);
+        testTime("10:00", startOfDayDate + 1000 * 60 * 60 * 10 - getOffset());
+        testTime("10:00Z", startOfDayDate + 1000 * 60 * 60 * 10);
 
-        testTime("10:00+02", midnightDate + 1000 * 60 * 60 * 8);
-        testTime("10:00-02", midnightDate + 1000 * 60 * 60 * 12);
+        testTime("10:00+02", startOfDayDate + 1000 * 60 * 60 * 8);
+        testTime("10:00-02", startOfDayDate + 1000 * 60 * 60 * 12);
 
-        testTime("10:00+02:30", midnightDate + 1000 * 60 * (60 * 10 - 150));
-        testTime("10:00-02:30", midnightDate + 1000 * 60 * (60 * 10 + 150));
+        testTime("10:00+02:30", startOfDayDate + 1000 * 60 * (60 * 10 - 150));
+        testTime("10:00-02:30", startOfDayDate + 1000 * 60 * (60 * 10 + 150));
 
         TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-02");
 
         TimeZone.setDefault(offsetMinusTwoHours);
 
-        testTime("14:00", midnightDate + 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", midnightDate + 1000 * 60 * 60 * 14);
+        testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
+        testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
 
-        testTime("14:00+02", midnightDate + 1000 * 60 * 60 * 12);
-        testTime("14:00-02", midnightDate + 1000 * 60 * 60 * 16);
+        testTime("14:00+02", startOfDayDate + 1000 * 60 * 60 * 12);
+        testTime("14:00-02", startOfDayDate + 1000 * 60 * 60 * 16);
 
-        testTime("14:00+02:30", midnightDate + 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", midnightDate + 1000 * 60 * (60 * 14 + 150));
+        testTime("14:00+02:30", startOfDayDate + 1000 * 60 * (60 * 14 - 150));
+        testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
 
 
         TimeZone offsetPlusHalf = TimeZone.getTimeZone("GMT+0230");
 
         TimeZone.setDefault(offsetPlusHalf);
 
-        testTime("14:00", midnightDate + 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", midnightDate + 1000 * 60 * 60 * 14);
+        testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
+        testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
 
-        testTime("14:00+02", midnightDate + 1000 * 60 * 60 * 12);
-        testTime("14:00-02", midnightDate + 1000 * 60 * 60 * 16);
+        testTime("14:00+02", startOfDayDate + 1000 * 60 * 60 * 12);
+        testTime("14:00-02", startOfDayDate + 1000 * 60 * 60 * 16);
 
-        testTime("14:00+02:30", midnightDate + 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", midnightDate + 1000 * 60 * (60 * 14 + 150));
+        testTime("14:00+02:30", startOfDayDate + 1000 * 60 * (60 * 14 - 150));
+        testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
 
-        testTime("14:00+04:00", midnightDate + 1000 * 60 * 60 * 10);
+        testTime("14:00+04:00", startOfDayDate + 1000 * 60 * 60 * 10);
     }
 
     private void testTime(String in, long test) {


### PR DESCRIPTION
Closes #https://github.com/opendatakit/collect/issues/3305

#### What has been done to verify that this works as intended?
I tested the case described in https://github.com/opendatakit/collect/issues/3305
also, I confirmed that it doesn't cause regression here https://github.com/opendatakit/collect/issues/170

#### Why is this the best possible solution? Were any other approaches considered?
Another solution I was thinking about was using always 01/01/1970 (in COllect as well) it would fix the issue but it's a bit worse in my opinion because changing timezones it would cause different time changes than we have now (because they were different in 1970).
In most cases, the current date is ok so my solution LFTM.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Time is a tricky case because of timezones and daylight saving. We can't be sure if it's the last problem in this area. The change is pretty small so I think testing the described case and related already fixed problems like https://github.com/opendatakit/collect/issues/170 would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with time question like the one attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
