### PR TITLE
Add support for nested odk-instance-first-load event and space-separated event lists

### DIFF
--- a/src/main/java/org/javarosa/core/model/CoreModelModule.java
+++ b/src/main/java/org/javarosa/core/model/CoreModelModule.java
@@ -29,6 +29,7 @@ public class CoreModelModule implements IModule {
             "org.javarosa.core.model.QuestionDef",
             "org.javarosa.core.model.RangeQuestion",
             "org.javarosa.core.model.GroupDef",
+            "org.javarosa.core.model.instance.TreeReference",
             "org.javarosa.core.model.instance.FormInstance",
             "org.javarosa.core.model.instance.ExternalDataInstance",
             "org.javarosa.core.model.data.BooleanData",

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -190,6 +190,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     private HashMap<String, DataInstance> formInstances;
     private FormInstance mainInstance = null;
 
+    //region Actions
     private ActionController actionController;
     /**
      * The names of the action types that this form includes. This allows clients to do things like let users know if
@@ -197,6 +198,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * includes we'd have to query the actionController on every node.
      */
     private Set<String> actions;
+    /**
+     * Questions and groups that have nested actions triggered by top-level events.
+     */
+    private Set<IFormElement> elementsWithActionTriggeredByToplevelEvent;
+    //endregion
 
     private EventNotifier eventNotifier;
 
@@ -240,8 +246,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         submissionProfiles = new HashMap<>();
         formInstances = new HashMap<>();
         extensions = new ArrayList<>();
+
         actionController = new ActionController();
         actions = new HashSet<>();
+        elementsWithActionTriggeredByToplevelEvent = new HashSet<>();
 
         this.eventNotifier = eventNotifier;
     }
@@ -1288,6 +1296,41 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         resetEvaluationContext();
         actionController = (ActionController) ExtUtil.read(dis, new ExtWrapNullable(ActionController.class), pf);
         actions = new HashSet<>((List<String>) ExtUtil.read(dis, new ExtWrapListPoly(), pf));
+
+        List<TreeReference> treeReferencesWithActions = (List<TreeReference>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
+        elementsWithActionTriggeredByToplevelEvent = getElementsFromReferences(treeReferencesWithActions);
+    }
+
+    /**
+     * Given one or more {@link TreeReference}, return a set of questions and/or groups corresponding to the references
+     * that are found in this form definition.
+     *
+     * Note: this performs a recursive breadth-first search so is not intended to be used where performance matters.
+     */
+    private Set<IFormElement> getElementsFromReferences(Collection<TreeReference> references) {
+        Set<TreeReference> referencesRemaining = new HashSet<>();
+        referencesRemaining.addAll(references);
+
+        Set<IFormElement> elements = new HashSet<>();
+
+        getElementsFromReferences(referencesRemaining, this, elements);
+        return elements;
+    }
+
+    private static void getElementsFromReferences(Set<TreeReference> referencesRemaining, IFormElement fe, Set<IFormElement> elementsSoFar) {
+        if (referencesRemaining.size() > 0 && fe.getChildren() != null) {
+            for (IFormElement candidate : fe.getChildren()) {
+                TreeReference candidateReference = FormInstance.unpackReference(candidate.getBind());
+                for (TreeReference reference : referencesRemaining) {
+                    if (candidateReference.equals(reference)) {
+                        elementsSoFar.add(candidate);
+                        referencesRemaining.remove(candidate);
+                    }
+                }
+
+                getElementsFromReferences(referencesRemaining, candidate, elementsSoFar);
+            }
+        }
     }
 
     /**
@@ -1313,6 +1356,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         if (newInstance) {
             actionController.triggerActionsFromEvent(Action.EVENT_ODK_INSTANCE_FIRST_LOAD, this);
+            for (IFormElement element : elementsWithActionTriggeredByToplevelEvent) {
+                element.getActionController().triggerActionsFromEvent(Action.EVENT_ODK_INSTANCE_FIRST_LOAD, this, ((TreeReference) element.getBind().getReference()).getParentRef(), null);
+            }
 
             // xforms-ready is marked as deprecated as of JavaRosa 2.14.0 but is still dispatched for compatibility with
             // old form definitions
@@ -1360,6 +1406,20 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         ExtUtil.write(dos, new ExtWrapListPoly(extensions));
         ExtUtil.write(dos, new ExtWrapNullable(actionController));
         ExtUtil.write(dos, new ExtWrapListPoly(new ArrayList<>(actions)));
+        ExtUtil.write(dos, new ExtWrapListPoly(getReferencesFromElements(elementsWithActionTriggeredByToplevelEvent)));
+    }
+
+    /**
+     * Given a collection of form elements, build and return a list of corresponding TreeReferences.
+     */
+    private static List<TreeReference> getReferencesFromElements(Collection<IFormElement> elements) {
+        List<TreeReference> references = new ArrayList<>();
+
+        for (IFormElement element : elements) {
+            references.add(FormInstance.unpackReference(element.getBind()));
+        }
+
+        return references;
     }
 
     public void collapseIndex(FormIndex index, List<Integer> indexes, List<Integer> multiplicities, List<IFormElement> elements) {
@@ -1777,6 +1837,14 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      */
     public boolean hasAction(String name) {
         return actions.contains(name);
+    }
+
+    /**
+     * Records that this question or group has a nested action triggered by a top-level event so that the action can be
+     * triggered without having to traverse all elements.
+     */
+    public void registerElementWithActionsTriggeredByToplevelEvent(IFormElement element) {
+        elementsWithActionTriggeredByToplevelEvent.add(element);
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1843,7 +1843,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * Records that this question or group has a nested action triggered by a top-level event so that the action can be
      * triggered without having to traverse all elements.
      */
-    public void registerElementWithActionsTriggeredByToplevelEvent(IFormElement element) {
+    public void registerElementWithActionTriggeredByToplevelEvent(IFormElement element) {
         elementsWithActionTriggeredByToplevelEvent.add(element);
     }
 

--- a/src/main/java/org/javarosa/core/model/actions/ActionController.java
+++ b/src/main/java/org/javarosa/core/model/actions/ActionController.java
@@ -1,11 +1,12 @@
 package org.javarosa.core.model.actions;
 
 
+import static org.javarosa.xform.parse.XFormParser.getValidEventNames;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import org.javarosa.core.model.FormDef;
@@ -48,7 +49,7 @@ public class ActionController implements Externalizable {
      */
     public void registerEventListener(String event, Action action) {
         // event could be a single event or a space separated event list.
-        registerEventListener(Arrays.asList(event.split(" ")), action);
+        registerEventListener(getValidEventNames(event), action);
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/actions/ActionController.java
+++ b/src/main/java/org/javarosa/core/model/actions/ActionController.java
@@ -39,15 +39,23 @@ public class ActionController implements Externalizable {
         return new ArrayList<>();
     }
 
-    public void registerEventListener(String event, Action action) {
-        List<Action> actions;
-        if (eventListeners.containsKey(event)) {
-            actions = eventListeners.get(event);
-        } else {
-            actions = new ArrayList<>();
-            eventListeners.put(event, actions);
+    /**
+     * Register an action to be triggered by the specified event(s).
+     *
+     * @param eventList space-separated list of event names defined in {@link Action}. All names must be valid.
+     * @param action the action to associate with each of the events.
+     */
+    public void registerEventListener(String eventList, Action action) {
+        for (String event : eventList.split(" ")) {
+            List<Action> actions;
+            if (eventListeners.containsKey(event)) {
+                actions = eventListeners.get(event);
+            } else {
+                actions = new ArrayList<>();
+                eventListeners.put(event, actions);
+            }
+            actions.add(action);
         }
-        actions.add(action);
     }
 
     public void triggerActionsFromEvent(String event, FormDef model) {

--- a/src/main/java/org/javarosa/core/model/actions/ActionController.java
+++ b/src/main/java/org/javarosa/core/model/actions/ActionController.java
@@ -1,6 +1,13 @@
 package org.javarosa.core.model.actions;
 
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -9,13 +16,6 @@ import org.javarosa.core.util.externalizable.ExtWrapListPoly;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 /**
  * Registers actions that should be triggered by certain events, and handles the triggering
@@ -42,11 +42,23 @@ public class ActionController implements Externalizable {
     /**
      * Register an action to be triggered by the specified event(s).
      *
-     * @param eventList space-separated list of event names defined in {@link Action}. All names must be valid.
-     * @param action the action to associate with each of the events.
+     * @param event  the event name defined in {@link Action}
+     * @param action the action to associate with the events.
+     * @deprecated Use {@link #registerEventListener(List, Action)}
      */
-    public void registerEventListener(String eventList, Action action) {
-        for (String event : eventList.split(" ")) {
+    public void registerEventListener(String event, Action action) {
+        // event could be a single event or a space separated event list.
+        registerEventListener(Arrays.asList(event.split(" ")), action);
+    }
+
+    /**
+     * Register an action to be triggered by the specified event(s).
+     *
+     * @param eventList list of event names defined in {@link Action}. All names must be valid.
+     * @param action    the action to associate with each of the events.
+     */
+    public void registerEventListener(List<String> eventList, Action action) {
+        for (String event : eventList) {
             List<Action> actions;
             if (eventListeners.containsKey(event)) {
                 actions = eventListeners.get(event);
@@ -75,7 +87,7 @@ public class ActionController implements Externalizable {
     @Override
     public void readExternal(DataInputStream inStream, PrototypeFactory pf) throws IOException, DeserializationException {
         eventListeners = (HashMap<String, List<Action>>) ExtUtil.read(inStream,
-                new ExtWrapMap(String.class, new ExtWrapListPoly()), pf);
+            new ExtWrapMap(String.class, new ExtWrapListPoly()), pf);
     }
 
     @Override
@@ -87,7 +99,7 @@ public class ActionController implements Externalizable {
     public interface ActionResultProcessor {
         /**
          * @param targetRef - the ref that this action targeted
-         * @param event - the event that triggered this action
+         * @param event     - the event that triggered this action
          */
         void processResultOfAction(TreeReference targetRef, String event);
     }

--- a/src/main/java/org/javarosa/core/model/actions/setgeopoint/SetGeopointActionHandler.java
+++ b/src/main/java/org/javarosa/core/model/actions/setgeopoint/SetGeopointActionHandler.java
@@ -16,6 +16,10 @@
 
 package org.javarosa.core.model.actions.setgeopoint;
 
+import static org.javarosa.xform.parse.XFormParser.EVENT_ATTR;
+
+import java.util.Arrays;
+import java.util.List;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.IFormElement;
@@ -49,7 +53,7 @@ public abstract class SetGeopointActionHandler implements IElementHandler {
         SetGeopointAction action = getSetGeopointAction();
         action.setTargetReference(target);
 
-        String eventList = e.getAttributeValue(null, XFormParser.EVENT_ATTR);
+        List<String> eventList = Arrays.asList(e.getAttributeValue(null, EVENT_ATTR).split(" "));
         // XFormParser.parseAction already ensures parent is an IFormElement so we can safely cast
         ((IFormElement) parent).getActionController().registerEventListener(eventList, action);
     }

--- a/src/main/java/org/javarosa/core/model/actions/setgeopoint/SetGeopointActionHandler.java
+++ b/src/main/java/org/javarosa/core/model/actions/setgeopoint/SetGeopointActionHandler.java
@@ -17,9 +17,8 @@
 package org.javarosa.core.model.actions.setgeopoint;
 
 import static org.javarosa.xform.parse.XFormParser.EVENT_ATTR;
+import static org.javarosa.xform.parse.XFormParser.getValidEventNames;
 
-import java.util.Arrays;
-import java.util.List;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.IFormElement;
@@ -53,9 +52,11 @@ public abstract class SetGeopointActionHandler implements IElementHandler {
         SetGeopointAction action = getSetGeopointAction();
         action.setTargetReference(target);
 
-        List<String> eventList = Arrays.asList(e.getAttributeValue(null, EVENT_ATTR).split(" "));
         // XFormParser.parseAction already ensures parent is an IFormElement so we can safely cast
-        ((IFormElement) parent).getActionController().registerEventListener(eventList, action);
+        ((IFormElement) parent).getActionController().registerEventListener(
+            getValidEventNames(e.getAttributeValue(null, EVENT_ATTR)),
+            action
+        );
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/actions/setgeopoint/SetGeopointActionHandler.java
+++ b/src/main/java/org/javarosa/core/model/actions/setgeopoint/SetGeopointActionHandler.java
@@ -49,9 +49,9 @@ public abstract class SetGeopointActionHandler implements IElementHandler {
         SetGeopointAction action = getSetGeopointAction();
         action.setTargetReference(target);
 
-        String event = e.getAttributeValue(null, "event");
+        String eventList = e.getAttributeValue(null, XFormParser.EVENT_ATTR);
         // XFormParser.parseAction already ensures parent is an IFormElement so we can safely cast
-        ((IFormElement) parent).getActionController().registerEventListener(event, action);
+        ((IFormElement) parent).getActionController().registerEventListener(eventList, action);
     }
 
     /**

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -16,7 +16,48 @@
 
 package org.javarosa.xform.parse;
 
-import java.util.Arrays;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
+import static org.javarosa.core.model.Constants.CONTROL_INPUT;
+import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_RANK;
+import static org.javarosa.core.model.Constants.CONTROL_SECRET;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
+import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
+import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
+import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
+import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
+import static org.javarosa.core.services.ProgramFlow.die;
+import static org.javarosa.xform.parse.Constants.ID_ATTR;
+import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
+import static org.javarosa.xform.parse.Constants.RANK;
+import static org.javarosa.xform.parse.Constants.SELECT;
+import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
+import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.GroupDef;
@@ -70,49 +111,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
-import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
-import static org.javarosa.core.model.Constants.CONTROL_INPUT;
-import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_RANGE;
-import static org.javarosa.core.model.Constants.CONTROL_RANK;
-import static org.javarosa.core.model.Constants.CONTROL_SECRET;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
-import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
-import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
-import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
-import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
-import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
-import static org.javarosa.core.services.ProgramFlow.die;
-import static org.javarosa.xform.parse.Constants.ID_ATTR;
-import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
-import static org.javarosa.xform.parse.Constants.RANK;
-import static org.javarosa.xform.parse.Constants.SELECT;
-import static org.javarosa.xform.parse.Constants.SELECTONE;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
-import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 /* droos: i think we need to start storing the contents of the <bind>s in the formdef again */
 
@@ -174,7 +172,9 @@ public class XFormParser implements IXFormParserFunctions {
     private List<String> itextKnownForms;
     private static HashMap<String, IElementHandler> actionHandlers;
 
-    /** The string IDs of all instances that are referenced in a instance() function call in the primary instance **/
+    /**
+     * The string IDs of all instances that are referenced in a instance() function call in the primary instance
+     **/
     private static Set<String> referencedInstanceIds;
 
     private final List<WarningCallback> warningCallbacks = new ArrayList<>();
@@ -242,7 +242,8 @@ public class XFormParser implements IXFormParserFunctions {
                 }
             });
             put(RANK, new IElementHandler() {
-                @Override public void handle(XFormParser p, Element e, Object parent) {
+                @Override
+                public void handle(XFormParser p, Element e, Object parent) {
                     p.parseControl((IFormElement) parent, e, CONTROL_RANK);
                 }
             });
@@ -371,7 +372,7 @@ public class XFormParser implements IXFormParserFunctions {
     }
 
     /**
-     * @param formXmlSrc The path of the form definition.
+     * @param formXmlSrc   The path of the form definition.
      * @param lastSavedSrc The src of the last-saved instance of this form (for auto-filling). If null,
      *                     no data will be loaded and the instance will be blank.
      */
@@ -716,12 +717,9 @@ public class XFormParser implements IXFormParserFunctions {
      */
     private void parseAction(Element e, Object parent, IElementHandler specificHandler) {
         // Check that all events registered to trigger this action are valid events that we support
-        String eventList = e.getAttributeValue(null, EVENT_ATTR);
+        List<String> validEvents = getValidEventNames(e.getAttributeValue(null, EVENT_ATTR));
 
-        for (String event : eventList.split(" ")) {
-            if (!Action.isValidEvent(event)) {
-                throw new XFormParseException("An action was registered for an unsupported event: " + event);
-            }
+        for (String event : validEvents) {
             // Check that the action was included in a valid place within the XForm
             if (!(parent instanceof IFormElement)) {
                 // parent must either be a FormDef, GroupDef or QuestionDef
@@ -737,6 +735,19 @@ public class XFormParser implements IXFormParserFunctions {
         _f.registerAction(e.getName());
 
         specificHandler.handle(this, e, parent);
+    }
+
+    public static List<String> getValidEventNames(String eventsString) {
+        List<String> validEvents = new ArrayList<>();
+        List<String> invalidEventList = new ArrayList<>();
+        for (String event : eventsString.split(" "))
+            if (Action.isValidEvent(event))
+                validEvents.add(event);
+            else
+                invalidEventList.add(event);
+        if (!invalidEventList.isEmpty())
+            throw new XFormParseException("An action was registered for unsupported events: " + String.join(", ", invalidEventList));
+        return validEvents;
     }
 
     public void parseSetValueAction(ActionController source, Element e) {
@@ -786,8 +797,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        List<String> eventList = Arrays.asList(e.getAttributeValue(null, EVENT_ATTR).split(" "));
-        source.registerEventListener(eventList, action);
+        source.registerEventListener(getValidEventNames(e.getAttributeValue(null, EVENT_ATTR)), action);
     }
 
     private void parseSubmission(Element submission) {
@@ -1059,8 +1069,8 @@ public class XFormParser implements IXFormParserFunctions {
 
         boolean isItem =
             controlType == CONTROL_SELECT_MULTI
-            || controlType == CONTROL_RANK
-            || controlType == CONTROL_SELECT_ONE;
+                || controlType == CONTROL_RANK
+                || controlType == CONTROL_SELECT_ONE;
 
         question.setControlType(controlType);
         question.setAppearanceAttr(e.getAttributeValue(null, APPEARANCE_ATTR));
@@ -2190,12 +2200,12 @@ public class XFormParser implements IXFormParserFunctions {
      */
     public static void registerActionHandler(String name, final IElementHandler specificHandler) {
         actionHandlers.put(
-                name,
-                new IElementHandler() {
-                    public void handle(XFormParser p, Element e, Object parent) {
-                        p.parseAction(e, parent, specificHandler);
-                    }
+            name,
+            new IElementHandler() {
+                public void handle(XFormParser p, Element e, Object parent) {
+                    p.parseAction(e, parent, specificHandler);
                 }
+            }
         );
     }
 

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -725,6 +725,10 @@ public class XFormParser implements IXFormParserFunctions {
             throw new XFormParseException("An action element occurred in an invalid location. " +
             "Must be either a child of a control element, or a child of the <model>");
         }
+
+        if (!parent.equals(_f) && event.equals(Action.EVENT_ODK_INSTANCE_FIRST_LOAD)) {
+            _f.registerElementWithActionsTriggeredByToplevelEvent((IFormElement) parent);
+        }
         
         _f.registerAction(e.getName());
 

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.xform.parse;
 
+import java.util.Arrays;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.GroupDef;
@@ -732,7 +733,7 @@ public class XFormParser implements IXFormParserFunctions {
                 _f.registerElementWithActionTriggeredByToplevelEvent((IFormElement) parent);
             }
         }
-        
+
         _f.registerAction(e.getName());
 
         specificHandler.handle(this, e, parent);
@@ -785,7 +786,7 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        String eventList = e.getAttributeValue(null, EVENT_ATTR);
+        List<String> eventList = Arrays.asList(e.getAttributeValue(null, EVENT_ATTR).split(" "));
         source.registerEventListener(eventList, action);
     }
 

--- a/src/test/java/org/javarosa/core/model/actions/MultipleEventsTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/MultipleEventsTest.java
@@ -1,0 +1,45 @@
+package org.javarosa.core.model.actions;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.test.Scenario;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class MultipleEventsTest {
+    @Test
+    public void nestedFirstLoadEvent_setsValue() {
+        Scenario scenario = Scenario.init("multiple-events.xml");
+
+        assertThat(scenario.answerOf("/data/nested-first-load").getDisplayText(), is("cheese"));
+    }
+
+    @Test
+    public void nestedFirstLoadEventInGroup_setsValue() {
+        Scenario scenario = Scenario.init("multiple-events.xml");
+
+        assertThat(scenario.answerOf("/data/my-group/nested-first-load-in-group").getDisplayText(), is("more cheese"));
+    }
+
+    @Test
+    public void serializedAndDeserializedNestedFirstLoadEvent_setsValue() throws IOException, DeserializationException {
+        Scenario scenario = Scenario.init("multiple-events.xml");
+
+        Scenario deserializedScenario = scenario.serializeAndDeserializeForm();
+        deserializedScenario.newInstance();
+        assertThat(deserializedScenario.answerOf("/data/nested-first-load").getDisplayText(), is("cheese"));
+    }
+
+    @Test
+    public void serializedAndDeserializedNestedFirstLoadEventInGroup_setsValue() throws IOException, DeserializationException {
+        Scenario scenario = Scenario.init("multiple-events.xml");
+
+        Scenario deserializedScenario = scenario.serializeAndDeserializeForm();
+        deserializedScenario.newInstance();
+        assertThat(deserializedScenario.answerOf("/data/my-group/nested-first-load-in-group").getDisplayText(), is("more cheese"));
+    }
+}

--- a/src/test/java/org/javarosa/core/model/actions/MultipleEventsTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/MultipleEventsTest.java
@@ -1,6 +1,5 @@
 package org.javarosa.core.model.actions;
 
-import org.javarosa.core.model.FormDef;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.junit.Test;
@@ -41,5 +40,25 @@ public class MultipleEventsTest {
         Scenario deserializedScenario = scenario.serializeAndDeserializeForm();
         deserializedScenario.newInstance();
         assertThat(deserializedScenario.answerOf("/data/my-group/nested-first-load-in-group").getDisplayText(), is("more cheese"));
+    }
+
+    @Test
+    public void nestedFirstLoadAndValueChangedEvents_setValue() {
+        Scenario scenario = Scenario.init("multiple-events.xml");
+
+        assertThat(scenario.answerOf("/data/my-calculated-value").getDisplayText(), is("10"));
+        scenario.answer("/data/my-value", "15");
+        assertThat(scenario.answerOf("/data/my-calculated-value").getDisplayText(), is("30"));
+    }
+
+    @Test
+    public void serializedAndDeserializedNestedFirstLoadAndValueChangedEvents_setValue() throws IOException, DeserializationException {
+        Scenario scenario = Scenario.init("multiple-events.xml");
+
+        Scenario deserializedScenario = scenario.serializeAndDeserializeForm();
+        deserializedScenario.newInstance();
+        assertThat(deserializedScenario.answerOf("/data/my-calculated-value").getDisplayText(), is("10"));
+        deserializedScenario.answer("/data/my-value", "15");
+        assertThat(deserializedScenario.answerOf("/data/my-calculated-value").getDisplayText(), is("30"));
     }
 }

--- a/src/test/java/org/javarosa/core/model/actions/MultipleEventsTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/MultipleEventsTest.java
@@ -2,7 +2,10 @@ package org.javarosa.core.model.actions;
 
 import org.javarosa.core.test.Scenario;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.xform.parse.XFormParseException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
@@ -10,6 +13,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class MultipleEventsTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     @Test
     public void nestedFirstLoadEvent_setsValue() {
         Scenario scenario = Scenario.init("multiple-events.xml");
@@ -60,5 +66,13 @@ public class MultipleEventsTest {
         assertThat(deserializedScenario.answerOf("/data/my-calculated-value").getDisplayText(), is("10"));
         deserializedScenario.answer("/data/my-value", "15");
         assertThat(deserializedScenario.answerOf("/data/my-calculated-value").getDisplayText(), is("30"));
+    }
+
+    @Test
+    public void invalidEventNames_throwException() {
+        expectedException.expect(XFormParseException.class);
+        expectedException.expectMessage("An action was registered for unsupported events: odk-inftance-first-load, my-fake-event");
+
+        Scenario.init("invalid-events.xml");
     }
 }

--- a/src/test/resources/org/javarosa/core/model/actions/invalid-events.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/invalid-events.xml
@@ -1,0 +1,19 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Invalid events</h:title>
+        <model>
+            <instance>
+                <data id="invalid-events">
+                    <nested-first-load/>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/nested-first-load" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/nested-first-load">
+            <setvalue event="odk-inftance-first-load my-fake-event" ref="/data/nested-first-load">cheese</setvalue>
+        </input>
+    </h:body>
+</h:html>

--- a/src/test/resources/org/javarosa/core/model/actions/multiple-events.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/multiple-events.xml
@@ -9,10 +9,16 @@
                     <my-group>
                         <nested-first-load-in-group/>
                     </my-group>
+
+                    <my-value>5</my-value>
+                    <my-calculated-value/>
                 </data>
             </instance>
+
             <bind nodeset="/data/nested-first-load" type="string" />
             <bind nodeset="/data/my-group/nested-first-load-in-group" type="string" />
+            <bind nodeset="/data/my-value" type="integer" />
+            <bind nodeset="/data/my-calculated-value" type="integer" />
         </model>
     </h:head>
     <h:body>
@@ -25,5 +31,9 @@
                 <setvalue event="odk-instance-first-load" ref="/data/my-group/nested-first-load-in-group">more cheese</setvalue>
             </input>
         </group>
+
+        <input ref="/data/my-value">
+            <setvalue event="odk-instance-first-load xforms-value-changed" ref="/data/my-calculated-value" value="../my-value * 2" />
+        </input>
     </h:body>
 </h:html>

--- a/src/test/resources/org/javarosa/core/model/actions/multiple-events.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/multiple-events.xml
@@ -1,0 +1,29 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Space-separated event list</h:title>
+        <model>
+            <instance>
+                <data id="multiple-events">
+                    <nested-first-load/>
+
+                    <my-group>
+                        <nested-first-load-in-group/>
+                    </my-group>
+                </data>
+            </instance>
+            <bind nodeset="/data/nested-first-load" type="string" />
+            <bind nodeset="/data/my-group/nested-first-load-in-group" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/nested-first-load">
+            <setvalue event="odk-instance-first-load" ref="/data/nested-first-load">cheese</setvalue>
+        </input>
+
+        <group ref="/data/my-group">
+            <input ref="nested-first-load-in-group">
+                <setvalue event="odk-instance-first-load" ref="/data/my-group/nested-first-load-in-group">more cheese</setvalue>
+            </input>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #466

#### What has been done to verify that this works as intended?
Added test form for nested `odk-instance-first-load` event in isolation and then space-separated event lists.

#### Why is this the best possible solution? Were any other approaches considered?
First I realized that `odk-instance-first-load` only triggered actions defined in the model so 56ebdd6 adds support for top-level events on actions nested in form controls. The best way I could think to do this is to register the form controls that have actions triggered by top-level events when doing the initial parsing. Without adding that state, we'd need to traverse the entire form definition in search of responding nodes every time a top-level event is triggered. This would be ok for `odk-instance-first-load` because it would just extend the load time of the form but I thought it was worth trying to solve in a more general way. I could be convinced to reconsider.

The problematic thing about adding this state is that it needs to be serialized. It doesn't make sense to serialize `IFormElement`s because 1) they're big and 2) the deserialization process doesn't match references so there would be duplicate objects representing the same form element which seems bad. Instead I serialized the corresponding references.

I apologize if someone is offended by the name `elementsWithActionTriggeredByToplevelEvent` and am open to suggestions!

41b745c adds support for space-separated event lists. I did that by registering lists of events rather than single events. I didn't really think of any alternatives for this one.

Once #493 is merged I will add a test for the combined functionality.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intent is for this not to change any existing behavior. It should just add support for `odk-instance-first-load` nested in form controls and space-separated event lists. Because I add state to `FormDef`, there's risk around form caching. I tried to add test coverage for that but wonder whether there are more cases than top-level question and question nested in group with relative ref that I should add.

#### Do we need any specific form for testing your changes? If so, please attach one.

See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Already documented at https://opendatakit.github.io/xforms-spec/#actions.