### PR TITLE
Fixed forms with external instances

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1827,7 +1827,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         return formXmlPath;
     }
 
-    private HashMap<String, DataInstance> getFormInstances() {
+    public HashMap<String, DataInstance> getFormInstances() {
         return formInstances;
     }
 }

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1816,7 +1816,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     private HashMap<String, DataInstance> getExternalInstances() {
         HashMap<String, DataInstance> externalFormInstances = new HashMap<>();
         for (Map.Entry<String, DataInstance> formInstanceEntry : formInstances.entrySet()) {
-            if (formInstanceEntry instanceof ExternalDataInstance) {
+            if (formInstanceEntry.getValue() instanceof ExternalDataInstance) {
                 externalFormInstances.put(formInstanceEntry.getKey(), formInstanceEntry.getValue());
             }
         }

--- a/src/test/java/org/javarosa/xform/parse/ExternalSecondaryInstanceParseTest.java
+++ b/src/test/java/org/javarosa/xform/parse/ExternalSecondaryInstanceParseTest.java
@@ -26,6 +26,7 @@ import static org.javarosa.xform.parse.FormParserHelper.getSerializedFormPath;
 import static org.javarosa.xform.parse.FormParserHelper.parse;
 import static org.javarosa.xpath.XPathParseTool.parseXPath;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExternalSecondaryInstanceParseTest {
     private static final Logger logger = LoggerFactory.getLogger(ExternalSecondaryInstanceParseTest.class);
@@ -57,6 +58,19 @@ public class ExternalSecondaryInstanceParseTest {
         FormDef deserializedFormDef = deserializeAndCleanUpSerializedForm(serializedForm);
 
         assertThat(originalFormDef.getTitle(), is(deserializedFormDef.getTitle()));
+    }
+
+    @Test
+    public void deserializedFormDefCreatedFromAFormWithExternalSecondaryXMLInstance_ShouldContainThatExternalInstance() throws IOException, DeserializationException {
+        Path formPath = r("external-select-xml.xml");
+        setUpSimpleReferenceManager(formPath.getParent(), "file");
+
+        FormDef originalFormDef = parse(formPath);
+        originalFormDef.setFormXmlPath(formPath.toString());
+
+        Path serializedForm = getSerializedFormPath(originalFormDef);
+        FormDef deserializedFormDef = deserializeAndCleanUpSerializedForm(serializedForm);
+        assertTrue(deserializedFormDef.getFormInstances().containsKey("external-xml"));
     }
 
     @Test


### PR DESCRIPTION
Closes #496 

#### What has been done to verify that this works as intended?
I tested [Remembering previously entered values](https://github.com/opendatakit/javarosa/pull/406) and external secondary instances.

#### Why is this the best possible solution? Were any other approaches considered?
It was just a bug I fixed in this line: https://github.com/opendatakit/javarosa/compare/master...grzesiek2010:JAVAROSA-496?expand=1#diff-b60f702426880ccc5f1b079019104bd4R1819
using just `formInstanceEntry` we always get false because it's always `HashMap$HashMapEntry`
![Screenshot from 2019-10-02 07-53-37](https://user-images.githubusercontent.com/3276264/66034365-685e7d00-e509-11e9-8f45-26acc6968d3d.png)


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
A form that uses [Remembering previously entered values](https://github.com/opendatakit/javarosa/pull/406) like the one used for testing: https://github.com/opendatakit/collect/pull/2882
or a form with external secondary instances like: 
[esi.zip](https://github.com/opendatakit/javarosa/files/3680452/esi.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
