### PR TITLE
Explicitly identify the value that can't be converted to a date

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -818,7 +818,7 @@ public class XPathFuncExpr extends XPathExpression {
                 }
 
                 if (n.isInfinite() || n > Integer.MAX_VALUE || n < Integer.MIN_VALUE) {
-                    throw new XPathTypeMismatchException("converting out-of-range value to date");
+                    throw new XPathTypeMismatchException("The value \"" + n + "\" is out of range for representing a date.");
                 }
 
                 long timeMillis = (long) (n * DateUtils.DAY_IN_MS);
@@ -833,7 +833,7 @@ public class XPathFuncExpr extends XPathExpression {
                 }
 
                 if (n.isInfinite() || n > Integer.MAX_VALUE || n < Integer.MIN_VALUE) {
-                    throw new XPathTypeMismatchException("converting out-of-range value to date");
+                    throw new XPathTypeMismatchException("The value \"" + n + "\" is out of range for representing a date.");
                 }
 
                 return DateUtils.dateAdd(DateUtils.getDate(1970, 1, 1), n.intValue());
@@ -847,7 +847,7 @@ public class XPathFuncExpr extends XPathExpression {
 
             Date d = DateUtils.parseDateTime(s);
             if (d == null) {
-                throw new XPathTypeMismatchException("converting to date");
+                throw new XPathTypeMismatchException("The value \"" + s + "\" can't be converted to a date.");
             } else {
                 return d;
             }
@@ -858,7 +858,7 @@ public class XPathFuncExpr extends XPathExpression {
                 return DateUtils.roundDate((Date) input);
             }
         } else {
-            throw new XPathTypeMismatchException("converting to date");
+            throw new XPathTypeMismatchException("The value \"" + input.toString() + "\" can't be converted to a date.");
         }
     }
 
@@ -873,7 +873,7 @@ public class XPathFuncExpr extends XPathExpression {
             }
 
             if (n.isInfinite() || n > Integer.MAX_VALUE || n < Integer.MIN_VALUE) {
-                throw new XPathTypeMismatchException("converting out-of-range value to date");
+                throw new XPathTypeMismatchException("The value \"" + n + "\" is out of range for representing a date.");
             }
 
             if (keepDate) {
@@ -890,7 +890,7 @@ public class XPathFuncExpr extends XPathExpression {
 
             Date d = DateUtils.parseDateTime(s);
             if (d == null) {
-                throw new XPathTypeMismatchException("converting to date");
+                throw new XPathTypeMismatchException("The value \"" + s + "\" can't be converted to a date.");
             } else {
                 if (keepDate) {
                     long milli = d.getTime();
@@ -910,7 +910,7 @@ public class XPathFuncExpr extends XPathExpression {
                 return DateUtils.decimalTimeOfLocalDay(d);
             }
         } else {
-            throw new XPathTypeMismatchException("converting to date");
+            throw new XPathTypeMismatchException("The value \"" + o.toString() + "\" can't be converted to a date.");
         }
     }
 

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -318,6 +318,8 @@ public class XPathEvalTest {
         testEval("date-time('2000-01-01T10:20:30.000')", DateUtils.getDateTimeFromString("2000-01-01T10:20:30.000"));
         testEval("decimal-date-time('2000-01-01T10:20:30.000')", 10957.430902777778);
         testEval("decimal-time('2000-01-01T10:20:30.000+03:00')", .30590277777810115);
+        testEval("decimal-date-time('-1000')", new XPathTypeMismatchException());
+        testEval("decimal-date-time('-01-2019')", new XPathTypeMismatchException());
     }
 
     @Test


### PR DESCRIPTION
In response to #405

#### What has been done to verify that this works as intended?
Added tests to make sure the exceptions are thrown when expected.

#### Why is this the best possible solution? Were any other approaches considered?
In Collect, these exception messages will be shown to the user in a dialog if re-computation leads to an invalid value being passed to a function that converts to date. These error messages should help the user identify what form design improvements they could make to avoid that case without making them too long. I considered providing suggestions like adding constraints or defaults but I think it's too hard to make generically useful.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
All this should do is improve error text. 

#### Do we need any specific form for testing your changes? If so, please attach one.
[decimal-date-time-bug.xls.zip](https://github.com/opendatakit/javarosa/files/3659111/decimal-date-time-bug.xls.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.