### PR TITLE
Use custom join method for Android compatibility

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -100,6 +100,7 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.XPathConditional;
 import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.expr.XPathNumericLiteral;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
@@ -750,7 +751,7 @@ public class XFormParser implements IXFormParserFunctions {
             else
                 invalidEventList.add(event);
         if (!invalidEventList.isEmpty())
-            throw new XFormParseException("An action was registered for unsupported events: " + String.join(", ", invalidEventList));
+            throw new XFormParseException("An action was registered for unsupported events: " + XPathFuncExpr.join(", ", invalidEventList.toArray()));
         return validEvents;
     }
 


### PR DESCRIPTION
Closes #502

#### What has been done to verify that this works as intended?
Ran all tests.

#### Why is this the best possible solution? Were any other approaches considered?
We could consider pulling out the join method from `XPathFuncExpr` to a utility class but this seems ok for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only user impact should be that forms with unsupported events don't crash on API < 26.

#### Do we need any specific form for testing your changes? If so, please attach one.

Form with invalid events from `MultipleEventsTest` or https://github.com/opendatakit/collect/issues/3383.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
