### PR TITLE
Fixed getSubmissionProfile() method

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1764,12 +1764,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     public SubmissionProfile getSubmissionProfile() {
-        // At some point these profiles will be set by the <submit> control in the
-        // form.
-        // In the mean time, though, we can only promise that the default one will
-        // be used.
-
-        return submissionProfiles.get(DEFAULT_SUBMISSION_PROFILE);
+        return submissionProfiles.size() > 0
+            ? submissionProfiles.entrySet().iterator().next().getValue()
+            : null;
     }
 
     @Override

--- a/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
+++ b/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
@@ -300,6 +300,22 @@ public class XFormParserTest {
         assertEquals("/data/text", submissionProfile.getRef().getReference().toString());
     }
 
+    @Test
+    public void parseFormWithSubmissionElementWithId() throws IOException {
+        // Given & When
+        FormDef formDef = parse(r("submission-element-with-id.xml"));
+
+        // Then
+        assertEquals(formDef.getTitle(), "Single Submission Element");
+        assertNoParseErrors(formDef);
+
+        SubmissionProfile submissionProfile = formDef.getSubmissionProfile();
+        assertEquals("http://some.destination.com", submissionProfile.getAction());
+        assertEquals("form-data-post", submissionProfile.getMethod());
+        assertNull(submissionProfile.getMediaType());
+        assertEquals("/data/text", submissionProfile.getRef().getReference().toString());
+    }
+
     /**
      * Simple tests that documents assumption that the model has to come before the body tag.
      * According to the comment above {@link XFormParser#parseModel(Element)} method,

--- a/src/test/resources/submission-element-with-id.xml
+++ b/src/test/resources/submission-element-with-id.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+    <h:head>
+        <h:title>Single Submission Element</h:title>
+        <model>
+            <submission id="submissionId" action="http://some.destination.com" method="form-data-post" bind="text-data-binding" />
+            <instance>
+                <data id="single-submission-test">
+                    <text/>
+                </data>
+            </instance>
+            <bind id="text-data-binding" nodeset="/data/text" type="string"/>
+        </model>
+    </h:head>
+    <h:body/>
+</h:html>


### PR DESCRIPTION
Closes #https://github.com/opendatakit/collect/issues/3533

#### What has been done to verify that this works as intended?
I added automated tests and tested the changes manually with collect.

#### Why is this the best possible solution? Were any other approaches considered?
We keep a list of submissionProfiles, I don't know why since we use just one but I decided not to change it. Instead, I fixed `getSubmissionProfile()`
The problem with that method was that we add submissionProfiles using DEFAULT_SUBMISSION_PROFILE (which is "1") if a the submission doesn't have an id and using id otherwise but `getSubmissionProfile()` returned values only using DEFAULT_SUBMISSION_PROFILE key, so if we had a submission with its id the method returned null.

I don't now why we allow to keep a list of submissionProfiles since only one submission is allowed... am I right?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test the forms with submissions (with ids and without), that's all nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms added to automated tests:
`parseFormWithSubmissionElementWithId()` and `parseFormWithSubmissionElement()`

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
