### PR TITLE
Add support for odk-new-repeat event and actions nested in repeats

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -550,10 +550,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         TreeElement newNode = mainInstance.resolveReference(repeatContextRef);
         preloadInstance(newNode);
 
-        // 2013-05-14 - ctsims - Events should get fired _before_ calculate stuff
-        // is fired, moved this above triggering triggerables
+        // Fire events before form recomputation (calculates, relevance, etc). First trigger actions defined in the
+        // model and then trigger actions defined in the body
         actionController.triggerActionsFromEvent(Action.EVENT_JR_INSERT, this, repeatContextRef, this);
         actionController.triggerActionsFromEvent(Action.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);
+        // Trigger actions nested in the new repeat
+        getChild(index).getActionController().triggerActionsFromEvent(Action.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);
 
         // trigger conditions that depend on the creation of this new node
         triggerTriggerables(repeatContextRef, true);

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -553,6 +553,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // 2013-05-14 - ctsims - Events should get fired _before_ calculate stuff
         // is fired, moved this above triggering triggerables
         actionController.triggerActionsFromEvent(Action.EVENT_JR_INSERT, this, repeatContextRef, this);
+        actionController.triggerActionsFromEvent(Action.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);
 
         // trigger conditions that depend on the creation of this new node
         triggerTriggerables(repeatContextRef, true);

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -550,7 +550,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         TreeElement newNode = mainInstance.resolveReference(repeatContextRef);
         preloadInstance(newNode);
 
-        // Fire events before form recomputation (calculates, relevance, etc). First trigger actions defined in the
+        // Fire events before form re-computation (calculates, relevance, etc). First trigger actions defined in the
         // model and then trigger actions defined in the body
         actionController.triggerActionsFromEvent(Action.EVENT_JR_INSERT, this, repeatContextRef, this);
         actionController.triggerActionsFromEvent(Action.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);

--- a/src/main/java/org/javarosa/core/model/GroupDef.java
+++ b/src/main/java/org/javarosa/core/model/GroupDef.java
@@ -16,12 +16,6 @@
 
 package org.javarosa.core.model;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.javarosa.core.model.actions.ActionController;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
@@ -37,6 +31,12 @@ import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /** The definition of a group in a form or questionaire.
  *
@@ -72,6 +72,8 @@ public class GroupDef implements IFormElement, Localizable {
     public boolean noAddRemove = false;
     public IDataReference count = null;
 
+    private ActionController actionController;
+
     public GroupDef () {
         this(Constants.NULL_ID, null, false);
     }
@@ -81,6 +83,8 @@ public class GroupDef implements IFormElement, Localizable {
         setChildren(children);
         setRepeat(repeat);
         observers = new ArrayList<FormElementStateListener>(0);
+
+        actionController = new ActionController();
     }
 
     public int getID () {
@@ -165,7 +169,7 @@ public class GroupDef implements IFormElement, Localizable {
 
     @Override
     public ActionController getActionController() {
-        return null;
+        return actionController;
     }
 
     public void localeChanged(String locale, Localizer localizer) {
@@ -222,6 +226,8 @@ public class GroupDef implements IFormElement, Localizable {
             mainHeader = ExtUtil.nullIfEmpty(ExtUtil.readString(dis));
 
             additionalAttributes = ExtUtil.readAttributes(dis, null);
+
+            actionController = (ActionController) ExtUtil.read(dis, new ExtWrapNullable(ActionController.class), pf);
         } catch ( OutOfMemoryError e ) {
             throw new DeserializationException("serialization format change caused misalignment and out-of-memory error");
         }
@@ -251,6 +257,8 @@ public class GroupDef implements IFormElement, Localizable {
         ExtUtil.writeString(dos, ExtUtil.emptyIfNull(mainHeader));
 
         ExtUtil.writeAttributes(dos, additionalAttributes);
+
+        ExtUtil.write(dos, new ExtWrapNullable(actionController));
     }
 
     public void registerStateObserver (FormElementStateListener qsl) {

--- a/src/main/java/org/javarosa/core/model/actions/Action.java
+++ b/src/main/java/org/javarosa/core/model/actions/Action.java
@@ -3,16 +3,16 @@
  */
 package org.javarosa.core.model.actions;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 /**
  * @author ctsims
@@ -34,10 +34,18 @@ public abstract class Action implements Externalizable {
     @Deprecated
     public static final String EVENT_XFORMS_READY = "xforms-ready";
     public static final String EVENT_XFORMS_REVALIDATE = "xforms-revalidate";
+
+    public static final String EVENT_ODK_NEW_REPEAT = "odk-new-repeat";
+
+    /**
+     * @deprecated because it was never documented. Use {@link #EVENT_ODK_NEW_REPEAT} instead.
+     */
     public static final String EVENT_JR_INSERT = "jr-insert";
+
     public static final String EVENT_QUESTION_VALUE_CHANGED = "xforms-value-changed";
-    private static final String[] allEvents = new String[]{EVENT_ODK_INSTANCE_FIRST_LOAD, EVENT_JR_INSERT,
-                        EVENT_QUESTION_VALUE_CHANGED, EVENT_XFORMS_READY, EVENT_XFORMS_REVALIDATE};
+
+    private static final String[] allEvents = new String[]{EVENT_ODK_INSTANCE_FIRST_LOAD, EVENT_XFORMS_READY,
+                        EVENT_ODK_NEW_REPEAT, EVENT_JR_INSERT, EVENT_QUESTION_VALUE_CHANGED, EVENT_XFORMS_REVALIDATE};
 
     private String name;
 

--- a/src/main/java/org/javarosa/core/model/actions/ActionController.java
+++ b/src/main/java/org/javarosa/core/model/actions/ActionController.java
@@ -9,6 +9,8 @@ import org.javarosa.core.util.externalizable.ExtWrapListPoly;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -24,6 +26,7 @@ import java.util.List;
  * @author Aliza Stone
  */
 public class ActionController implements Externalizable {
+    private static final Logger log = LoggerFactory.getLogger(ActionController.class);
 
     // map from an event to the actions it should trigger
     private HashMap<String, List<Action>> eventListeners;
@@ -57,6 +60,7 @@ public class ActionController implements Externalizable {
     public void triggerActionsFromEvent(String event, FormDef model, TreeReference contextForAction,
                                         ActionResultProcessor resultProcessor) {
         for (Action action : getListenersForEvent(event)) {
+            log.info("Event {} triggering action {} in context {}", event, action.getName(), contextForAction);
             TreeReference refSetByAction = action.processAction(model, contextForAction);
             if (resultProcessor != null && refSetByAction != null) {
                 resultProcessor.processResultOfAction(refSetByAction, event);

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -703,7 +703,11 @@ public class XFormParser implements IXFormParserFunctions {
                 parseSubmission(child);
             } else {
                 // For now, anything that isn't a submission is an action
-                actionHandlers.get(name).handle(this, child, _f);
+                if (actionHandlers.containsKey(name) && child.getAttributeValue(null, EVENT_ATTR).equals(Action.EVENT_ODK_NEW_REPEAT)) {
+                    throw new XFormParseException("Actions triggered by " + Action.EVENT_ODK_NEW_REPEAT + " must be nested in the repeat form control.", child);
+                } else {
+                    actionHandlers.get(name).handle(this, child, _f);
+                }
             }
         }
     }

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1563,25 +1563,31 @@ public class XFormParser implements IXFormParserFunctions {
             String childName = (child != null ? child.getName() : null);
             String childNamespace = (child != null ? child.getNamespace() : null);
 
-            if (group.getRepeat() && NAMESPACE_JAVAROSA.equals(childNamespace)) {
-                if ("chooseCaption".equals(childName)) {
-                    group.chooseCaption = getLabel(child);
-                } else if ("addCaption".equals(childName)) {
-                    group.addCaption = getLabel(child);
-                } else if ("delCaption".equals(childName)) {
-                    group.delCaption = getLabel(child);
-                } else if ("doneCaption".equals(childName)) {
-                    group.doneCaption = getLabel(child);
-                } else if ("addEmptyCaption".equals(childName)) {
-                    group.addEmptyCaption = getLabel(child);
-                } else if ("doneEmptyCaption".equals(childName)) {
-                    group.doneEmptyCaption = getLabel(child);
-                } else if ("entryHeader".equals(childName)) {
-                    group.entryHeader = getLabel(child);
-                } else if ("delHeader".equals(childName)) {
-                    group.delHeader = getLabel(child);
-                } else if ("mainHeader".equals(childName)) {
-                    group.mainHeader = getLabel(child);
+            if (group.getRepeat()) {
+                if (actionHandlers.containsKey(childName)) {
+                    actionHandlers.get(childName).handle(this, child, group);
+                }
+
+                if (NAMESPACE_JAVAROSA.equals(childNamespace)) {
+                    if ("chooseCaption".equals(childName)) {
+                        group.chooseCaption = getLabel(child);
+                    } else if ("addCaption".equals(childName)) {
+                        group.addCaption = getLabel(child);
+                    } else if ("delCaption".equals(childName)) {
+                        group.delCaption = getLabel(child);
+                    } else if ("doneCaption".equals(childName)) {
+                        group.doneCaption = getLabel(child);
+                    } else if ("addEmptyCaption".equals(childName)) {
+                        group.addEmptyCaption = getLabel(child);
+                    } else if ("doneEmptyCaption".equals(childName)) {
+                        group.doneEmptyCaption = getLabel(child);
+                    } else if ("entryHeader".equals(childName)) {
+                        group.entryHeader = getLabel(child);
+                    } else if ("delHeader".equals(childName)) {
+                        group.delHeader = getLabel(child);
+                    } else if ("mainHeader".equals(childName)) {
+                        group.mainHeader = getLabel(child);
+                    }
                 }
             }
         }

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1567,42 +1567,38 @@ public class XFormParser implements IXFormParserFunctions {
             String childName = (child != null ? child.getName() : null);
             String childNamespace = (child != null ? child.getNamespace() : null);
 
-            if (group.getRepeat()) {
-                if (actionHandlers.containsKey(childName)) {
-                    actionHandlers.get(childName).handle(this, child, group);
+            if (group.getRepeat() && NAMESPACE_JAVAROSA.equals(childNamespace)) {
+                if ("chooseCaption".equals(childName)) {
+                    group.chooseCaption = getLabel(child);
+                } else if ("addCaption".equals(childName)) {
+                    group.addCaption = getLabel(child);
+                } else if ("delCaption".equals(childName)) {
+                    group.delCaption = getLabel(child);
+                } else if ("doneCaption".equals(childName)) {
+                    group.doneCaption = getLabel(child);
+                } else if ("addEmptyCaption".equals(childName)) {
+                    group.addEmptyCaption = getLabel(child);
+                } else if ("doneEmptyCaption".equals(childName)) {
+                    group.doneEmptyCaption = getLabel(child);
+                } else if ("entryHeader".equals(childName)) {
+                    group.entryHeader = getLabel(child);
+                } else if ("delHeader".equals(childName)) {
+                    group.delHeader = getLabel(child);
+                } else if ("mainHeader".equals(childName)) {
+                    group.mainHeader = getLabel(child);
                 }
+            }
 
-                if (NAMESPACE_JAVAROSA.equals(childNamespace)) {
-                    if ("chooseCaption".equals(childName)) {
-                        group.chooseCaption = getLabel(child);
-                    } else if ("addCaption".equals(childName)) {
-                        group.addCaption = getLabel(child);
-                    } else if ("delCaption".equals(childName)) {
-                        group.delCaption = getLabel(child);
-                    } else if ("doneCaption".equals(childName)) {
-                        group.doneCaption = getLabel(child);
-                    } else if ("addEmptyCaption".equals(childName)) {
-                        group.addEmptyCaption = getLabel(child);
-                    } else if ("doneEmptyCaption".equals(childName)) {
-                        group.doneEmptyCaption = getLabel(child);
-                    } else if ("entryHeader".equals(childName)) {
-                        group.entryHeader = getLabel(child);
-                    } else if ("delHeader".equals(childName)) {
-                        group.delHeader = getLabel(child);
-                    } else if ("mainHeader".equals(childName)) {
-                        group.mainHeader = getLabel(child);
-                    }
+            if (type == Element.ELEMENT) {
+                if (group.getRepeat() && actionHandlers.containsKey(e.getElement(i).getName())) {
+                    actionHandlers.get(childName).handle(this, child, group);
+                } else {
+                    parseElement(e.getElement(i), group, groupLevelHandlers);
                 }
             }
         }
 
         //the case of a group wrapping a repeat is cleaned up in a post-processing step (collapseRepeatGroups)
-
-        for (int i = 0; i < e.getChildCount(); i++) {
-            if (e.getType(i) == Element.ELEMENT) {
-                parseElement(e.getElement(i), group, groupLevelHandlers);
-            }
-        }
 
         // save all the unused attributes verbatim...
         for (int i = 0; i < e.getAttributeCount(); i++) {

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.model.actions;
 
+import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParseException;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class OdkNewRepeatEventTest {
         assertThat(scenario.repeatInstancesOf("/data/my-repeat").size(), is(0));
         scenario.createMissingRepeats("/data/my-repeat[0]");
         assertThat(scenario.repeatInstancesOf("/data/my-repeat").size(), is(1));
-        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-now"), is(notNullValue()));
+        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
     }
 
     @Test
@@ -31,14 +32,12 @@ public class OdkNewRepeatEventTest {
         Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
 
         scenario.createMissingRepeats("/data/my-repeat[0]");
-        String firstRepeatDisplayText = scenario.answerOf("/data/my-repeat[0]/defaults-to-now").getDisplayText();
-        assertThat(firstRepeatDisplayText, is(not(isEmptyOrNullString())));
+        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
 
         scenario.createMissingRepeats("/data/my-repeat[1]");
-        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-now"), is(notNullValue()));
+        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-position").getDisplayText(), is("2"));
 
-        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-now").getDisplayText(), is(firstRepeatDisplayText));
-        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-now").getDisplayText(), is(not(firstRepeatDisplayText)));
+        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
     }
 
     @Test
@@ -55,16 +54,29 @@ public class OdkNewRepeatEventTest {
     public void setValueOnRepeatWithCount_setsValueForEachRepeat() {
         Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
 
+        scenario.answer("/data/repeat-count", 4);
+
         while (!scenario.atTheEndOfForm()) {
             scenario.next();
         }
 
         assertThat(scenario.repeatInstancesOf("/data/my-jr-count-repeat").size(), is(4));
 
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[1]/defaults-to-position").getDisplayText(), is("2"));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[2]/defaults-to-position").getDisplayText(), is("3"));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[3]/defaults-to-position").getDisplayText(), is("4"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[0]/defaults-to-position-again").getDisplayText(), is("1"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[1]/defaults-to-position-again").getDisplayText(), is("2"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[2]/defaults-to-position-again").getDisplayText(), is("3"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[3]/defaults-to-position-again").getDisplayText(), is("4"));
+
+        // Adding repeats should trigger odk-new-repeat for those new nodes
+        scenario.answer("/data/repeat-count", 6);
+
+        scenario.jumpToFirst("defaults-to-position-again");
+        while (!scenario.atTheEndOfForm()) {
+            scenario.next();
+        }
+        assertThat(scenario.repeatInstancesOf("/data/my-jr-count-repeat").size(), is(6));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[5]/defaults-to-position-again").getDisplayText(), is("6"));
+
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -1,0 +1,90 @@
+package org.javarosa.core.model.actions;
+
+import org.javarosa.core.test.Scenario;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Specification: https://opendatakit.github.io/xforms-spec/#the-odk-new-repeat-event.
+ */
+public class OdkNewRepeatEventTest {
+    @Test
+    public void setValueOnRepeatInsertInBody_setsValueInRepeat() {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        assertThat(scenario.repeatInstancesOf("/data/my-repeat").size(), is(0));
+        scenario.createMissingRepeats("/data/my-repeat[0]");
+        assertThat(scenario.repeatInstancesOf("/data/my-repeat").size(), is(1));
+        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-now"), is(notNullValue()));
+    }
+
+    @Test
+    public void addingRepeat_doesNotChangeValueSetForPreviousRepeat() {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        scenario.createMissingRepeats("/data/my-repeat[0]");
+        String firstRepeatDisplayText = scenario.answerOf("/data/my-repeat[0]/defaults-to-now").getDisplayText();
+        assertThat(firstRepeatDisplayText, is(not(isEmptyOrNullString())));
+
+        scenario.createMissingRepeats("/data/my-repeat[1]");
+        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-now"), is(notNullValue()));
+
+        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-now").getDisplayText(), is(firstRepeatDisplayText));
+        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-now").getDisplayText(), is(not(firstRepeatDisplayText)));
+    }
+
+    @Test
+    public void setValueOnRepeatInBody_usesCurrentContextForRelativeReferences() {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        scenario.answer("/data/my-toplevel-value", "12");
+
+        scenario.createMissingRepeats("/data/my-repeat[0]");
+        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-toplevel").getDisplayText(), is("14"));
+    }
+
+    @Test
+    public void setValueOnRepeatWithCount_setsValueForEachRepeat() {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        while (!scenario.atTheEndOfForm()) {
+            scenario.next();
+        }
+
+        assertThat(scenario.repeatInstancesOf("/data/my-jr-count-repeat").size(), is(4));
+
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[1]/defaults-to-position").getDisplayText(), is("2"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[2]/defaults-to-position").getDisplayText(), is("3"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[3]/defaults-to-position").getDisplayText(), is("4"));
+    }
+
+    @Test
+    public void repeatInFormDefInstance_neverFiresNewRepeatEvent() {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        assertThat(scenario.answerOf("/data/my-repeat-without-template[0]/my-value"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/my-repeat-without-template[1]/my-value"), is(nullValue()));
+
+        scenario.createMissingRepeats("/data/my-repeat-without-template[2]");
+        assertThat(scenario.answerOf("/data/my-repeat-without-template[2]/my-value").getDisplayText(), is("2"));
+    }
+
+    // Not part of ODK XForms spec but incidentally supported because of support for model-level setvalue. We could
+    // explicitly block this case but it feels less consistent.
+    @Test
+    public void setValueOnRepeatInsertInModel_setsValueInRepeat() {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        scenario.createMissingRepeats("/data/my-other-repeat[0]/my-value");
+        assertThat(scenario.answerOf("/data/my-other-repeat[0]/my-value"), is(notNullValue()));
+    }
+
+}

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.model.actions;
 
 import org.javarosa.core.test.Scenario;
+import org.javarosa.xform.parse.XFormParseException;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -77,14 +78,9 @@ public class OdkNewRepeatEventTest {
         assertThat(scenario.answerOf("/data/my-repeat-without-template[2]/my-value").getDisplayText(), is("2"));
     }
 
-    // Not part of ODK XForms spec but incidentally supported because of support for model-level setvalue. We could
-    // explicitly block this case but it feels less consistent.
-    @Test
-    public void setValueOnRepeatInsertInModel_setsValueInRepeat() {
-        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
-
-        scenario.createMissingRepeats("/data/my-other-repeat[0]/my-value");
-        assertThat(scenario.answerOf("/data/my-other-repeat[0]/my-value"), is(notNullValue()));
+    // Not part of ODK XForms so throws parse exception.
+    @Test(expected = XFormParseException.class)
+    public void setValueOnRepeatInsertInModel_notAllowed() {
+        Scenario.init(r("event-odk-new-repeat-model.xml"));
     }
-
 }

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -1,14 +1,10 @@
 package org.javarosa.core.model.actions;
 
-import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParseException;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -16,6 +16,27 @@
 
 package org.javarosa.core.test;
 
+import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
+import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+import static org.javarosa.core.model.instance.utils.TreeElementNameComparator.elementMatchesName;
+import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
+import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.IFormElement;
@@ -33,28 +54,6 @@ import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
-import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
-import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
-import static org.javarosa.core.model.instance.utils.TreeElementNameComparator.elementMatchesName;
-import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
-import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
-import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
-import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
-import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
-import static org.javarosa.test.utils.ResourcePathHelper.r;
 
 /**
  * <div style="border: 1px 1px 1px 1px; background-color: #556B2F; color: white; padding: 20px">

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -43,6 +43,7 @@ import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.MultipleItemsData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.data.helper.Selection;
@@ -148,6 +149,17 @@ public class Scenario {
 
         List<Selection> selections = Arrays.stream(selectionValues).map(Selection::new).collect(Collectors.toList());
         formDef.setValue(new MultipleItemsData(selections), element.getRef(), true);
+    }
+
+    /**
+     * Sets the value of the element located at the given xPath in the main instance to the given integer value.
+     *
+     * @see #answer(String, String)
+     */
+    public void answer(String xPath, int value) {
+        createMissingRepeats(xPath);
+        TreeElement element = Objects.requireNonNull(resolve(xPath));
+        formDef.setValue(new IntegerData(value), element.getRef(), true);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -16,27 +16,6 @@
 
 package org.javarosa.core.test;
 
-import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
-import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
-import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
-import static org.javarosa.core.model.instance.utils.TreeElementNameComparator.elementMatchesName;
-import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
-import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
-import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
-import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
-import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
-import static org.javarosa.test.utils.ResourcePathHelper.r;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.IFormElement;
@@ -54,6 +33,28 @@ import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
+import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
+import static org.javarosa.core.model.instance.utils.TreeElementNameComparator.elementMatchesName;
+import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
+import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
 
 /**
  * <div style="border: 1px 1px 1px 1px; background-color: #556B2F; color: white; padding: 20px">
@@ -276,7 +277,7 @@ public class Scenario {
         formDef.initialize(true, new InstanceInitializationFactory());
     }
 
-    private void createMissingRepeats(String xPath) {
+    public void createMissingRepeats(String xPath) {
         // We will be looking to the parts in the xPath from left to right.
         // xPath.substring(1) makes the first "/" char go away, giving us an xPath relative to the root
         List<String> parts = Arrays.asList(xPath.substring(1).split("/"));

--- a/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat-model.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat-model.xml
@@ -1,0 +1,30 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Event: odk-new-repeat in model</h:title>
+        <model>
+            <instance>
+                <data id="event-odk-new-repeat">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+
+                    <my-repeat jr:template="">
+                        <my-value/>
+                    </my-repeat>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/my-repeat/my-value" type="string"/>
+            <!-- setvalue event in model; not part of ODK XForms specification -->
+            <setvalue event="odk-new-repeat" ref="/data/my-repeat/my-value" value="now()"/>
+        </model>
+    </h:head>
+
+    <h:body>
+        <repeat nodeset="/data/my-repeat">
+            <input ref="/data/my-repeat/my-value">
+                <label>A value</label>
+            </input>
+        </repeat>
+    </h:body>
+</h:html>

--- a/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
@@ -1,9 +1,9 @@
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
     <h:head>
-        <h:title>Repeat default now() in body</h:title>
+        <h:title>Event: odk-new-repeat</h:title>
         <model>
             <instance>
-                <data id="repeat-default-now-nested">
+                <data id="event-odk-new-repeat">
                     <meta>
                         <instanceID/>
                     </meta>
@@ -27,10 +27,6 @@
                     <my-repeat-without-template>
                         <my-value/>
                     </my-repeat-without-template>
-
-                    <my-other-repeat jr:template="">
-                        <my-value/>
-                    </my-other-repeat>
                 </data>
             </instance>
 
@@ -43,10 +39,6 @@
             <bind nodeset="/data/my-jr-count-repeat/defaults-to-position" type="string"/>
 
             <bind nodeset="/data/my-repeat-without-template/my-value" type="integer"/>
-
-            <bind nodeset="/data/my-other-repeat/my-value" type="string"/>
-            <!-- setvalue event in model; not part of ODK XForms specification -->
-            <setvalue event="odk-new-repeat" ref="/data/my-other-repeat/my-value" value="now()"/>
         </model>
     </h:head>
 
@@ -83,12 +75,6 @@
         <repeat nodeset="/data/my-repeat-without-template">
             <setvalue event="odk-new-repeat" ref="/data/my-repeat-without-template/my-value">2</setvalue>
             <input ref="/data/my-repeat-without-template/my-value">
-                <label>A value</label>
-            </input>
-        </repeat>
-
-        <repeat nodeset="/data/my-other-repeat">
-            <input ref="/data/my-other-repeat/my-value">
                 <label>A value</label>
             </input>
         </repeat>

--- a/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
@@ -1,0 +1,96 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Repeat default now() in body</h:title>
+        <model>
+            <instance>
+                <data id="repeat-default-now-nested">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                    <my-toplevel-value/>
+
+                    <!-- no repeat instance in model -->
+                    <my-repeat jr:template="">
+                        <defaults-to-now/>
+                        <defaults-to-toplevel/>
+                    </my-repeat>
+
+                    <repeat-count>4</repeat-count>
+                    <my-jr-count-repeat jr:template="">
+                        <defaults-to-position/>
+                    </my-jr-count-repeat>
+
+                    <!-- repeat instances in model should not fire odk-new-repeat event -->
+                    <my-repeat-without-template>
+                        <my-value/>
+                    </my-repeat-without-template>
+                    <my-repeat-without-template>
+                        <my-value/>
+                    </my-repeat-without-template>
+
+                    <my-other-repeat jr:template="">
+                        <my-value/>
+                    </my-other-repeat>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+            <bind nodeset="/data/my-toplevel-value" type="integer"/>
+            <bind nodeset="/data/my-repeat/defaults-to-now" type="string"/>
+            <bind nodeset="/data/my-repeat/defaults-to-toplevel" type="integer"/>
+
+            <bind nodeset="/data/repeat-count" type="integer"/>
+            <bind nodeset="/data/my-jr-count-repeat/defaults-to-position" type="string"/>
+
+            <bind nodeset="/data/my-repeat-without-template/my-value" type="integer"/>
+
+            <bind nodeset="/data/my-other-repeat/my-value" type="string"/>
+            <!-- setvalue event in model; not part of ODK XForms specification -->
+            <setvalue event="odk-new-repeat" ref="/data/my-other-repeat/my-value" value="now()"/>
+        </model>
+    </h:head>
+
+    <h:body>
+        <input ref="/data/my-toplevel-value">
+            <label>A top-level value</label>
+        </input>
+
+        <repeat nodeset="/data/my-repeat">
+            <!-- setvalue event in body -->
+            <setvalue event="odk-new-repeat" ref="/data/my-repeat/defaults-to-now" value="now()" />
+            <input ref="/data/my-repeat/defaults-to-now">
+                <label>A value</label>
+            </input>
+
+            <!-- setvalue with relative reference -->
+            <setvalue event="odk-new-repeat" ref="/data/my-repeat/defaults-to-toplevel" value="../../my-toplevel-value + 2" />
+            <input ref="/data/my-repeat/defaults-to-toplevel">
+                <label>A value</label>
+            </input>
+        </repeat>
+
+        <input ref="/data/repeat-count">
+            <label>Repeat count</label>
+        </input>
+        <!-- odk-new-repeat event in repeat with jr:count -->
+        <repeat nodeset="/data/my-jr-count-repeat"  jr:count="/data/repeat-count">
+            <setvalue event="odk-new-repeat" ref="/data/my-jr-count-repeat/defaults-to-position" value="position(..)" />
+            <input ref="/data/my-jr-count-repeat/defaults-to-position">
+                <label>A value</label>
+            </input>
+        </repeat>
+
+        <repeat nodeset="/data/my-repeat-without-template">
+            <setvalue event="odk-new-repeat" ref="/data/my-repeat-without-template/my-value">2</setvalue>
+            <input ref="/data/my-repeat-without-template/my-value">
+                <label>A value</label>
+            </input>
+        </repeat>
+
+        <repeat nodeset="/data/my-other-repeat">
+            <input ref="/data/my-other-repeat/my-value">
+                <label>A value</label>
+            </input>
+        </repeat>
+    </h:body>
+</h:html>

--- a/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
@@ -7,17 +7,19 @@
                     <meta>
                         <instanceID/>
                     </meta>
+
+                    <!-- used to test relative references that parent out of a repeat -->
                     <my-toplevel-value/>
 
-                    <!-- no repeat instance in model -->
+                    <!-- no repeat instance in model so odk-new-repeat event should fire for each new instance -->
                     <my-repeat jr:template="">
-                        <defaults-to-now/>
+                        <defaults-to-position/>
                         <defaults-to-toplevel/>
                     </my-repeat>
 
-                    <repeat-count>4</repeat-count>
+                    <repeat-count/>
                     <my-jr-count-repeat jr:template="">
-                        <defaults-to-position/>
+                        <defaults-to-position-again/>
                     </my-jr-count-repeat>
 
                     <!-- repeat instances in model should not fire odk-new-repeat event -->
@@ -32,11 +34,11 @@
 
             <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
             <bind nodeset="/data/my-toplevel-value" type="integer"/>
-            <bind nodeset="/data/my-repeat/defaults-to-now" type="string"/>
+            <bind nodeset="/data/my-repeat/defaults-to-position" type="string"/>
             <bind nodeset="/data/my-repeat/defaults-to-toplevel" type="integer"/>
 
             <bind nodeset="/data/repeat-count" type="integer"/>
-            <bind nodeset="/data/my-jr-count-repeat/defaults-to-position" type="string"/>
+            <bind nodeset="/data/my-jr-count-repeat/defaults-to-position-again" type="string"/>
 
             <bind nodeset="/data/my-repeat-without-template/my-value" type="integer"/>
         </model>
@@ -48,30 +50,31 @@
         </input>
 
         <repeat nodeset="/data/my-repeat">
-            <!-- setvalue event in body -->
-            <setvalue event="odk-new-repeat" ref="/data/my-repeat/defaults-to-now" value="now()" />
-            <input ref="/data/my-repeat/defaults-to-now">
+            <!-- setvalue event nested in repeat rather than in model -->
+            <setvalue event="odk-new-repeat" ref="/data/my-repeat/defaults-to-position" value="position(..)" />
+            <input ref="/data/my-repeat/defaults-to-position">
                 <label>A value</label>
             </input>
 
-            <!-- setvalue with relative reference -->
+            <!-- setvalue with relative reference. Context should be the contextualized ref (https://www.w3.org/TR/xforms11/#action-setvalue) -->
             <setvalue event="odk-new-repeat" ref="/data/my-repeat/defaults-to-toplevel" value="../../my-toplevel-value + 2" />
             <input ref="/data/my-repeat/defaults-to-toplevel">
                 <label>A value</label>
             </input>
         </repeat>
 
+        <!-- odk-new-repeat event in repeat with jr:count. Event should be fired for each repeat added as count changes -->
         <input ref="/data/repeat-count">
             <label>Repeat count</label>
         </input>
-        <!-- odk-new-repeat event in repeat with jr:count -->
         <repeat nodeset="/data/my-jr-count-repeat"  jr:count="/data/repeat-count">
-            <setvalue event="odk-new-repeat" ref="/data/my-jr-count-repeat/defaults-to-position" value="position(..)" />
-            <input ref="/data/my-jr-count-repeat/defaults-to-position">
+            <setvalue event="odk-new-repeat" ref="/data/my-jr-count-repeat/defaults-to-position-again" value="position(..)" />
+            <input ref="/data/my-jr-count-repeat/defaults-to-position-again">
                 <label>A value</label>
             </input>
         </repeat>
 
+        <!-- odk-new-repeat event without template. Event should not be fired for the repeats in the instance -->
         <repeat nodeset="/data/my-repeat-without-template">
             <setvalue event="odk-new-repeat" ref="/data/my-repeat-without-template/my-value">2</setvalue>
             <input ref="/data/my-repeat-without-template/my-value">


### PR DESCRIPTION
Closes #465

#### What has been done to verify that this works as intended?
Automated test with form that captures all cases mentioned in [the specification](https://opendatakit.github.io/xforms-spec/#the-odk-new-repeat-event).

#### Why is this the best possible solution? Were any other approaches considered?I followed the event/action patterns that are already established so I didn't feel like there were many decisions to make. 

The one thing I went back and forth on is whether or not to block actions that respond to `odk-new-repeat` at the model level. See the last test for an example. The specification currently says "Actions triggered by odk-new-repeat must be nested in the repeat form control." I initially was going to leave incidental support but I think it's confusing when there's unofficially supported behavior so I made that enforced on initial parse.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should be a purely additive change making it very low risk. Some code has moved around in `XFormParser` but as far as I know, the affected nodes are for configuring a type of repeat that is undocumented and unused by Collect.

I added an action controller to `GroupDef` and I could imagine some mistakes there having negative consequences.

#### Do we need any specific form for testing your changes? If so, please attach one.

See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No.
