### PR TITLE
Improve getting dependant triggerables

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -687,7 +687,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // DAGify the triggerables based on dependencies and sort them so that
         // triggerables come only after the triggerables they depend on
         //
-        dagImpl.finalizeTriggerables(getMainInstance(), getEvaluationContext());
+        dagImpl.finalizeTriggerables(getMainInstance());
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/QuickTriggerable.java
+++ b/src/main/java/org/javarosa/core/model/QuickTriggerable.java
@@ -58,10 +58,8 @@ public final class QuickTriggerable {
         return this.triggerable.equals(triggerable);
     }
 
-    public Triggerable changeContextRefToIntersectWithTriggerable(Triggerable other) {
-        // TODO It's fishy to mutate the Triggerable here. We might prefer to return a copy of the original Triggerable
-        triggerable.changeContextRefToIntersectWithTriggerable(other);
-        return triggerable;
+    public void intersectContextWith(Triggerable other) {
+        triggerable.intersectContextWith(other);
     }
 
     public void setImmediateCascades(Set<QuickTriggerable> deps) {

--- a/src/main/java/org/javarosa/core/model/QuickTriggerable.java
+++ b/src/main/java/org/javarosa/core/model/QuickTriggerable.java
@@ -50,7 +50,7 @@ public final class QuickTriggerable {
         return triggerable.apply(mainInstance, ec, qualified);
     }
 
-    public List<TreeReference> getTargets() {
+    public Set<TreeReference> getTargets() {
         return triggerable.getTargets();
     }
 

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -327,10 +327,7 @@ public class TriggerableDag {
      *                               triggers can't be laid out appropriately
      */
     public void finalizeTriggerables(FormInstance mainInstance, EvaluationContext evalContext) throws IllegalStateException {
-        Set<QuickTriggerable> newTriggerablesDAG = buildDag(mainInstance, evalContext);
-
-        triggerablesDAG.clear();
-        triggerablesDAG = newTriggerablesDAG;
+        triggerablesDAG = buildDag(mainInstance, evalContext);
 
         //
         // build the condition index for repeatable nodes

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class TriggerableDag {
      * the list, where tA comes before tB, evaluating tA cannot depend on any
      * result from evaluating tB.
      */
-    protected final List<QuickTriggerable> triggerablesDAG = new ArrayList<>();
+    protected final Set<QuickTriggerable> triggerablesDAG = new LinkedHashSet<>();
 
     /**
      * NOT VALID UNTIL finalizeTriggerables() is called!!

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -35,7 +35,6 @@ import org.javarosa.core.model.condition.Condition;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.Recalculate;
 import org.javarosa.core.model.condition.Triggerable;
-import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
@@ -436,51 +435,6 @@ public class TriggerableDag {
         }
 
         return doEvaluateTriggerables(mainInstance, evalContext, tv, anchorRef, alreadyEvaluated);
-    }
-
-    /**
-     * This is a utility method to get all of the references of a node. It can
-     * be replaced when we support dependent XPath Steps (IE: /path/to//)
-     *
-     * @return
-     */
-    private static Set<TreeReference> getChildrenOfReference(FormInstance mainInstance, EvaluationContext ec, TreeReference ref) {
-        TreeElement repeatTemplate = mainInstance.getTemplatePath(ref);
-        if (repeatTemplate != null)
-            return getChildrenRefsByTemplate(mainInstance, repeatTemplate);
-        // TODO Write a test that goes through this path and see how and why childrenRef can be different than child.getRef()
-        return getChildrenByExpandedRef(mainInstance, ec, ref);
-    }
-
-    private static Set<TreeReference> getChildrenRefsOfElement(FormInstance mainInstance, AbstractTreeElement<?> element) {
-        TreeElement repeatTemplate = mainInstance.getTemplatePath(element.getRef());
-        if (repeatTemplate != null)
-            return getChildrenRefsByTemplate(mainInstance, repeatTemplate);
-        return getChildrenOfElement(mainInstance, element);
-    }
-
-    private static Set<TreeReference> getChildrenRefsByTemplate(FormInstance mainInstance, TreeElement repeatTemplate) {
-        return getChildrenOfElement(mainInstance, repeatTemplate);
-    }
-
-    private static Set<TreeReference> getChildrenByExpandedRef(FormInstance mainInstance, EvaluationContext ec, TreeReference initialRef) {
-        Set<TreeReference> descendants = new HashSet<>();
-        for (TreeReference childrenRef : ec.expandReference(initialRef)) {
-            AbstractTreeElement<?> child = ec.resolveReference(childrenRef);
-            descendants.add(child.getRef().genericize());
-            descendants.addAll(getChildrenRefsOfElement(mainInstance, child));
-        }
-        return descendants;
-    }
-
-    private static Set<TreeReference> getChildrenOfElement(FormInstance mainInstance, AbstractTreeElement<?> element) {
-        Set<TreeReference> childrenRefs = new HashSet<>();
-        for (int i = 0; i < element.getNumChildren(); ++i) {
-            AbstractTreeElement<?> child = element.getChildAt(i);
-            childrenRefs.add(child.getRef().genericize());
-            childrenRefs.addAll(getChildrenRefsOfElement(mainInstance, child));
-        }
-        return childrenRefs;
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -59,13 +59,12 @@ public class TriggerableDag {
 
     protected final EventNotifierAccessor accessor;
 
+    protected final Set<QuickTriggerable> allTriggerables = new HashSet<>();
     protected Set<QuickTriggerable> triggerablesDAG = emptySet();
 
     protected Map<TreeReference, QuickTriggerable> repeatConditionsPerTargets = new HashMap<>();
-
     protected final Map<TreeReference, Set<QuickTriggerable>> triggerablesPerTrigger = new HashMap<>();
 
-    protected final Set<QuickTriggerable> allTriggerables = new HashSet<>();
 
     protected TriggerableDag(EventNotifierAccessor accessor) {
         this.accessor = accessor;

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -84,7 +84,7 @@ public class TriggerableDag {
     /**
      * List of all the triggerables in the form. Unordered.
      */
-    protected final List<QuickTriggerable> unorderedTriggerables = new ArrayList<>();
+    protected final Set<QuickTriggerable> unorderedTriggerables = new HashSet<>();
 
     protected TriggerableDag(EventNotifierAccessor accessor) {
         this.accessor = accessor;

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -343,8 +343,7 @@ public class TriggerableDag {
 
             if (triggerable.canCascade())
                 for (QuickTriggerable dependantTriggerable : dependantTriggerables) {
-                    QuickTriggerable[] edge = {triggerable, dependantTriggerable};
-                    edges.add(edge);
+                    edges.add(new QuickTriggerable[]{triggerable, dependantTriggerable});
                 }
 
             // TODO Move this from Triggerable to TriggerableDag

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -335,7 +335,7 @@ public class TriggerableDag {
         triggerablesDAG.clear();
         List<QuickTriggerable[]> partialOrdering = new ArrayList<>();
         for (QuickTriggerable qt : vertices) {
-            Set<QuickTriggerable> deps = fillTriggeredElements(mainInstance, evalContext, qt, new HashSet<>());
+            Set<QuickTriggerable> deps = fillTriggeredElements(mainInstance, evalContext, qt);
 
             if (deps.contains(qt))
                 throwCyclesInDagException(deps);
@@ -417,7 +417,7 @@ public class TriggerableDag {
      * Get all of the elements which will need to be evaluated (in order) when
      * the triggerable is fired.
      */
-    public Set<QuickTriggerable> fillTriggeredElements(FormInstance mainInstance, EvaluationContext evalContext, QuickTriggerable qt, Set<QuickTriggerable> destinationSet) {
+    public Set<QuickTriggerable> fillTriggeredElements(FormInstance mainInstance, EvaluationContext evalContext, QuickTriggerable qt) {
         Set<QuickTriggerable> dependantTriggerables = new LinkedHashSet<>();
 
         for (TreeReference target : qt.getTargets()) {
@@ -454,8 +454,7 @@ public class TriggerableDag {
                     for (QuickTriggerable qu : triggered) {
                         // And add them to the queue if they aren't
                         // there already
-                        if (!destinationSet.contains(qu)) {
-                            destinationSet.add(qu);
+                            if (!dependantTriggerables.contains(qu)) {
                             dependantTriggerables.add(qu);
                         }
                     }

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -370,7 +370,6 @@ public class TriggerableDag {
         Set<QuickTriggerable> remainingVertices = new HashSet<>(vertices);
         Set<QuickTriggerable[]> remainingEdges = new HashSet<>(edges);
         while (remainingVertices.size() > 0) {
-
             Set<QuickTriggerable> roots = new HashSet<>(remainingVertices);
             for (QuickTriggerable[] edge : remainingEdges)
                 roots.remove(edge[1]);
@@ -378,8 +377,7 @@ public class TriggerableDag {
             if (roots.size() == 0)
                 throwCyclesInDagException(vertices);
 
-            List<QuickTriggerable> orderedRoots = new ArrayList<>(roots);
-            dag.addAll(orderedRoots);
+            dag.addAll(roots);
 
             Set<QuickTriggerable> newRemainingVertices = new HashSet<>();
             for (QuickTriggerable vertex : vertices)

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -59,32 +59,12 @@ public class TriggerableDag {
 
     protected final EventNotifierAccessor accessor;
 
-    /**
-     * NOT VALID UNTIL finalizeTriggerables() is called!!
-     * <p>
-     * Topologically ordered list, meaning that for any tA and tB in
-     * the list, where tA comes before tB, evaluating tA cannot depend on any
-     * result from evaluating tB.
-     */
     protected Set<QuickTriggerable> triggerablesDAG = emptySet();
 
-    /**
-     * NOT VALID UNTIL finalizeTriggerables() is called!!
-     * <p>
-     * Associates repeatable nodes with the Condition that determines their
-     * relevance.
-     */
     protected Map<TreeReference, QuickTriggerable> repeatConditionsPerTargets = new HashMap<>();
 
-    /**
-     * Maps a tree reference to the set of triggerables that need to be
-     * processed when the value at this reference changes.
-     */
     protected final Map<TreeReference, Set<QuickTriggerable>> triggerIndex = new HashMap<>();
 
-    /**
-     * List of all the triggerables in the form. Unordered.
-     */
     protected final Set<QuickTriggerable> unorderedTriggerables = new HashSet<>();
 
     protected TriggerableDag(EventNotifierAccessor accessor) {
@@ -282,25 +262,7 @@ public class TriggerableDag {
     public final Triggerable addTriggerable(Triggerable t) {
         QuickTriggerable qt = findTriggerable(t);
         if (qt != null) {
-            // one node may control access to many nodes; this means many nodes
-            // effectively have the same condition
-            // let's identify when conditions are the same, and store and calculate
-            // it only once
-
-            // nov-2-2011: ctsims - We need to merge the context nodes together
-            // whenever we do this (finding the highest
-            // common ground between the two), otherwise we can end up failing to
-            // trigger when the ignored context
-            // exists and the used one doesn't
-
-            // TODO It's fishy to mutate the Triggerable here. We might prefer to return a copy of the original Triggerable
             return qt.changeContextRefToIntersectWithTriggerable(t);
-
-            // note, if the contextRef is unnecessarily deep, the condition will be
-            // evaluated more times than needed
-            // perhaps detect when 'identical' condition has a shorter contextRef,
-            // and use that one instead?
-
         } else {
             qt = QuickTriggerable.of(t);
             unorderedTriggerables.add(qt);

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -329,6 +329,8 @@ public class TriggerableDag {
     public void finalizeTriggerables(FormInstance mainInstance, EvaluationContext evalContext) throws IllegalStateException {
         triggerablesDAG.clear();
 
+        // TODO Study how this algorithm ensures that we follow the ancestor >>> descendant direction and if the sorting step is strictly required
+
         // DAGify the triggerables based on dependencies and sort them so that
         // triggerables come only after the triggerables they depend on
         List<QuickTriggerable> vertices = new ArrayList<>(unorderedTriggerables);

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -420,9 +420,9 @@ public class TriggerableDag {
      */
     public Set<QuickTriggerable> getDependantTriggerables(FormInstance mainInstance, EvaluationContext ec, QuickTriggerable triggerable) {
         Set<QuickTriggerable> allDependantTriggerables = new LinkedHashSet<>();
-
+        Set<TreeReference> targets = new HashSet<>();
         for (TreeReference target : triggerable.getTargets()) {
-            Set<TreeReference> targets = new HashSet<>();
+
             targets.add(target);
 
             // For certain types of triggerables, the update will affect
@@ -432,25 +432,25 @@ public class TriggerableDag {
             if (triggerable.isCascadingToChildren()) {
                 targets.addAll(getChildrenOfReference(mainInstance, ec, target));
             }
+        }
 
-            // Now go through each of these updated nodes (generally
-            // just 1 for a normal calculation,
-            // multiple nodes if there's a relevance cascade.
-            for (TreeReference ref : targets) {
-                // Check our index to see if that target is a Trigger
-                // for other conditions
-                // IE: if they are an element of a different calculation
-                // or relevancy calc
+        // Now go through each of these updated nodes (generally
+        // just 1 for a normal calculation,
+        // multiple nodes if there's a relevance cascade.
+        for (TreeReference target : targets) {
+            // Check our index to see if that target is a Trigger
+            // for other conditions
+            // IE: if they are an element of a different calculation
+            // or relevancy calc
 
-                // We can't make this reference generic before now or
-                // we'll lose the target information,
-                // so we'll be more inclusive than needed and see if any
-                // of our triggers are keyed on the predicate-less path
-                // of this ref
-                Set<QuickTriggerable> dependantTriggerables = triggerIndex.get(ref.hasPredicates() ? ref.removePredicates() : ref);
-                if (dependantTriggerables != null)
-                    allDependantTriggerables.addAll(dependantTriggerables);
-            }
+            // We can't make this reference generic before now or
+            // we'll lose the target information,
+            // so we'll be more inclusive than needed and see if any
+            // of our triggers are keyed on the predicate-less path
+            // of this ref
+            Set<QuickTriggerable> dependantTriggerables = triggerIndex.get(target.hasPredicates() ? target.removePredicates() : target);
+            if (dependantTriggerables != null)
+                allDependantTriggerables.addAll(dependantTriggerables);
         }
         return allDependantTriggerables;
     }

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -327,12 +327,11 @@ public class TriggerableDag {
      *                               triggers can't be laid out appropriately
      */
     public void finalizeTriggerables(FormInstance mainInstance, EvaluationContext evalContext) throws IllegalStateException {
-        //
+        triggerablesDAG.clear();
+
         // DAGify the triggerables based on dependencies and sort them so that
         // triggerables come only after the triggerables they depend on
-        //
         List<QuickTriggerable> vertices = new ArrayList<>(unorderedTriggerables);
-        triggerablesDAG.clear();
         List<QuickTriggerable[]> partialOrdering = new ArrayList<>();
         for (QuickTriggerable qt : vertices) {
             Set<QuickTriggerable> deps = fillTriggeredElements(mainInstance, evalContext, qt);

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -182,8 +182,7 @@ public class TriggerableDag {
 
         Set<QuickTriggerable> applicable = new HashSet<>();
         for (QuickTriggerable qt : triggerablesDAG) {
-            for (int j = 0; j < qt.getTargets().size(); j++) {
-                TreeReference target = qt.getTargets().get(j);
+            for (TreeReference target : qt.getTargets()) {
                 if (genericRoot.isAncestorOf(target, false)) {
                     applicable.add(qt);
                     break;
@@ -394,8 +393,7 @@ public class TriggerableDag {
         conditionRepeatTargetIndex.clear();
         for (QuickTriggerable qt : triggerablesDAG) {
             if (qt.isCondition()) {
-                List<TreeReference> targets = qt.getTargets();
-                for (TreeReference target : targets) {
+                for (TreeReference target : qt.getTargets()) {
                     if (mainInstance.getTemplate(target) != null) {
                         conditionRepeatTargetIndex.put(target, qt);
                     }
@@ -426,8 +424,7 @@ public class TriggerableDag {
     public void fillTriggeredElements(FormInstance mainInstance, EvaluationContext evalContext, QuickTriggerable qt, Set<QuickTriggerable> destinationSet, Set<QuickTriggerable> newDestinationSet) {
 
 
-        for (int j = 0; j < qt.getTargets().size(); j++) {
-            TreeReference target = qt.getTargets().get(j);
+            for (TreeReference target : qt.getTargets()) {
             Set<TreeReference> updatedNodes = new HashSet<>();
             updatedNodes.add(target);
 
@@ -622,8 +619,7 @@ public class TriggerableDag {
             List<QuickTriggerable> triggered = triggerIndex.get(trigger);
             targets.clear();
             for (QuickTriggerable qt : triggered) {
-                for (int j = 0; j < qt.getTargets().size(); j++) {
-                    TreeReference target = qt.getTargets().get(j);
+                for (TreeReference target : qt.getTargets()) {
                     if (!targets.contains(target))
                         targets.add(target);
                 }

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -394,7 +394,9 @@ public class TriggerableDag {
     private static Set<QuickTriggerable> getDependantTriggerables(QuickTriggerable triggerable, Map<TreeReference, Set<QuickTriggerable>> triggerIndex) {
         Set<QuickTriggerable> result = new HashSet<>();
         for (TreeReference targetRef : triggerable.getTargets()) {
-            Set<QuickTriggerable> children = triggerIndex.getOrDefault(targetRef, emptySet());
+            Set<QuickTriggerable> children = triggerIndex.containsKey(targetRef)
+                ? triggerIndex.get(targetRef)
+                : emptySet();
             result.addAll(children);
             for (QuickTriggerable child : children)
                 if (child != triggerable && !result.contains(child))

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -23,7 +23,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -367,7 +366,6 @@ public class TriggerableDag {
 
     private static Set<QuickTriggerable> buildDag(Set<QuickTriggerable> vertices, List<QuickTriggerable[]> edges) {
         Set<QuickTriggerable> dag = new LinkedHashSet<>();
-        // TODO Study how this algorithm ensures that we follow the ancestor >>> descendant direction and if the sorting step is strictly required
 
         Set<QuickTriggerable> remainingVertices = new HashSet<>(vertices);
         Set<QuickTriggerable[]> remainingEdges = new HashSet<>(edges);
@@ -381,8 +379,6 @@ public class TriggerableDag {
                 throwCyclesInDagException(vertices);
 
             List<QuickTriggerable> orderedRoots = new ArrayList<>(roots);
-            // TODO Study if insertion order & using LinkedSets would suffice to ensure proper triggerable chaining
-            Collections.sort(orderedRoots, QuickTriggerableComparator.INSTANCE);
             dag.addAll(orderedRoots);
 
             Set<QuickTriggerable> newRemainingVertices = new HashSet<>();

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -335,8 +335,7 @@ public class TriggerableDag {
         triggerablesDAG.clear();
         List<QuickTriggerable[]> partialOrdering = new ArrayList<>();
         for (QuickTriggerable qt : vertices) {
-            Set<QuickTriggerable> deps = new HashSet<>();
-            Set<QuickTriggerable> newDestinationSet = fillTriggeredElements(mainInstance, evalContext, qt, deps);
+            Set<QuickTriggerable> deps = fillTriggeredElements(mainInstance, evalContext, qt, new HashSet<>());
 
             if (deps.contains(qt))
                 throwCyclesInDagException(deps);

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -65,7 +65,7 @@ public class TriggerableDag {
      * the list, where tA comes before tB, evaluating tA cannot depend on any
      * result from evaluating tB.
      */
-    protected final Set<QuickTriggerable> triggerablesDAG = new LinkedHashSet<>();
+    protected Set<QuickTriggerable> triggerablesDAG = new LinkedHashSet<>();
 
     /**
      * NOT VALID UNTIL finalizeTriggerables() is called!!
@@ -327,8 +327,7 @@ public class TriggerableDag {
      *                               triggers can't be laid out appropriately
      */
     public void finalizeTriggerables(FormInstance mainInstance, EvaluationContext evalContext) throws IllegalStateException {
-        triggerablesDAG.clear();
-
+        Set<QuickTriggerable> newTriggerablesDAG = new LinkedHashSet<>();
         // TODO Study how this algorithm ensures that we follow the ancestor >>> descendant direction and if the sorting step is strictly required
 
         // DAGify the triggerables based on dependencies and sort them so that
@@ -373,7 +372,7 @@ public class TriggerableDag {
             // remove root nodes and edges originating from them
             // add them to the triggerablesDAG.
             for (QuickTriggerable root : orderedRoots) {
-                triggerablesDAG.add(root);
+                newTriggerablesDAG.add(root);
                 vertices.remove(root);
             }
             for (int i = edges.size() - 1; i >= 0; i--) {
@@ -382,6 +381,9 @@ public class TriggerableDag {
                     edges.remove(i);
             }
         }
+
+        triggerablesDAG.clear();
+        triggerablesDAG = newTriggerablesDAG;
 
         //
         // build the condition index for repeatable nodes

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -74,7 +74,7 @@ public class TriggerableDag {
      * Associates repeatable nodes with the Condition that determines their
      * relevance.
      */
-    protected final Map<TreeReference, QuickTriggerable> conditionRepeatTargetIndex = new HashMap<>();
+    protected Map<TreeReference, QuickTriggerable> conditionRepeatTargetIndex = new HashMap<>();
 
     /**
      * Maps a tree reference to the set of triggerables that need to be
@@ -333,16 +333,17 @@ public class TriggerableDag {
             getDagEdges(mainInstance, evalContext, unorderedTriggerables, triggerIndex)
         );
 
-        conditionRepeatTargetIndex.clear();
+        Map<TreeReference, QuickTriggerable> newRepeatConditionsPerTarget = new HashMap<>();
         for (QuickTriggerable qt : triggerablesDAG) {
             if (qt.isCondition()) {
                 for (TreeReference target : qt.getTargets()) {
                     if (mainInstance.getTemplate(target) != null) {
-                        conditionRepeatTargetIndex.put(target, qt);
+                        newRepeatConditionsPerTarget.put(target, qt);
                     }
                 }
             }
         }
+        conditionRepeatTargetIndex = newRepeatConditionsPerTarget;
     }
 
     // TODO We can avoid having to resolve dependant refs using the mainInstance by adding descendant refs as targets of relevance triggerables

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -79,7 +79,7 @@ public class TriggerableDag {
      * Maps a tree reference to the set of triggerables that need to be
      * processed when the value at this reference changes.
      */
-    protected final Map<TreeReference, List<QuickTriggerable>> triggerIndex = new HashMap<>();
+    protected final Map<TreeReference, Set<QuickTriggerable>> triggerIndex = new HashMap<>();
 
     /**
      * List of all the triggerables in the form. Unordered.
@@ -306,14 +306,12 @@ public class TriggerableDag {
 
             Set<TreeReference> triggers = t.getTriggers();
             for (TreeReference trigger : triggers) {
-                List<QuickTriggerable> triggered = triggerIndex.get(trigger);
+                Set<QuickTriggerable> triggered = triggerIndex.get(trigger);
                 if (triggered == null) {
-                    triggered = new ArrayList<>();
+                    triggered = new HashSet<>();
                     triggerIndex.put(trigger.clone(), triggered);
                 }
-                if (!triggered.contains(qt)) {
-                    triggered.add(qt);
-                }
+                triggered.add(qt);
             }
 
             return t;
@@ -452,7 +450,7 @@ public class TriggerableDag {
                 // so we'll be more inclusive than needed and see if any
                 // of our triggers are keyed on the predicate-less path
                 // of this ref
-                List<QuickTriggerable> triggered = triggerIndex.get(ref.hasPredicates() ? ref.removePredicates() : ref);
+                    Set<QuickTriggerable> triggered = triggerIndex.get(ref.hasPredicates() ? ref.removePredicates() : ref);
 
                 if (triggered != null) {
                     // If so, walk all of these triggerables that we
@@ -590,7 +588,7 @@ public class TriggerableDag {
         TreeReference genericRef = ref.genericize();
 
         // get triggerables which are activated by the generic reference
-        List<QuickTriggerable> triggered = triggerIndex.get(genericRef);
+        Set<QuickTriggerable> triggered = triggerIndex.get(genericRef);
         if (triggered == null) {
             return alreadyEvaluated;
         }
@@ -617,7 +615,7 @@ public class TriggerableDag {
         List<TreeReference> targets = new ArrayList<>();
         for (TreeReference trigger : triggerIndex.keySet()) {
             vertices.add(trigger);
-            List<QuickTriggerable> triggered = triggerIndex.get(trigger);
+            Set<QuickTriggerable> triggered = triggerIndex.get(trigger);
             targets.clear();
             for (QuickTriggerable qt : triggered) {
                 for (TreeReference target : qt.getTargets()) {

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -315,6 +315,16 @@ public class TriggerableDag {
     }
 
     // TODO We can avoid having to resolve dependant refs using the mainInstance by adding descendant refs as targets of relevance triggerables
+
+    /**
+     * Returns the list of edges in the DAG that can be built from the provided vertices.
+     * <p>
+     * This method has side-effects:
+     * <ul>
+     *     <li>Throws IllegalStateException when cycles are detected, either due to a self-reference or more complex cycle chains</li>
+     *     <li>Builds a cache of immediate cascades of each vertex, meaning that we will remember the dependant vertices without having to traverse the DAG again</li>
+     * </ul>
+     */
     private static List<QuickTriggerable[]> getDagEdges(FormInstance mainInstance, EvaluationContext evalContext, Set<QuickTriggerable> vertices, Map<TreeReference, Set<QuickTriggerable>> triggerIndex) {
         List<QuickTriggerable[]> edges = new ArrayList<>();
         for (QuickTriggerable vertex : vertices) {

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -447,18 +447,8 @@ public class TriggerableDag {
                 // of our triggers are keyed on the predicate-less path
                 // of this ref
                 Set<QuickTriggerable> triggered = triggerIndex.get(ref.hasPredicates() ? ref.removePredicates() : ref);
-
-                if (triggered != null) {
-                    // If so, walk all of these triggerables that we
-                    // found
-                    for (QuickTriggerable qu : triggered) {
-                        // And add them to the queue if they aren't
-                        // there already
-                            if (!dependantTriggerables.contains(qu)) {
-                            dependantTriggerables.add(qu);
-                        }
-                    }
-                }
+                    if (triggered != null)
+                        dependantTriggerables.addAll(triggered);
             }
         }
         return dependantTriggerables;

--- a/src/main/java/org/javarosa/core/model/condition/Condition.java
+++ b/src/main/java/org/javarosa/core/model/condition/Condition.java
@@ -42,7 +42,7 @@ public class Condition extends Triggerable {
     public Condition() {
     }
 
-    protected Condition(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, List<TreeReference> targets, Set<QuickTriggerable> immediateCascades, ConditionAction trueAction, ConditionAction falseAction) {
+    protected Condition(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades, ConditionAction trueAction, ConditionAction falseAction) {
         super(expr, contextRef, originalContextRef, targets, immediateCascades);
         this.trueAction = trueAction;
         this.falseAction = falseAction;

--- a/src/main/java/org/javarosa/core/model/condition/Condition.java
+++ b/src/main/java/org/javarosa/core/model/condition/Condition.java
@@ -19,7 +19,6 @@ package org.javarosa.core.model.condition;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 import org.javarosa.core.model.QuickTriggerable;
 import org.javarosa.core.model.instance.FormInstance;

--- a/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -41,7 +41,7 @@ public class Recalculate extends Triggerable {
 
     }
 
-    protected Recalculate(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, List<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
+    protected Recalculate(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
         super(expr, contextRef, originalContextRef, targets, immediateCascades);
     }
 

--- a/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -19,7 +19,6 @@ package org.javarosa.core.model.condition;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 import org.javarosa.core.model.QuickTriggerable;
 import org.javarosa.core.model.data.IAnswerData;

--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -171,8 +171,8 @@ public abstract class Triggerable implements Externalizable {
         return targets;
     }
 
-    public void changeContextRefToIntersectWithTriggerable(Triggerable t) {
-        contextRef = contextRef.intersect(t.contextRef);
+    public void intersectContextWith(Triggerable other) {
+        contextRef = contextRef.intersect(other.contextRef);
     }
 
     public TreeReference getContext() {

--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -58,7 +58,7 @@ public abstract class Triggerable implements Externalizable {
      * References to all of the (non-contextualized) nodes which should be
      * updated by the result of this triggerable
      */
-    protected List<TreeReference> targets;
+    protected Set<TreeReference> targets;
 
     /**
      * Current reference which is the "Basis" of the trigerrables being evaluated. This is the highest
@@ -79,7 +79,7 @@ public abstract class Triggerable implements Externalizable {
 
     }
 
-    protected Triggerable(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, List<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
+    protected Triggerable(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
         this.expr = expr;
         this.targets = targets;
         this.contextRef = contextRef;
@@ -88,11 +88,11 @@ public abstract class Triggerable implements Externalizable {
     }
 
     public static Triggerable condition(XPathConditional expr, ConditionAction trueAction, ConditionAction falseAction, TreeReference contextRef) {
-        return new Condition(expr, contextRef, contextRef, new ArrayList<>(), new HashSet<>(), trueAction, falseAction);
+        return new Condition(expr, contextRef, contextRef, new HashSet<>(), new HashSet<>(), trueAction, falseAction);
     }
 
     public static Triggerable recalculate(XPathConditional expr, TreeReference contextRef) {
-        return new Recalculate(expr, contextRef, contextRef, new ArrayList<>(), new HashSet<>());
+        return new Recalculate(expr, contextRef, contextRef, new HashSet<>(), new HashSet<>());
     }
 
     public abstract Object eval(FormInstance instance, EvaluationContext ec);
@@ -167,7 +167,7 @@ public abstract class Triggerable implements Externalizable {
         return affectedNodes;
     }
 
-    public List<TreeReference> getTargets() {
+    public Set<TreeReference> getTargets() {
         return targets;
     }
 
@@ -196,9 +196,7 @@ public abstract class Triggerable implements Externalizable {
     }
 
     public void addTarget(TreeReference target) {
-        if (targets.indexOf(target) == -1) {
-            targets.add(target);
-        }
+        targets.add(target);
     }
 
     @Override
@@ -242,7 +240,7 @@ public abstract class Triggerable implements Externalizable {
         expr = (XPathConditional) ExtUtil.read(in, new ExtWrapTagged(), pf);
         contextRef = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
         originalContextRef = (TreeReference) ExtUtil.read(in, TreeReference.class, pf);
-        targets = new ArrayList<>((List<TreeReference>) ExtUtil.read(in, new ExtWrapList(TreeReference.class), pf));
+        targets = new HashSet<>((List<TreeReference>) ExtUtil.read(in, new ExtWrapList(TreeReference.class), pf));
     }
 
     @Override

--- a/src/main/java/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/main/java/org/javarosa/xform/parse/FormInstanceParser.java
@@ -392,25 +392,23 @@ class FormInstanceParser {
             EvaluationContext ec = new EvaluationContext(instance);
             final List<TreeReference> nodes = ec.expandReference(ref, true);
 
-            if (nodes.size() > 0) {
-                if (bind.relevancyCondition != null) {
-                    bind.relevancyCondition.addTarget(ref);
-                    // Since relevancy can affect not only to individual fields, but also to
-                    // groups, we need to register all descendant refs as targets for relevancy
-                    // conditions to allow for chained reactions in triggerables registered in
-                    // any of those descendants
-                    for (TreeReference r : getDescendantRefs(instance, ec, ref))
-                        bind.relevancyCondition.addTarget(r);
-                }
-                if (bind.requiredCondition != null) {
-                    bind.requiredCondition.addTarget(ref);
-                }
-                if (bind.readonlyCondition != null) {
-                    bind.readonlyCondition.addTarget(ref);
-                }
-                if (bind.calculate != null) {
-                    bind.calculate.addTarget(ref);
-                }
+            if (bind.relevancyCondition != null) {
+                bind.relevancyCondition.addTarget(ref);
+                // Since relevancy can affect not only to individual fields, but also to
+                // groups, we need to register all descendant refs as targets for relevancy
+                // conditions to allow for chained reactions in triggerables registered in
+                // any of those descendants
+                for (TreeReference r : getDescendantRefs(instance, ec, ref))
+                    bind.relevancyCondition.addTarget(r);
+            }
+            if (bind.requiredCondition != null) {
+                bind.requiredCondition.addTarget(ref);
+            }
+            if (bind.readonlyCondition != null) {
+                bind.readonlyCondition.addTarget(ref);
+            }
+            if (bind.calculate != null) {
+                bind.calculate.addTarget(ref);
             }
             for (TreeReference nref : nodes) {
                 TreeElement node = instance.resolveReference(nref);

--- a/src/main/java/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/main/java/org/javarosa/xform/parse/FormInstanceParser.java
@@ -388,10 +388,11 @@ class FormInstanceParser {
 
     private void applyInstanceProperties(FormInstance instance) {
         for (DataBinding bind : bindings) {
-            final TreeReference ref = FormInstance.unpackReference(bind.getReference());
+            TreeReference ref = FormInstance.unpackReference(bind.getReference());
             EvaluationContext ec = new EvaluationContext(instance);
-            final List<TreeReference> nodes = ec.expandReference(ref, true);
+            List<TreeReference> nodeRefs = ec.expandReference(ref, true);
 
+            // Add triggerable targets if needed
             if (bind.relevancyCondition != null) {
                 bind.relevancyCondition.addTarget(ref);
                 // Since relevancy can affect not only to individual fields, but also to
@@ -401,31 +402,26 @@ class FormInstanceParser {
                 for (TreeReference r : getDescendantRefs(instance, ec, ref))
                     bind.relevancyCondition.addTarget(r);
             }
-            if (bind.requiredCondition != null) {
+            if (bind.requiredCondition != null)
                 bind.requiredCondition.addTarget(ref);
-            }
-            if (bind.readonlyCondition != null) {
+            if (bind.readonlyCondition != null)
                 bind.readonlyCondition.addTarget(ref);
-            }
-            if (bind.calculate != null) {
+            if (bind.calculate != null)
                 bind.calculate.addTarget(ref);
-            }
-            for (TreeReference nref : nodes) {
-                TreeElement node = instance.resolveReference(nref);
+
+            // Initialize present nodes under the provided ref
+            for (TreeReference nodeRef : nodeRefs) {
+                TreeElement node = instance.resolveReference(nodeRef);
                 node.setDataType(bind.getDataType());
 
-                if (bind.relevancyCondition == null) {
+                if (bind.relevancyCondition == null)
                     node.setRelevant(bind.relevantAbsolute);
-                }
-                if (bind.requiredCondition == null) {
+                if (bind.requiredCondition == null)
                     node.setRequired(bind.requiredAbsolute);
-                }
-                if (bind.readonlyCondition == null) {
+                if (bind.readonlyCondition == null)
                     node.setEnabled(!bind.readonlyAbsolute);
-                }
-                if (bind.constraint != null) {
+                if (bind.constraint != null)
                     node.setConstraint(new Constraint(bind.constraint, bind.constraintMessage));
-                }
 
                 node.setPreloadHandler(bind.getPreload());
                 node.setPreloadParams(bind.getPreloadParams());

--- a/src/main/java/org/javarosa/xform/parse/FormInstanceParser.java
+++ b/src/main/java/org/javarosa/xform/parse/FormInstanceParser.java
@@ -393,25 +393,23 @@ class FormInstanceParser {
             final List<TreeReference> nodes = ec.expandReference(ref, true);
 
             if (nodes.size() > 0) {
-                TreeReference ref1 = FormInstance.unpackReference(bind.getReference());
-
                 if (bind.relevancyCondition != null) {
-                    bind.relevancyCondition.addTarget(ref1);
+                    bind.relevancyCondition.addTarget(ref);
                     // Since relevancy can affect not only to individual fields, but also to
                     // groups, we need to register all descendant refs as targets for relevancy
                     // conditions to allow for chained reactions in triggerables registered in
                     // any of those descendants
-                    for (TreeReference r : getDescendantRefs(instance, ec, ref1))
+                    for (TreeReference r : getDescendantRefs(instance, ec, ref))
                         bind.relevancyCondition.addTarget(r);
                 }
                 if (bind.requiredCondition != null) {
-                    bind.requiredCondition.addTarget(ref1);
+                    bind.requiredCondition.addTarget(ref);
                 }
                 if (bind.readonlyCondition != null) {
-                    bind.readonlyCondition.addTarget(ref1);
+                    bind.readonlyCondition.addTarget(ref);
                 }
                 if (bind.calculate != null) {
-                    bind.calculate.addTarget(ref1);
+                    bind.calculate.addTarget(ref);
                 }
             }
             for (TreeReference nref : nodes) {

--- a/src/main/java/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
+++ b/src/main/java/org/javarosa/xform/parse/StandardBindAttributesProcessor.java
@@ -59,9 +59,7 @@ class StandardBindAttributesProcessor {
             } else if ("false()".equals(xpathRel)) {
                 binding.relevantAbsolute = false;
             } else {
-                Triggerable c = buildCondition(xpathRel, "relevant", ref);
-                c = formDef.addTriggerable(c);
-                binding.relevancyCondition = c;
+                binding.relevancyCondition = formDef.addTriggerable(buildCondition(xpathRel, "relevant", ref));
             }
         }
 
@@ -72,9 +70,7 @@ class StandardBindAttributesProcessor {
             } else if ("false()".equals(xpathReq)) {
                 binding.requiredAbsolute = false;
             } else {
-                Triggerable c = buildCondition(xpathReq, "required", ref);
-                c = formDef.addTriggerable(c);
-                binding.requiredCondition = c;
+                binding.requiredCondition = formDef.addTriggerable(buildCondition(xpathReq, "required", ref));
             }
         }
 
@@ -85,9 +81,7 @@ class StandardBindAttributesProcessor {
             } else if ("false()".equals(xpathRO)) {
                 binding.readonlyAbsolute = false;
             } else {
-                Triggerable c = buildCondition(xpathRO, "readonly", ref);
-                c = formDef.addTriggerable(c);
-                binding.readonlyCondition = c;
+                binding.readonlyCondition = formDef.addTriggerable(buildCondition(xpathRO, "readonly", ref));
             }
         }
 
@@ -104,15 +98,13 @@ class StandardBindAttributesProcessor {
 
         final String xpathCalc = element.getAttributeValue(null, "calculate");
         if (xpathCalc != null) {
-            Triggerable r;
             try {
-                r = buildCalculate(xpathCalc, ref);
+                binding.calculate = formDef.addTriggerable(buildCalculate(xpathCalc, ref));
             } catch (XPathSyntaxException xpse) {
                 throw new XFormParseException("Invalid calculate for the bind attached to \"" + nodeset +
                     "\" : " + xpse.getMessage() + " in expression " + xpathCalc);
             }
-            r = formDef.addTriggerable(r);
-            binding.calculate = r;
+
         }
 
         binding.setPreload(element.getAttributeValue(NAMESPACE_JAVAROSA, "preload"));


### PR DESCRIPTION
This PR is built on top of #523 and brings a performance improvement during the DAG build process.
 It starts on 88874a6e053ffb7ecbafa1cb728e1932c216e74c

#### What has been done to verify that this works as intended?
Run automated tests

#### Why is this the best possible solution? Were any other approaches considered?
Before this PR, we used to hit the main instance to get descendant references of each triggerable, which is potentially a slow process.

The main reason behind this PR is that we should be able to build a descendant tree of triggerables with the information that they already have (their target refs) and the triggerable index the DAG stores.

We have established that doing so breaks some trigger chains when a group has relevance conditions. This has been solved by adding all the group's descedant refs as targets of the relevance condition.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should be no behavior change.

Performance-wise, the changes should be safe, if not faster than the original code, although no benchmarking has been done.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.