### PR TITLE
Issue 534 fix date utils test

### DIFF
--- a/src/test/java/org/javarosa/core/model/data/test/TimeDataLimitationsTest.java
+++ b/src/test/java/org/javarosa/core/model/data/test/TimeDataLimitationsTest.java
@@ -1,63 +1,54 @@
 package org.javarosa.core.model.data.test;
 
-import org.javarosa.core.model.data.TimeData;
-import org.javarosa.core.model.utils.DateUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import java.util.Date;
-import java.util.TimeZone;
-
+import static org.javarosa.test.utils.SystemHelper.withTimeZone;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Date;
+import java.util.TimeZone;
+import org.javarosa.core.model.data.TimeData;
+import org.javarosa.core.model.utils.DateUtils;
+import org.junit.Test;
+
 /**
- This test is intended to show the limitation of {@link TimeData}.
-
- Using this data type in countries which change their time (summer/winter - DST) will cause that forms saved during
- wintertime and then edited during summertime (and vice versa) will be treated as saved in a neighbor's timezone.
- It's because we have just time and time offset like: 10:00:00.000+02:00 but we don't know when the form has been
- saved so we parse it using the current date.
-
- Example:
- If we saved 10:00:00.000+02:00 during summertime (in Poland) and we are editing the form during winter time our
- timezone is +01:00 not +02:00. As mentioned above javarosa doesn't know that the form has been saved in the same location
- but different timezone because of DST so it treats the value like saved in the neighbor timezone
- (in Kiev or London for example).
-
- Related issues:
- https://github.com/opendatakit/javarosa/pull/478
- https://github.com/opendatakit/collect/issues/170
+ * This test is intended to show the limitation of {@link TimeData}.
+ * <p>
+ * Using this data type in countries which change their time (summer/winter - DST) will cause that forms saved during
+ * wintertime and then edited during summertime (and vice versa) will be treated as saved in a neighbor's timezone.
+ * It's because we have just time and time offset like: 10:00:00.000+02:00 but we don't know when the form has been
+ * saved so we parse it using the current date.
+ * <p>
+ * Example:
+ * If we saved 10:00:00.000+02:00 during summertime (in Poland) and we are editing the form during winter time our
+ * timezone is +01:00 not +02:00. As mentioned above javarosa doesn't know that the form has been saved in the same location
+ * but different timezone because of DST so it treats the value like saved in the neighbor timezone
+ * (in Kiev or London for example).
+ * <p>
+ * Related issues:
+ * https://github.com/opendatakit/javarosa/pull/478
+ * https://github.com/opendatakit/collect/issues/170
  */
 public class TimeDataLimitationsTest {
-
-    private TimeZone backupTimeZone;
-
-    @Before
-    public void setUp() {
-        backupTimeZone = TimeZone.getDefault();
-    }
-
-    @After
-    public void tearDown() {
-        TimeZone.setDefault(backupTimeZone);
-    }
+    public static final TimeZone WARSAW = TimeZone.getTimeZone("Europe/Warsaw");
+    public static final TimeZone KIEV = TimeZone.getTimeZone("Europe/Kiev");
 
     @Test
     public void editingFormsSavedInDifferentTimezoneTest() {
+        StringWrapper savedTime = StringWrapper.empty();
         // A user is in Warsaw (GMT+2) saved a form with the time question
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
+        withTimeZone(WARSAW, () -> {
+            boolean isSummerTime = TimeZone.getDefault().inDaylightTime(new Date());
+            savedTime.set(isSummerTime ? "10:00:00.000+02:00" : "10:00:00.000+01:00");
 
-        boolean isSummerTime = TimeZone.getDefault().inDaylightTime(new Date());
-        String savedTime = isSummerTime ? "10:00:00.000+02:00" : "10:00:00.000+01:00";
-
-        // A user opens saved form in Warsaw as well - the hour should be the same
-        TimeData timeData = new TimeData(DateUtils.parseTime(savedTime));
-        assertEquals("10:00", timeData.getDisplayText());
-
+            // A user opens saved form in Warsaw as well - the hour should be the same
+            TimeData timeData = new TimeData(DateUtils.parseTime(savedTime.get()));
+            assertEquals("10:00", timeData.getDisplayText());
+        });
         // A user travels to Kiev (GMT+3) and opens the saved form again - the hour should be edited +1h
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Kiev"));
-        timeData = new TimeData(DateUtils.parseTime(savedTime));
-        assertEquals("11:00", timeData.getDisplayText());
+        withTimeZone(KIEV, () -> {
+            TimeData timeData = new TimeData(DateUtils.parseTime(savedTime.get()));
+            assertEquals("11:00", timeData.getDisplayText());
+        });
+
     }
 
     @Test
@@ -67,17 +58,37 @@ public class TimeDataLimitationsTest {
         dateFields.month = 8;
         dateFields.day = 1;
 
-        // A user is in Warsaw (during summer time - GMT+2) and saved a form with the time question
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
-        String savedTime = "10:00:00.000+02:00";
+        withTimeZone(WARSAW, () -> {
+            String savedTime = "10:00:00.000+02:00";
 
-        // A user opens saved form in Warsaw and during summertime as well - the hour should be the same
-        TimeData timeData = new TimeData(DateUtils.parseTimeWithFixedDate(savedTime, dateFields));
-        assertEquals("10:00", timeData.getDisplayText());
+            // A user opens saved form in Warsaw and during summertime as well - the hour should be the same
+            TimeData timeData = new TimeData(DateUtils.parseTimeWithFixedDate(savedTime, dateFields));
+            assertEquals("10:00", timeData.getDisplayText());
 
-        // A user opens saved form in Warsaw as well but during wintertime - the hour is edited -1h (the mentioned limitation)
-        dateFields.month = 12;
-        timeData = new TimeData(DateUtils.parseTimeWithFixedDate(savedTime, dateFields));
-        assertEquals("09:00", timeData.getDisplayText());
+            // A user opens saved form in Warsaw as well but during wintertime - the hour is edited -1h (the mentioned limitation)
+            dateFields.month = 12;
+            timeData = new TimeData(DateUtils.parseTimeWithFixedDate(savedTime, dateFields));
+            assertEquals("09:00", timeData.getDisplayText());
+        });
+    }
+
+    static class StringWrapper {
+        private String value;
+
+        StringWrapper(String value) {
+            this.value = value;
+        }
+
+        static StringWrapper empty() {
+            return new StringWrapper("");
+        }
+
+        public String get() {
+            return value;
+        }
+
+        public void set(String value) {
+            this.value = value;
+        }
     }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatLocalizationTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatLocalizationTests.java
@@ -18,15 +18,15 @@ package org.javarosa.core.model.utils.test;
 
 import static java.time.DayOfWeek.SUNDAY;
 import static java.time.Month.JANUARY;
+import static java.time.format.TextStyle.SHORT;
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.test.utils.SystemHelper.withLocale;
 import static org.junit.Assert.assertThat;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.TextStyle;
 import java.util.Date;
 import java.util.Locale;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.javarosa.core.model.utils.DateUtils;
 import org.junit.Test;
@@ -43,15 +43,9 @@ public class DateUtilsFormatLocalizationTests {
             Locale.forLanguageTag("es-ES"),
             Locale.FRENCH
         ).forEach(locale -> withLocale(locale, l -> {
-            assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, l)));
-            assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, l)));
+            assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(SHORT, l)));
+            assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(SHORT, l)));
         }));
     }
 
-    public void withLocale(Locale locale, Consumer<Locale> block) {
-        Locale backupLocale = Locale.getDefault();
-        Locale.setDefault(locale);
-        block.accept(locale);
-        Locale.setDefault(backupLocale);
-    }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatLocalizationTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatLocalizationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009 JavaRosa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.javarosa.core.model.utils.test;
+
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.Month.JANUARY;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
+import static org.junit.Assert.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.TextStyle;
+import java.util.Date;
+import java.util.Locale;
+import java.util.function.Consumer;
+import org.javarosa.core.model.utils.DateUtils;
+import org.junit.Test;
+
+public class DateUtilsFormatLocalizationTests {
+    @Test
+    public void format_is_localized() {
+        class LangJanSun {
+            private LangJanSun(Locale locale) {
+                this.locale = locale;
+            }
+
+            private Locale locale;
+        }
+
+        LangJanSun langJanSuns[] = new LangJanSun[]{
+            new LangJanSun(Locale.ENGLISH),
+            new LangJanSun(Locale.forLanguageTag("es-ES")),
+            new LangJanSun(Locale.FRENCH)
+        };
+
+        // Use a Sunday in January for our test
+        LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
+        Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
+
+        for (LangJanSun ljs : langJanSuns) {
+            withLocale(ljs.locale, locale -> {
+                assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, locale)));
+                assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, locale)));
+            });
+        }
+    }
+
+    public void withLocale(Locale locale, Consumer<Locale> block) {
+        Locale backupLocale = Locale.getDefault();
+        Locale.setDefault(locale);
+        block.accept(locale);
+        Locale.setDefault(backupLocale);
+    }
+}

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatLocalizationTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatLocalizationTests.java
@@ -19,46 +19,33 @@ package org.javarosa.core.model.utils.test;
 import static java.time.DayOfWeek.SUNDAY;
 import static java.time.Month.JANUARY;
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
 import static org.junit.Assert.assertThat;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.TextStyle;
 import java.util.Date;
 import java.util.Locale;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.javarosa.core.model.utils.DateUtils;
 import org.junit.Test;
 
 public class DateUtilsFormatLocalizationTests {
     @Test
     public void format_is_localized() {
-        class LangJanSun {
-            private LangJanSun(Locale locale) {
-                this.locale = locale;
-            }
-
-            private Locale locale;
-        }
-
-        LangJanSun langJanSuns[] = new LangJanSun[]{
-            new LangJanSun(Locale.ENGLISH),
-            new LangJanSun(Locale.forLanguageTag("es-ES")),
-            new LangJanSun(Locale.FRENCH)
-        };
-
         // Use a Sunday in January for our test
         LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
         Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
 
-        for (LangJanSun ljs : langJanSuns) {
-            withLocale(ljs.locale, locale -> {
-                assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, locale)));
-                assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, locale)));
-            });
-        }
+        Stream.of(
+            Locale.ENGLISH,
+            Locale.forLanguageTag("es-ES"),
+            Locale.FRENCH
+        ).forEach(locale -> withLocale(locale, l -> {
+            assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, l)));
+            assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, l)));
+        }));
     }
 
     public void withLocale(Locale locale, Consumer<Locale> block) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatSanityCheckTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatSanityCheckTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2009 JavaRosa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.javarosa.core.model.utils.test;
+
+import static java.util.TimeZone.getTimeZone;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.utils.DateUtils.FORMAT_ISO8601;
+import static org.javarosa.core.model.utils.DateUtils.formatDateTime;
+import static org.javarosa.core.model.utils.DateUtils.parseDateTime;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class DateUtilsFormatSanityCheckTests {
+    @Parameterized.Parameter(value = 0)
+    public long inputTimestamp;
+
+    @Parameterized.Parameters(name = "Input timestamp: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {1300139579000L},
+            {0}
+        });
+    }
+
+    @Test
+    public void sanity_check_iso_format_and_parse_back() {
+        Date input = new Date(inputTimestamp);
+        Stream.of(
+            TimeZone.getDefault(),
+            getTimeZone("UTC"),
+            getTimeZone("GMT+12"),
+            getTimeZone("GMT-13"),
+            getTimeZone("GMT+0230")
+        ).forEach(timeZone -> withTimeZone(timeZone, () ->
+            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input))));
+    }
+
+    private void withTimeZone(TimeZone timeZone, Runnable block) {
+        TimeZone backupZone = TimeZone.getDefault();
+        TimeZone.setDefault(timeZone);
+        block.run();
+        TimeZone.setDefault(backupZone);
+    }
+}

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatSanityCheckTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsFormatSanityCheckTests.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.utils.DateUtils.FORMAT_ISO8601;
 import static org.javarosa.core.model.utils.DateUtils.formatDateTime;
 import static org.javarosa.core.model.utils.DateUtils.parseDateTime;
+import static org.javarosa.test.utils.SystemHelper.withTimeZone;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -56,12 +57,5 @@ public class DateUtilsFormatSanityCheckTests {
             getTimeZone("GMT+0230")
         ).forEach(timeZone -> withTimeZone(timeZone, () ->
             assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input))));
-    }
-
-    private void withTimeZone(TimeZone timeZone, Runnable block) {
-        TimeZone backupZone = TimeZone.getDefault();
-        TimeZone.setDefault(timeZone);
-        block.run();
-        TimeZone.setDefault(backupZone);
     }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsGetXmlStringValueTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsGetXmlStringValueTest.java
@@ -34,7 +34,7 @@ public class DateUtilsGetXmlStringValueTest {
      * parsed by LocalDate.parse()
      */
     @Test
-    public void testGetXMLStringValueFormat() {
+    public void xml_string_is_well_formatted() {
         LocalDateTime nowDateTime = LocalDateTime.now();
         Date nowDate = Date.from(nowDateTime.toInstant(OffsetDateTime.now().getOffset()));
         String nowXmlFormatterDate = getXMLStringValue(nowDate);

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsGetXmlStringValueTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsGetXmlStringValueTest.java
@@ -26,7 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import org.junit.Test;
 
-public class DateUtilsTests {
+public class DateUtilsGetXmlStringValueTest {
     /**
      * This test ensures that the Strings returned
      * by the getXMLStringValue function are in

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2009 JavaRosa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.javarosa.core.model.utils.test;
+
+import static java.util.TimeZone.getTimeZone;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+import org.javarosa.core.model.utils.DateUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class DateUtilsParseDateTimeTests {
+    @Parameterized.Parameter(value = 0)
+    public String input;
+
+    @Parameterized.Parameter(value = 1)
+    public Temporal expectedDateTime;
+
+    @Parameterized.Parameters(name = "Input: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"2016-04-13T16:26:00.000-07", OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")},
+            {"2015-12-16T16:09:00.000-08", OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00")},
+            {"2015-12-16T07:09:00.000+08", OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00")},
+            {"2015-11-30T16:09:00.000-08", OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00")},
+            {"2015-11-01T07:09:00.000+08", OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00")},
+            {"2015-12-31T16:09:00.000-08", OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00")},
+        });
+    }
+
+    @Test
+    public void testTimeParses() {
+        Stream.of(
+            TimeZone.getDefault(),
+            getTimeZone("UTC"),
+            getTimeZone("GMT+12"),
+            getTimeZone("GMT-13"),
+            getTimeZone("GMT+0230")
+        ).forEach(tz -> withTimeZone(tz, () -> assertThat(parseDateTime(input), is(expectedDateTime))));
+    }
+
+    private void withTimeZone(TimeZone timeZone, Runnable block) {
+        TimeZone backupZone = TimeZone.getDefault();
+        TimeZone.setDefault(timeZone);
+        block.run();
+        TimeZone.setDefault(backupZone);
+    }
+
+    /**
+     * Returns a LocalDateTime or an OffsetTimeTime obtained from the result of
+     * calling DateUtils.parseDateTime() with the provided input, ensuring that
+     * both represent the same instant.
+     */
+    private Temporal parseDateTime(String input) {
+        Instant inputInstant = Objects.requireNonNull(DateUtils.parseDateTime(input)).toInstant();
+
+        String timePart = input.substring(11);
+        if (timePart.contains("+") || timePart.contains("-")) {
+            // The input declares some positive or negative time offset
+            int beginOfOffsetPart = timePart.contains("+") ? timePart.indexOf("+") : timePart.indexOf("-");
+            String offsetPart = timePart.substring(beginOfOffsetPart);
+            // The input declares some positive or negative time offset
+            String offset = offsetPart.length() == 3 ? offsetPart + ":00" : offsetPart;
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of(offset));
+        }
+
+        if (input.endsWith("Z"))
+            // The input time is at UTC
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of("Z"));
+
+        // No time offset declared. Return a LocalTime
+        return LocalDateTime.ofInstant(inputInstant, ZoneId.systemDefault());
+    }
+}

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
@@ -18,6 +18,7 @@ package org.javarosa.core.model.utils.test;
 
 import static java.util.TimeZone.getTimeZone;
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.test.utils.SystemHelper.withTimeZone;
 import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
@@ -57,7 +58,7 @@ public class DateUtilsParseDateTimeTests {
     }
 
     @Test
-    public void testTimeParses() {
+    public void parseDateTime_produces_expected_results_in_all_time_zones() {
         Stream.of(
             TimeZone.getDefault(),
             getTimeZone("UTC"),
@@ -65,13 +66,6 @@ public class DateUtilsParseDateTimeTests {
             getTimeZone("GMT-13"),
             getTimeZone("GMT+0230")
         ).forEach(tz -> withTimeZone(tz, () -> assertThat(parseDateTime(input), is(expectedDateTime))));
-    }
-
-    private void withTimeZone(TimeZone timeZone, Runnable block) {
-        TimeZone backupZone = TimeZone.getDefault();
-        TimeZone.setDefault(timeZone);
-        block.run();
-        TimeZone.setDefault(backupZone);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
@@ -46,6 +46,7 @@ public class DateUtilsParseDateTimeTests {
     @Parameterized.Parameters(name = "Input: {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
+            {"2016-04-13T16:26:00.000", LocalDateTime.parse("2016-04-13T16:26:00.000")},
             {"2016-04-13T16:26:00.000-07", OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")},
             {"2015-12-16T16:09:00.000-08", OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00")},
             {"2015-12-16T07:09:00.000+08", OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00")},

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseTimeTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseTimeTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2009 JavaRosa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.javarosa.core.model.utils.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+import org.javarosa.core.model.utils.DateUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class DateUtilsParseTimeTests {
+    private Locale backupLocale;
+    private TimeZone backupZone;
+
+    @Parameterized.Parameter(value = 0)
+    public String input;
+
+    @Parameterized.Parameter(value = 1)
+    public Temporal expectedTime;
+
+    @Parameterized.Parameters(name = "Input: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"14:00", LocalTime.parse("14:00")},
+            {"14:00Z", OffsetTime.parse("14:00Z")},
+            {"14:00+02", OffsetTime.parse("14:00+02:00")},
+            {"14:00-02", OffsetTime.parse("14:00-02:00")},
+            {"14:00+02:30", OffsetTime.parse("14:00+02:30")},
+            {"14:00-02:30", OffsetTime.parse("14:00-02:30")},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        backupLocale = Locale.getDefault();
+        backupZone = TimeZone.getDefault();
+    }
+
+    @After
+    public void tearDown() {
+        TimeZone.setDefault(backupZone);
+        Locale.setDefault(backupLocale);
+    }
+
+    @Test
+    public void testTimeParses() {
+        // The tricky part of DateUtils.parseTime is that we allow for input time
+        // values to include time offset declarations, which has issues at different
+        // levels:
+        // - Conceptually, time values with offsets don't make sense until they're
+        //   paired with a date so, how can we reason about what "10:00+02:00" means,
+        //   and what should be a valid expected output for that input value?
+        // - Next, DateUtils.parseTime() produces Date values, which are a date and a
+        //   time in the system's default time zone. Then, which date would we have to
+        //   expect?
+        //
+        // To solve these issues, DateUtils.parseTime() will use the system's current
+        // date as a base for its output value whenever that is and whichever time zone
+        // the system's at.
+        //
+        // By testing parseTime under different system default time zones we're trying
+        // to have the confidence that our resulting Date objects will always translate
+        // to the same time declaration from the input string (ignoring their date part,
+        // of course).
+        Stream.of(
+            TimeZone.getTimeZone("UTC"),
+            TimeZone.getTimeZone("GMT+12"),
+            TimeZone.getTimeZone("GMT-13"),
+            TimeZone.getTimeZone("GMT+0230")
+        ).forEach(timeZone -> {
+            TimeZone backupZone = TimeZone.getDefault();
+            TimeZone.setDefault(timeZone);
+            assertThat(parseTime(input), is(expectedTime));
+            TimeZone.setDefault(backupZone);
+        });
+    }
+
+    /**
+     * Returns a LocalTime or a OffsetTime obtained from the result of
+     * calling DateUtils.parseTime() with the provided input.
+     * <p>
+     * The interim OffsetDateTime value ensures that it represents the
+     * same instant as the Date from the call to DateUtils.parseTime().
+     */
+    public Temporal parseTime(String input) {
+        Instant inputInstant = Objects.requireNonNull(DateUtils.parseTime(input)).toInstant();
+
+        // No time offset declared. Return a LocalTime
+        if (input.length() == 5)
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.systemDefault()).toLocalTime();
+
+        // The input time is at UTC
+        if (input.charAt(5) == 'Z')
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of("Z")).toOffsetTime();
+
+        // The input declares some positive or negative time offset
+        String offsetPart = input.substring(5);
+        // Fix for unparseable short offset notations such as +02
+        String offset = offsetPart.length() == 3 ? offsetPart + ":00" : offsetPart;
+        return OffsetDateTime.ofInstant(inputInstant, ZoneId.of(offset)).toOffsetTime();
+    }
+}

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseTimeTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseTimeTests.java
@@ -18,6 +18,7 @@ package org.javarosa.core.model.utils.test;
 
 import static java.util.TimeZone.getTimeZone;
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.test.utils.SystemHelper.withTimeZone;
 import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
@@ -58,7 +59,7 @@ public class DateUtilsParseTimeTests {
     }
 
     @Test
-    public void testTimeParses() {
+    public void parseTime_produces_expected_results_in_all_time_zones() {
         // The tricky part of DateUtils.parseTime is that we allow for input time
         // values to include time offset declarations, which has issues at different
         // levels:
@@ -84,13 +85,6 @@ public class DateUtilsParseTimeTests {
             getTimeZone("GMT-13"),
             getTimeZone("GMT+0230")
         ).forEach(tz -> withTimeZone(tz, () -> assertThat(parseTime(input), is(expectedTime))));
-    }
-
-    private void withTimeZone(TimeZone timeZone, Runnable block) {
-        TimeZone backupZone = TimeZone.getDefault();
-        TimeZone.setDefault(timeZone);
-        block.run();
-        TimeZone.setDefault(backupZone);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsSCTOTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsSCTOTests.java
@@ -6,67 +6,50 @@
 
 package org.javarosa.core.model.utils.test;
 
+import static org.javarosa.test.utils.SystemHelper.withTimeZone;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Locale;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class DateUtilsSCTOTests {
 
-    private Locale backupLocale;
-    private TimeZone backupZone;
-
-    @Before
-    public void setUp() {
-        backupLocale = Locale.getDefault();
-        backupZone = TimeZone.getDefault();
-    }
-
-    @After
-    public void tearDown() {
-        TimeZone.setDefault(backupZone);
-        Locale.setDefault(backupLocale);
-    }
-
     @Test
     public void testParseDateTime() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT+02"));
+        withTimeZone(TimeZone.getTimeZone("GMT+02"), () -> {
+            Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
+            String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
 
-        Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
-        String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
-
-        assertEquals("2014-10-04T23:03:05.244+02:00", str);
+            assertEquals("2014-10-04T23:03:05.244+02:00", str);
+        });
     }
 
     @Test
     public void testParseDateTime_withDST() {
-        applyDST();
+        withTimeZone(buildDstTimeZone(), () -> {
+            Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
+            String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
 
-        Date date = DateUtils.parseDateTime("2014-10-05T00:03:05.244+03");
-        String str = DateUtils.formatDateTime(date, DateUtils.FORMAT_ISO8601);
-
-        assertEquals("2014-10-05T00:03:05.244+03:00", str);
+            assertEquals("2014-10-05T00:03:05.244+03:00", str);
+        });
     }
 
     @Test
     public void testParseTime() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT+02"));
+        withTimeZone(TimeZone.getTimeZone("GMT+02"), () -> {
+            String time = "12:03:05.011+03";
 
-        String time = "12:03:05.011+03";
+            Date date = DateUtils.parseTime(time);
 
-        Date date = DateUtils.parseTime(time);
+            String formatted = DateUtils.formatTime(date, DateUtils.FORMAT_ISO8601);
 
-        String formatted = DateUtils.formatTime(date, DateUtils.FORMAT_ISO8601);
-
-        assertEquals("11:03:05.011+02:00", formatted);
+            assertEquals("11:03:05.011+02:00", formatted);
+        });
     }
 
     @Test
@@ -77,27 +60,25 @@ public class DateUtilsSCTOTests {
     // - We're effectively binding all times to the EPOCH date
     //   (1970-01-01, UTC), which has no DST
     public void testParseTime_withDST() {
-        applyDST();
+        withTimeZone(buildDstTimeZone(), () -> {
+            String time = "12:03:05.011+03";
 
-        String time = "12:03:05.011+03";
+            Date date = DateUtils.parseTime(time);
 
-        Date date = DateUtils.parseTime(time);
+            String formatted = DateUtils.formatTime(date, DateUtils.FORMAT_ISO8601);
 
-        String formatted = DateUtils.formatTime(date, DateUtils.FORMAT_ISO8601);
-
-        assertEquals("12:03:05.011+03", formatted);
+            assertEquals("12:03:05.011+03", formatted);
+        });
     }
 
-    private void applyDST() {
-        // this is a timezone that operates DST every day of the year!
-        SimpleTimeZone dstTimezone = new SimpleTimeZone(
-                2 * 60 * 60 * 1000,
-                "Europe/Athens",
-                Calendar.JANUARY, 1, 0,
-                0, SimpleTimeZone.UTC_TIME,
-                Calendar.DECEMBER, 31, 0,
-                24 * 60 * 60 * 1000, SimpleTimeZone.UTC_TIME,
-                60 * 60 * 1000);
-        TimeZone.setDefault(dstTimezone);
+    private SimpleTimeZone buildDstTimeZone() {
+        return new SimpleTimeZone(
+            2 * 60 * 60 * 1000,
+            "Europe/Athens",
+            Calendar.JANUARY, 1, 0,
+            0, SimpleTimeZone.UTC_TIME,
+            Calendar.DECEMBER, 31, 0,
+            24 * 60 * 60 * 1000, SimpleTimeZone.UTC_TIME,
+            60 * 60 * 1000);
     }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -29,29 +29,10 @@ import java.time.OffsetDateTime;
 import java.time.format.TextStyle;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class DateUtilsTests {
-    private Locale backupLocale;
-    private TimeZone backupZone;
-
-    @Before
-    public void setUp() {
-        backupLocale = Locale.getDefault();
-        backupZone = TimeZone.getDefault();
-
-    }
-
-    @After
-    public void tearDown() {
-        TimeZone.setDefault(backupZone);
-        Locale.setDefault(backupLocale);
-    }
-
     /**
      * This test ensures that the Strings returned
      * by the getXMLStringValue function are in
@@ -87,17 +68,24 @@ public class DateUtilsTests {
         };
 
         for (LangJanSun ljs : langJanSuns) {
-            Locale.setDefault(ljs.locale);
+            withLocale(ljs.locale, () -> {
+                // Use a Sunday in January for our test
+                LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
+                Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
 
-            // Use a Sunday in January for our test
-            LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
-            Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
+                String month = DateUtils.format(date, "%b");
+                assertEquals(ljs.january, month);
 
-            String month = DateUtils.format(date, "%b");
-            assertEquals(ljs.january, month);
-
-            String day = DateUtils.format(date, "%a");
-            assertEquals(ljs.sunday, day);
+                String day = DateUtils.format(date, "%a");
+                assertEquals(ljs.sunday, day);
+            });
         }
+    }
+
+    public void withLocale(Locale locale, Runnable block) {
+        Locale backupLocale = Locale.getDefault();
+        Locale.setDefault(locale);
+        block.run();
+        Locale.setDefault(backupLocale);
     }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,16 +16,22 @@
 
 package org.javarosa.core.model.utils.test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.text.DateFormat;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
@@ -126,75 +132,87 @@ public class DateUtilsTests {
 
     @Test
     public void testTimeParses() {
-        //This is all kind of tricky. We need to assume J2ME level compliance, so
-        //dates won't every be assumed to have an intrinsic timezone, they'll be
-        //assumed to be in the phone's default timezone
+        // The tricky part of DateUtils.parseTime is that we allow for input time
+        // values to include time offset declarations, which has issues at different
+        // levels:
+        // - Conceptually, time values with offsets don't make sense until they're
+        //   paired with a date so, how can we reason about what "10:00+02:00" means,
+        //   and what should be a valid expected output for that input value?
+        // - Next, DateUtils.parseTime() produces Date values, which are a date and a
+        //   time in the system's default time zone. Then, which date would we have to
+        //   expect?
+        //
+        // To solve these issues, DateUtils.parseTime() will use the system's current
+        // date as a base for its output value whenever that is and whichever time zone
+        // the system's at.
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        long startOfDayDate = getTodayStartOfDayUTCEpoch();
-
-        testTime("10:00", startOfDayDate + 1000 * 60 * 60 * 10 - getOffset());
-        testTime("10:00Z", startOfDayDate + 1000 * 60 * 60 * 10);
-
-        testTime("10:00+02", startOfDayDate + 1000 * 60 * 60 * 8);
-        testTime("10:00-02", startOfDayDate + 1000 * 60 * 60 * 12);
-
-        testTime("10:00+02:30", startOfDayDate + 1000 * 60 * (60 * 10 - 150));
-        testTime("10:00-02:30", startOfDayDate + 1000 * 60 * (60 * 10 + 150));
+        assertThat(parseTime("14:00"), is(LocalTime.parse("14:00")));
+        assertThat(parseTime("14:00Z"), is(OffsetTime.parse("14:00Z")));
+        assertThat(parseTime("14:00+02"), is(OffsetTime.parse("14:00+02:00")));
+        assertThat(parseTime("14:00-02"), is(OffsetTime.parse("14:00-02:00")));
+        assertThat(parseTime("14:00+02:30"), is(OffsetTime.parse("14:00+02:30")));
+        assertThat(parseTime("14:00-02:30"), is(OffsetTime.parse("14:00-02:30")));
 
         TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+12");
 
         TimeZone.setDefault(offsetTwoHours);
 
-        startOfDayDate = getTodayStartOfDayUTCEpoch();
-
-
-        testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
-
-        testTime("14:00+02", startOfDayDate + 1000 * 60 * 60 * 12);
-        testTime("14:00-02", startOfDayDate + 1000 * 60 * 60 * 16);
-
-        testTime("14:00+02:30", startOfDayDate + 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
+        assertThat(parseTime("14:00"), is(LocalTime.parse("14:00")));
+        assertThat(parseTime("14:00Z"), is(OffsetTime.parse("14:00Z")));
+        assertThat(parseTime("14:00+02"), is(OffsetTime.parse("14:00+02:00")));
+        assertThat(parseTime("14:00-02"), is(OffsetTime.parse("14:00-02:00")));
+        assertThat(parseTime("14:00+02:30"), is(OffsetTime.parse("14:00+02:30")));
+        assertThat(parseTime("14:00-02:30"), is(OffsetTime.parse("14:00-02:30")));
 
         TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-13");
 
         TimeZone.setDefault(offsetMinusTwoHours);
 
-        startOfDayDate = getTodayStartOfDayUTCEpoch();
-
-        testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
-
-        testTime("14:00+02", startOfDayDate + 1000 * 60 * 60 * 12);
-        testTime("14:00-02", startOfDayDate + 1000 * 60 * 60 * 16);
-
-        testTime("14:00+02:30", startOfDayDate + 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
-
+        assertThat(parseTime("14:00"), is(LocalTime.parse("14:00")));
+        assertThat(parseTime("14:00Z"), is(OffsetTime.parse("14:00Z")));
+        assertThat(parseTime("14:00+02"), is(OffsetTime.parse("14:00+02:00")));
+        assertThat(parseTime("14:00-02"), is(OffsetTime.parse("14:00-02:00")));
+        assertThat(parseTime("14:00+02:30"), is(OffsetTime.parse("14:00+02:30")));
+        assertThat(parseTime("14:00-02:30"), is(OffsetTime.parse("14:00-02:30")));
 
         TimeZone offsetPlusHalf = TimeZone.getTimeZone("GMT+0230");
 
         TimeZone.setDefault(offsetPlusHalf);
 
-        startOfDayDate = getTodayStartOfDayUTCEpoch();
-
-        testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
-        testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
-
-        testTime("14:00+02", startOfDayDate + 1000 * 60 * 60 * 12);
-        testTime("14:00-02", startOfDayDate + 1000 * 60 * 60 * 16);
-
-        testTime("14:00+02:30", startOfDayDate + 1000 * 60 * (60 * 14 - 150));
-        testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
-
-        testTime("14:00+04:00", startOfDayDate + 1000 * 60 * 60 * 10);
+        assertThat(parseTime("14:00"), is(LocalTime.parse("14:00")));
+        assertThat(parseTime("14:00Z"), is(OffsetTime.parse("14:00Z")));
+        assertThat(parseTime("14:00+02"), is(OffsetTime.parse("14:00+02:00")));
+        assertThat(parseTime("14:00-02"), is(OffsetTime.parse("14:00-02:00")));
+        assertThat(parseTime("14:00+02:30"), is(OffsetTime.parse("14:00+02:30")));
+        assertThat(parseTime("14:00-02:30"), is(OffsetTime.parse("14:00-02:30")));
+        assertThat(parseTime("14:00+04:00"), is(OffsetTime.parse("14:00+04:00")));
     }
 
-    public long getTodayStartOfDayUTCEpoch() {
-        return LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
+    /**
+     * Returns a LocalTime or a OffsetTime obtained from the result of
+     * calling DateUtils.parseTime() with the provided input.
+     * <p>
+     * The interim OffsetDateTime value ensures that it represents the
+     * same instant as the Date from the call to DateUtils.parseTime().
+     */
+    public Temporal parseTime(String input) {
+        Instant inputInstant = Objects.requireNonNull(DateUtils.parseTime(input)).toInstant();
+
+        // No time offset declared. Return a LocalTime
+        if (input.length() == 5)
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.systemDefault()).toLocalTime();
+
+        // The input time is at UTC
+        if (input.charAt(5) == 'Z')
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of("Z")).toOffsetTime();
+
+        // The input declares some positive or negative time offset
+        String offsetPart = input.substring(5);
+        // Fix for unparseable short offset notations such as +02
+        String offset = offsetPart.length() == 3 ? offsetPart + ":00" : offsetPart;
+        return OffsetDateTime.ofInstant(inputInstant, ZoneId.of(offset)).toOffsetTime();
     }
 
     private void testTime(String in, long test) {
@@ -203,13 +221,6 @@ public class DateUtilsTests {
         long value = d.getTime();
 
         assertEquals("Fail: " + in + "(" + TimeZone.getDefault().getDisplayName() + ")", test, value);
-    }
-
-    private long getOffset() {
-        DateFields df = new DateFields();
-        Date d = DateUtils.getDate(df);
-
-        return -d.getTime();
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -29,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.format.TextStyle;
 import java.util.Date;
 import java.util.Locale;
+import java.util.function.Consumer;
 import org.javarosa.core.model.utils.DateUtils;
 import org.junit.Test;
 
@@ -52,13 +53,9 @@ public class DateUtilsTests {
         class LangJanSun {
             private LangJanSun(Locale locale) {
                 this.locale = locale;
-                this.january = JANUARY.getDisplayName(TextStyle.SHORT, locale);
-                this.sunday = SUNDAY.getDisplayName(TextStyle.SHORT, locale);
             }
 
             private Locale locale;
-            private String january;
-            private String sunday;
         }
 
         LangJanSun langJanSuns[] = new LangJanSun[]{
@@ -68,24 +65,27 @@ public class DateUtilsTests {
         };
 
         for (LangJanSun ljs : langJanSuns) {
-            withLocale(ljs.locale, () -> {
+            withLocale(ljs.locale, locale -> {
+                String expectedJanuary = JANUARY.getDisplayName(TextStyle.SHORT, locale);
+                String expectedSunday = SUNDAY.getDisplayName(TextStyle.SHORT, locale);
+
                 // Use a Sunday in January for our test
                 LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
                 Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
 
                 String month = DateUtils.format(date, "%b");
-                assertEquals(ljs.january, month);
+                assertEquals(expectedJanuary, month);
 
                 String day = DateUtils.format(date, "%a");
-                assertEquals(ljs.sunday, day);
+                assertEquals(expectedSunday, day);
             });
         }
     }
 
-    public void withLocale(Locale locale, Runnable block) {
+    public void withLocale(Locale locale, Consumer<Locale> block) {
         Locale backupLocale = Locale.getDefault();
         Locale.setDefault(locale);
-        block.run();
+        block.accept(locale);
         Locale.setDefault(backupLocale);
     }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -20,7 +20,6 @@ import static java.time.DayOfWeek.SUNDAY;
 import static java.time.Month.JANUARY;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.time.LocalDate;
@@ -66,18 +65,12 @@ public class DateUtilsTests {
 
         for (LangJanSun ljs : langJanSuns) {
             withLocale(ljs.locale, locale -> {
-
                 // Use a Sunday in January for our test
                 LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
                 Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
 
-                String month = DateUtils.format(date, "%b");
-                String expectedJanuary = JANUARY.getDisplayName(TextStyle.SHORT, locale);
-                assertEquals(expectedJanuary, month);
-
-                String day = DateUtils.format(date, "%a");
-                String expectedSunday = SUNDAY.getDisplayName(TextStyle.SHORT, locale);
-                assertEquals(expectedSunday, day);
+                assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, locale)));
+                assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, locale)));
             });
         }
     }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -17,6 +17,11 @@
 package org.javarosa.core.model.utils.test;
 
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.utils.DateUtils.FORMAT_ISO8601;
+import static org.javarosa.core.model.utils.DateUtils.format;
+import static org.javarosa.core.model.utils.DateUtils.formatDateTime;
+import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
+import static org.javarosa.core.model.utils.DateUtils.parseDateTime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -26,7 +31,7 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import org.javarosa.core.model.utils.DateUtils;
+import java.util.stream.Stream;
 import org.javarosa.core.model.utils.DateUtils.DateFields;
 import org.junit.After;
 import org.junit.Before;
@@ -59,50 +64,43 @@ public class DateUtilsTests {
     public void testGetXMLStringValueFormat() {
         LocalDateTime nowDateTime = LocalDateTime.now();
         Date nowDate = Date.from(nowDateTime.toInstant(OffsetDateTime.now().getOffset()));
-        String nowXmlFormatterDate = DateUtils.getXMLStringValue(nowDate);
+        String nowXmlFormatterDate = getXMLStringValue(nowDate);
         assertThat(LocalDate.parse(nowXmlFormatterDate), is(nowDateTime.toLocalDate()));
     }
 
     @Test
-    public void testParity() {
+    public void sanity_check_iso_format_and_parse_back() {
 
-        testCycle(new Date(1300139579000L));
-        testCycle(new Date(0));
+        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
+            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        testCycle(new Date(1300139579000L));
-        testCycle(new Date(0));
+        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
+            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
 
         TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+02");
 
         TimeZone.setDefault(offsetTwoHours);
 
-        testCycle(new Date(1300139579000L));
-        testCycle(new Date(0));
-
+        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
+            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
 
         TimeZone offTwoHalf = TimeZone.getTimeZone("GMT+0230");
 
         TimeZone.setDefault(offTwoHalf);
 
-        testCycle(new Date(1300139579000L));
-        testCycle(new Date(0));
+        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
+            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
 
         TimeZone offMinTwoHalf = TimeZone.getTimeZone("GMT-0230");
 
         TimeZone.setDefault(offMinTwoHalf);
 
-        testCycle(new Date(1300139579000L));
-        testCycle(new Date(0));
+        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
+            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
 
 
-    }
-
-    private void testCycle(Date in) {
-        String formatted = DateUtils.formatDateTime(in, DateUtils.FORMAT_ISO8601);
-        Date out = DateUtils.parseDateTime(formatted);
-        assertEquals("Fail:", in.getTime(), out.getTime());
     }
 
     @Test
@@ -128,11 +126,11 @@ public class DateUtilsTests {
         for (LangJanSun ljs : langJanSuns) {
             Locale.setDefault(Locale.forLanguageTag(ljs.language));
 
-            String month = DateUtils.format(DateFields.of(2018, 1, 1, 10, 20, 30, 400), "%b");
+            String month = format(DateFields.of(2018, 1, 1, 10, 20, 30, 400), "%b");
             assertEquals(ljs.january, month);
 
             // 2018-04-01 was sunday
-            String day = DateUtils.format(DateFields.of(2018, 4, 1, 10, 20, 30, 400), "%a");
+            String day = format(DateFields.of(2018, 4, 1, 10, 20, 30, 400), "%a");
             assertEquals(ljs.sunday, day);
         }
     }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -146,7 +146,7 @@ public class DateUtilsTests {
         testTime("10:00+02:30", startOfDayDate + 1000 * 60 * (60 * 10 - 150));
         testTime("10:00-02:30", startOfDayDate + 1000 * 60 * (60 * 10 + 150));
 
-        TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+02");
+        TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+12");
 
         TimeZone.setDefault(offsetTwoHours);
 
@@ -159,7 +159,7 @@ public class DateUtilsTests {
         testTime("10:00+02:30", startOfDayDate + 1000 * 60 * (60 * 10 - 150));
         testTime("10:00-02:30", startOfDayDate + 1000 * 60 * (60 * 10 + 150));
 
-        TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-02");
+        TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-13");
 
         TimeZone.setDefault(offsetMinusTwoHours);
 
@@ -294,8 +294,8 @@ public class DateUtilsTests {
         }
 
         LangJanSun langJanSuns[] = new LangJanSun[]{
-            new LangJanSun("en", "Jan",   "Sun"),
-            new LangJanSun("es", "ene",   "dom"),
+            new LangJanSun("en", "Jan", "Sun"),
+            new LangJanSun("es", "ene", "dom"),
             new LangJanSun("fr", "janv.", "dim.")
         };
 

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -69,14 +69,6 @@ public class DateUtilsTests {
         assertEquals(testLocalDateTime.getDayOfMonth(), Integer.parseInt(currentDate.substring(8, 10)));
     }
 
-    private void testTime(String in, long test) {
-        Date d = DateUtils.parseTime(in);
-
-        long value = d.getTime();
-
-        assertEquals("Fail: " + in + "(" + TimeZone.getDefault().getDisplayName() + ")", test, value);
-    }
-
     @Test
     public void testParity() {
 
@@ -111,39 +103,6 @@ public class DateUtilsTests {
         testCycle(new Date(0));
 
 
-    }
-
-    @Test
-    @Ignore
-    // This test doesn't make sense:
-    // - A time has no offset nor zone. It can only have one
-    //   when bound to a date, which is not the case
-    // - We're effectively binding all times to the EPOCH date
-    //   (1970-01-01, UTC), which has no DST
-    public void testParseTime_with_DST() {// testFormatting
-        Locale.setDefault(Locale.US);
-
-        // this is a timezone that operates DST every day of the year!
-        SimpleTimeZone dstTimezone = new SimpleTimeZone(
-            2 * 60 * 60 * 1000,
-            "Europe/Athens",
-            Calendar.JANUARY, 1, 0,
-            0, SimpleTimeZone.UTC_TIME,
-            Calendar.DECEMBER, 31, 0,
-            24 * 60 * 60 * 1000, SimpleTimeZone.UTC_TIME,
-            60 * 60 * 1000);
-        TimeZone.setDefault(dstTimezone);
-
-        String time = "12:03:05.000Z";
-        testTime(time, 43385000L);
-
-        Date date = DateUtils.parseTime(time);
-
-        DateFormat formatter = DateFormat.getTimeInstance();
-        String formatted = formatter.format(date);
-
-        // It should shift 3 hours, 2 for the zone and 1 for DST.
-        assertEquals("3:03:05 PM", formatted);
     }
 
     private void testCycle(Date in) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,8 +16,11 @@
 
 package org.javarosa.core.model.utils.test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Date;
@@ -49,17 +52,15 @@ public class DateUtilsTests {
     /**
      * This test ensures that the Strings returned
      * by the getXMLStringValue function are in
-     * the proper XML compliant format.
+     * the proper XML compliant format, which can be
+     * parsed by LocalDate.parse()
      */
     @Test
     public void testGetXMLStringValueFormat() {
-        LocalDateTime testLocalDateTime = LocalDateTime.of(2018, 1, 1, 10, 20, 30, 400);
-        String currentDate = DateUtils.getXMLStringValue(Date.from(testLocalDateTime.toInstant(OffsetDateTime.now().getOffset())));
-        assertEquals("The date string was not of the proper length", currentDate.length(), "YYYY-MM-DD".length());
-        assertEquals("The date string does not have proper year formatting", currentDate.indexOf("-"), "YYYY-".indexOf("-"));
-        assertEquals(testLocalDateTime.getYear(), Integer.parseInt(currentDate.substring(0, 4)));
-        assertEquals(testLocalDateTime.getMonth().getValue(), Integer.parseInt(currentDate.substring(5, 7)));
-        assertEquals(testLocalDateTime.getDayOfMonth(), Integer.parseInt(currentDate.substring(8, 10)));
+        LocalDateTime nowDateTime = LocalDateTime.now();
+        Date nowDate = Date.from(nowDateTime.toInstant(OffsetDateTime.now().getOffset()));
+        String nowXmlFormatterDate = DateUtils.getXMLStringValue(nowDate);
+        assertThat(LocalDate.parse(nowXmlFormatterDate), is(nowDateTime.toLocalDate()));
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,15 +16,15 @@
 
 package org.javarosa.core.model.utils.test;
 
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.Month.JANUARY;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.format.TextStyle;
 import java.util.Date;
@@ -69,10 +69,10 @@ public class DateUtilsTests {
     @Test
     public void format_is_localized() {
         class LangJanSun {
-            private LangJanSun(Locale locale, String january, String sunday) {
+            private LangJanSun(Locale locale) {
                 this.locale = locale;
-                this.january = january;
-                this.sunday = sunday;
+                this.january = JANUARY.getDisplayName(TextStyle.SHORT, locale);
+                this.sunday = SUNDAY.getDisplayName(TextStyle.SHORT, locale);
             }
 
             private Locale locale;
@@ -81,9 +81,9 @@ public class DateUtilsTests {
         }
 
         LangJanSun langJanSuns[] = new LangJanSun[]{
-            new LangJanSun(Locale.ENGLISH, Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.ENGLISH), DayOfWeek.SUNDAY.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)),
-            new LangJanSun(Locale.forLanguageTag("es-ES"), Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.forLanguageTag("es-ES")), DayOfWeek.SUNDAY.getDisplayName(TextStyle.SHORT, Locale.forLanguageTag("es-ES"))),
-            new LangJanSun(Locale.FRENCH, Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.FRENCH), DayOfWeek.SUNDAY.getDisplayName(TextStyle.SHORT, Locale.FRENCH))
+            new LangJanSun(Locale.ENGLISH),
+            new LangJanSun(Locale.forLanguageTag("es-ES")),
+            new LangJanSun(Locale.FRENCH)
         };
 
         for (LangJanSun ljs : langJanSuns) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -63,12 +63,12 @@ public class DateUtilsTests {
             new LangJanSun(Locale.FRENCH)
         };
 
+        // Use a Sunday in January for our test
+        LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
+        Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
+
         for (LangJanSun ljs : langJanSuns) {
             withLocale(ljs.locale, locale -> {
-                // Use a Sunday in January for our test
-                LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
-                Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
-
                 assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, locale)));
                 assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, locale)));
             });

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -19,6 +19,8 @@ package org.javarosa.core.model.utils.test;
 import static org.junit.Assert.assertEquals;
 
 import java.text.DateFormat;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -129,13 +131,7 @@ public class DateUtilsTests {
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        Calendar startOfDay = Calendar.getInstance();
-        startOfDay.set(Calendar.HOUR_OF_DAY, 0);
-        startOfDay.set(Calendar.MINUTE, 0);
-        startOfDay.set(Calendar.SECOND, 0);
-        startOfDay.set(Calendar.MILLISECOND, 0);
-
-        long startOfDayDate = startOfDay.getTime().getTime();
+        long startOfDayDate = getTodayStartOfDayUTCEpoch();
 
         testTime("10:00", startOfDayDate + 1000 * 60 * 60 * 10 - getOffset());
         testTime("10:00Z", startOfDayDate + 1000 * 60 * 60 * 10);
@@ -150,6 +146,8 @@ public class DateUtilsTests {
 
         TimeZone.setDefault(offsetTwoHours);
 
+        startOfDayDate = getTodayStartOfDayUTCEpoch();
+
         testTime("10:00", startOfDayDate + 1000 * 60 * 60 * 10 - getOffset());
         testTime("10:00Z", startOfDayDate + 1000 * 60 * 60 * 10);
 
@@ -162,6 +160,8 @@ public class DateUtilsTests {
         TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-13");
 
         TimeZone.setDefault(offsetMinusTwoHours);
+
+        startOfDayDate = getTodayStartOfDayUTCEpoch();
 
         testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
         testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
@@ -177,6 +177,8 @@ public class DateUtilsTests {
 
         TimeZone.setDefault(offsetPlusHalf);
 
+        startOfDayDate = getTodayStartOfDayUTCEpoch();
+
         testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
         testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
 
@@ -187,6 +189,10 @@ public class DateUtilsTests {
         testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
 
         testTime("14:00+04:00", startOfDayDate + 1000 * 60 * 60 * 10);
+    }
+
+    public long getTodayStartOfDayUTCEpoch() {
+        return LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
     }
 
     private void testTime(String in, long test) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,20 +16,14 @@
 
 package org.javarosa.core.model.utils.test;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.text.DateFormat;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
@@ -73,63 +67,6 @@ public class DateUtilsTests {
         assertEquals(testLocalDateTime.getYear(), Integer.parseInt(currentDate.substring(0, 4)));
         assertEquals(testLocalDateTime.getMonth().getValue(), Integer.parseInt(currentDate.substring(5, 7)));
         assertEquals(testLocalDateTime.getDayOfMonth(), Integer.parseInt(currentDate.substring(8, 10)));
-    }
-
-    @Test
-    public void testDateTimeParses() {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-
-        assertThat(parseDateTime("2016-04-13T16:26:00.000-07"), is(OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")));
-        assertThat(parseDateTime("2015-12-16T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00"))); // wraps day!!!
-        assertThat(parseDateTime("2015-12-16T07:09:00.000+08"), is(OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00"))); // wraps day!!!
-        assertThat(parseDateTime("2015-11-30T16:09:00.000-08"), is(OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00"))); // wraps month!!!
-        assertThat(parseDateTime("2015-11-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00"))); // wraps month!!!
-        assertThat(parseDateTime("2015-12-31T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00"))); // wraps year!!!
-        assertThat(parseDateTime("2015-01-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-01-01T07:09:00.000+08:00"))); // wraps year!!!
-        assertThat(parseDateTime("2016-01-26T10:39:00.000-08"), is(OffsetDateTime.parse("2016-01-26T10:39:00.000-08:00")));
-
-        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
-
-        assertThat(parseDateTime("2016-04-13T16:26:00.000-07"), is(OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")));
-        assertThat(parseDateTime("2015-12-16T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00"))); // wraps day!!!
-        assertThat(parseDateTime("2015-12-16T07:09:00.000+08"), is(OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00"))); // wraps day!!!
-        assertThat(parseDateTime("2015-11-30T16:09:00.000-08"), is(OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00"))); // wraps month!!!
-        assertThat(parseDateTime("2015-11-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00"))); // wraps month!!!
-        assertThat(parseDateTime("2015-12-31T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00"))); // wraps year!!!
-        assertThat(parseDateTime("2015-01-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-01-01T07:09:00.000+08:00"))); // wraps year!!!
-        assertThat(parseDateTime("2016-01-26T10:39:00.000-08"), is(OffsetDateTime.parse("2016-01-26T10:39:00.000-08:00")));
-
-        TimeZone.setDefault(TimeZone.getTimeZone("PDT"));
-
-        assertThat(parseDateTime("2016-04-13T16:26:00.000-07"), is(OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")));
-        assertThat(parseDateTime("2015-12-16T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00"))); // wraps day!!!
-        assertThat(parseDateTime("2015-12-16T07:09:00.000+08"), is(OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00"))); // wraps day!!!
-        assertThat(parseDateTime("2015-11-30T16:09:00.000-08"), is(OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00"))); // wraps month!!!
-        assertThat(parseDateTime("2015-11-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00"))); // wraps month!!!
-        assertThat(parseDateTime("2015-12-31T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00"))); // wraps year!!!
-        assertThat(parseDateTime("2015-01-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-01-01T07:09:00.000+08:00"))); // wraps year!!!
-        assertThat(parseDateTime("2016-01-26T10:39:00.000-08"), is(OffsetDateTime.parse("2016-01-26T10:39:00.000-08:00")));
-    }
-
-    private Temporal parseDateTime(String input) {
-        Instant inputInstant = Objects.requireNonNull(DateUtils.parseDateTime(input)).toInstant();
-
-        String timePart = input.substring(11);
-        if (timePart.contains("+") || timePart.contains("-")) {
-            // The input declares some positive or negative time offset
-            int beginOfOffsetPart = timePart.contains("+") ? timePart.indexOf("+") : timePart.indexOf("-");
-            String offsetPart = timePart.substring(beginOfOffsetPart);
-            // The input declares some positive or negative time offset
-            String offset = offsetPart.length() == 3 ? offsetPart + ":00" : offsetPart;
-            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of(offset));
-        }
-
-        if (input.endsWith("Z"))
-            // The input time is at UTC
-            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of("Z"));
-
-        // No time offset declared. Return a LocalTime
-        return LocalDateTime.ofInstant(inputInstant, ZoneId.systemDefault());
     }
 
     private void testTime(String in, long test) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -66,17 +66,17 @@ public class DateUtilsTests {
 
         for (LangJanSun ljs : langJanSuns) {
             withLocale(ljs.locale, locale -> {
-                String expectedJanuary = JANUARY.getDisplayName(TextStyle.SHORT, locale);
-                String expectedSunday = SUNDAY.getDisplayName(TextStyle.SHORT, locale);
 
                 // Use a Sunday in January for our test
                 LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
                 Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
 
                 String month = DateUtils.format(date, "%b");
+                String expectedJanuary = JANUARY.getDisplayName(TextStyle.SHORT, locale);
                 assertEquals(expectedJanuary, month);
 
                 String day = DateUtils.format(date, "%a");
+                String expectedSunday = SUNDAY.getDisplayName(TextStyle.SHORT, locale);
                 assertEquals(expectedSunday, day);
             });
         }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -148,14 +148,14 @@ public class DateUtilsTests {
 
         startOfDayDate = getTodayStartOfDayUTCEpoch();
 
-        testTime("10:00", startOfDayDate + 1000 * 60 * 60 * 10 - getOffset());
-        testTime("10:00Z", startOfDayDate + 1000 * 60 * 60 * 10);
+        testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
+        testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);
 
-        testTime("10:00+02", startOfDayDate + 1000 * 60 * 60 * 8);
-        testTime("10:00-02", startOfDayDate + 1000 * 60 * 60 * 12);
+        testTime("14:00+02", startOfDayDate + 1000 * 60 * 60 * 12);
+        testTime("14:00-02", startOfDayDate + 1000 * 60 * 60 * 16);
 
-        testTime("10:00+02:30", startOfDayDate + 1000 * 60 * (60 * 10 - 150));
-        testTime("10:00-02:30", startOfDayDate + 1000 * 60 * (60 * 10 + 150));
+        testTime("14:00+02:30", startOfDayDate + 1000 * 60 * (60 * 14 - 150));
+        testTime("14:00-02:30", startOfDayDate + 1000 * 60 * (60 * 14 + 150));
 
         TimeZone offsetMinusTwoHours = TimeZone.getTimeZone("GMT-13");
 

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -21,9 +21,12 @@ import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.OffsetDateTime;
+import java.time.format.TextStyle;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -66,25 +69,25 @@ public class DateUtilsTests {
     @Test
     public void format_is_localized() {
         class LangJanSun {
-            private LangJanSun(String language, String january, String sunday) {
-                this.language = language;
+            private LangJanSun(Locale locale, String january, String sunday) {
+                this.locale = locale;
                 this.january = january;
                 this.sunday = sunday;
             }
 
-            private String language;
+            private Locale locale;
             private String january;
             private String sunday;
         }
 
         LangJanSun langJanSuns[] = new LangJanSun[]{
-            new LangJanSun("en", "Jan", "Sun"),
-            new LangJanSun("es", "ene", "dom"),
-            new LangJanSun("fr", "janv.", "dim.")
+            new LangJanSun(Locale.ENGLISH, Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.ENGLISH), DayOfWeek.SUNDAY.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)),
+            new LangJanSun(Locale.forLanguageTag("es-ES"), Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.forLanguageTag("es-ES")), DayOfWeek.SUNDAY.getDisplayName(TextStyle.SHORT, Locale.forLanguageTag("es-ES"))),
+            new LangJanSun(Locale.FRENCH, Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.FRENCH), DayOfWeek.SUNDAY.getDisplayName(TextStyle.SHORT, Locale.FRENCH))
         };
 
         for (LangJanSun ljs : langJanSuns) {
-            Locale.setDefault(Locale.forLanguageTag(ljs.language));
+            Locale.setDefault(ljs.locale);
 
             // Use a Sunday in January for our test
             LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.text.DateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
@@ -28,7 +30,6 @@ import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.DateUtils.DateFields;
-import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -45,8 +46,8 @@ public class DateUtilsTests {
     public void setUp() {
         backupLocale = Locale.getDefault();
         backupZone = TimeZone.getDefault();
-        testLocalDateTime = new LocalDateTime(2018, 1, 1, 10, 20, 30, 400);
-        testDate = testLocalDateTime.toDate();
+        testLocalDateTime = LocalDateTime.of(2018, 1, 1, 10, 20, 30, 400);
+        testDate = Date.from(testLocalDateTime.toInstant(OffsetDateTime.now().getOffset()));
     }
 
     @After
@@ -66,7 +67,7 @@ public class DateUtilsTests {
         assertEquals("The date string was not of the proper length", currentDate.length(), "YYYY-MM-DD".length());
         assertEquals("The date string does not have proper year formatting", currentDate.indexOf("-"), "YYYY-".indexOf("-"));
         assertEquals(testLocalDateTime.getYear(), Integer.parseInt(currentDate.substring(0, 4)));
-        assertEquals(testLocalDateTime.getMonthOfYear(), Integer.parseInt(currentDate.substring(5, 7)));
+        assertEquals(testLocalDateTime.getMonth().getValue(), Integer.parseInt(currentDate.substring(5, 7)));
         assertEquals(testLocalDateTime.getDayOfMonth(), Integer.parseInt(currentDate.substring(8, 10)));
     }
 
@@ -147,6 +148,7 @@ public class DateUtilsTests {
         TimeZone.setDefault(offsetTwoHours);
 
         startOfDayDate = getTodayStartOfDayUTCEpoch();
+
 
         testTime("14:00", startOfDayDate + 1000 * 60 * 60 * 14 - getOffset());
         testTime("14:00Z", startOfDayDate + 1000 * 60 * 60 * 14);

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,14 +16,20 @@
 
 package org.javarosa.core.model.utils.test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.text.DateFormat;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
@@ -73,53 +79,57 @@ public class DateUtilsTests {
     public void testDateTimeParses() {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        testDateTime("2016-04-13T16:26:00.000-07", 1460589960000L);
-        testDateTime("2015-12-16T16:09:00.000-08", 1450310940000L); // wraps day!!!
-        testDateTime("2015-12-16T07:09:00.000+08", 1450220940000L); // wraps day!!!
-
-        testDateTime("2015-11-30T16:09:00.000-08", 1448928540000L); // wraps month!!!
-        testDateTime("2015-11-01T07:09:00.000+08", 1446332940000L); // wraps month!!!
-
-        testDateTime("2015-12-31T16:09:00.000-08", 1451606940000L); // wraps year!!!
-        testDateTime("2015-01-01T07:09:00.000+08", 1420067340000L); // wraps year!!!
-
-        testDateTime("2016-01-26T10:39:00.000-08", 1453833540000L);
+        assertThat(parseDateTime("2016-04-13T16:26:00.000-07"), is(OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")));
+        assertThat(parseDateTime("2015-12-16T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00"))); // wraps day!!!
+        assertThat(parseDateTime("2015-12-16T07:09:00.000+08"), is(OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00"))); // wraps day!!!
+        assertThat(parseDateTime("2015-11-30T16:09:00.000-08"), is(OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00"))); // wraps month!!!
+        assertThat(parseDateTime("2015-11-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00"))); // wraps month!!!
+        assertThat(parseDateTime("2015-12-31T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00"))); // wraps year!!!
+        assertThat(parseDateTime("2015-01-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-01-01T07:09:00.000+08:00"))); // wraps year!!!
+        assertThat(parseDateTime("2016-01-26T10:39:00.000-08"), is(OffsetDateTime.parse("2016-01-26T10:39:00.000-08:00")));
 
         TimeZone.setDefault(TimeZone.getTimeZone("PST"));
 
-        testDateTime("2016-04-13T16:26:00.000-07", 1460589960000L);
-        testDateTime("2015-12-16T16:09:00.000-08", 1450310940000L); // wraps day!!!
-        testDateTime("2015-12-16T07:09:00.000+08", 1450220940000L); // wraps day!!!
-
-        testDateTime("2015-11-30T16:09:00.000-08", 1448928540000L); // wraps month!!!
-        testDateTime("2015-11-01T07:09:00.000+08", 1446332940000L); // wraps month!!!
-
-        testDateTime("2015-12-31T16:09:00.000-08", 1451606940000L); // wraps year!!!
-        testDateTime("2015-01-01T07:09:00.000+08", 1420067340000L); // wraps year!!!
-
-        testDateTime("2016-01-26T10:39:00.000-08", 1453833540000L);
+        assertThat(parseDateTime("2016-04-13T16:26:00.000-07"), is(OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")));
+        assertThat(parseDateTime("2015-12-16T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00"))); // wraps day!!!
+        assertThat(parseDateTime("2015-12-16T07:09:00.000+08"), is(OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00"))); // wraps day!!!
+        assertThat(parseDateTime("2015-11-30T16:09:00.000-08"), is(OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00"))); // wraps month!!!
+        assertThat(parseDateTime("2015-11-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00"))); // wraps month!!!
+        assertThat(parseDateTime("2015-12-31T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00"))); // wraps year!!!
+        assertThat(parseDateTime("2015-01-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-01-01T07:09:00.000+08:00"))); // wraps year!!!
+        assertThat(parseDateTime("2016-01-26T10:39:00.000-08"), is(OffsetDateTime.parse("2016-01-26T10:39:00.000-08:00")));
 
         TimeZone.setDefault(TimeZone.getTimeZone("PDT"));
 
-        testDateTime("2016-04-13T16:26:00.000-07", 1460589960000L);
-        testDateTime("2015-12-16T16:09:00.000-08", 1450310940000L); // wraps day!!!
-        testDateTime("2015-12-16T07:09:00.000+08", 1450220940000L); // wraps day!!!
-
-        testDateTime("2015-11-30T16:09:00.000-08", 1448928540000L); // wraps month!!!
-        testDateTime("2015-11-01T07:09:00.000+08", 1446332940000L); // wraps month!!!
-
-        testDateTime("2015-12-31T16:09:00.000-08", 1451606940000L); // wraps year!!!
-        testDateTime("2015-01-01T07:09:00.000+08", 1420067340000L); // wraps year!!!
-
-        testDateTime("2016-01-26T10:39:00.000-08", 1453833540000L);
+        assertThat(parseDateTime("2016-04-13T16:26:00.000-07"), is(OffsetDateTime.parse("2016-04-13T16:26:00.000-07:00")));
+        assertThat(parseDateTime("2015-12-16T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-16T16:09:00.000-08:00"))); // wraps day!!!
+        assertThat(parseDateTime("2015-12-16T07:09:00.000+08"), is(OffsetDateTime.parse("2015-12-16T07:09:00.000+08:00"))); // wraps day!!!
+        assertThat(parseDateTime("2015-11-30T16:09:00.000-08"), is(OffsetDateTime.parse("2015-11-30T16:09:00.000-08:00"))); // wraps month!!!
+        assertThat(parseDateTime("2015-11-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-11-01T07:09:00.000+08:00"))); // wraps month!!!
+        assertThat(parseDateTime("2015-12-31T16:09:00.000-08"), is(OffsetDateTime.parse("2015-12-31T16:09:00.000-08:00"))); // wraps year!!!
+        assertThat(parseDateTime("2015-01-01T07:09:00.000+08"), is(OffsetDateTime.parse("2015-01-01T07:09:00.000+08:00"))); // wraps year!!!
+        assertThat(parseDateTime("2016-01-26T10:39:00.000-08"), is(OffsetDateTime.parse("2016-01-26T10:39:00.000-08:00")));
     }
 
-    private void testDateTime(String in, long test) {
-        Date d = DateUtils.parseDateTime(in);
+    private Temporal parseDateTime(String input) {
+        Instant inputInstant = Objects.requireNonNull(DateUtils.parseDateTime(input)).toInstant();
 
-        long value = d.getTime();
+        String timePart = input.substring(11);
+        if (timePart.contains("+") || timePart.contains("-")) {
+            // The input declares some positive or negative time offset
+            int beginOfOffsetPart = timePart.contains("+") ? timePart.indexOf("+") : timePart.indexOf("-");
+            String offsetPart = timePart.substring(beginOfOffsetPart);
+            // The input declares some positive or negative time offset
+            String offset = offsetPart.length() == 3 ? offsetPart + ":00" : offsetPart;
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of(offset));
+        }
 
-        assertEquals("Fail: " + in + "(" + TimeZone.getDefault().getDisplayName() + ")", test, value);
+        if (input.endsWith("Z"))
+            // The input time is at UTC
+            return OffsetDateTime.ofInstant(inputInstant, ZoneId.of("Z"));
+
+        // No time offset declared. Return a LocalTime
+        return LocalDateTime.ofInstant(inputInstant, ZoneId.systemDefault());
     }
 
     private void testTime(String in, long test) {

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -54,8 +54,7 @@ public class DateUtilsTests {
     @Test
     public void testGetXMLStringValueFormat() {
         LocalDateTime testLocalDateTime = LocalDateTime.of(2018, 1, 1, 10, 20, 30, 400);
-        Date testDate = Date.from(testLocalDateTime.toInstant(OffsetDateTime.now().getOffset()));
-        String currentDate = DateUtils.getXMLStringValue(testDate);
+        String currentDate = DateUtils.getXMLStringValue(Date.from(testLocalDateTime.toInstant(OffsetDateTime.now().getOffset())));
         assertEquals("The date string was not of the proper length", currentDate.length(), "YYYY-MM-DD".length());
         assertEquals("The date string does not have proper year formatting", currentDate.indexOf("-"), "YYYY-".indexOf("-"));
         assertEquals(testLocalDateTime.getYear(), Integer.parseInt(currentDate.substring(0, 4)));

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -18,34 +18,26 @@ package org.javarosa.core.model.utils.test;
 
 import static org.junit.Assert.assertEquals;
 
-import java.text.DateFormat;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.DateUtils.DateFields;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class DateUtilsTests {
-
     private Locale backupLocale;
     private TimeZone backupZone;
-    private Date testDate;
-    private LocalDateTime testLocalDateTime;
 
     @Before
     public void setUp() {
         backupLocale = Locale.getDefault();
         backupZone = TimeZone.getDefault();
-        testLocalDateTime = LocalDateTime.of(2018, 1, 1, 10, 20, 30, 400);
-        testDate = Date.from(testLocalDateTime.toInstant(OffsetDateTime.now().getOffset()));
+
     }
 
     @After
@@ -61,6 +53,8 @@ public class DateUtilsTests {
      */
     @Test
     public void testGetXMLStringValueFormat() {
+        LocalDateTime testLocalDateTime = LocalDateTime.of(2018, 1, 1, 10, 20, 30, 400);
+        Date testDate = Date.from(testLocalDateTime.toInstant(OffsetDateTime.now().getOffset()));
         String currentDate = DateUtils.getXMLStringValue(testDate);
         assertEquals("The date string was not of the proper length", currentDate.length(), "YYYY-MM-DD".length());
         assertEquals("The date string does not have proper year formatting", currentDate.indexOf("-"), "YYYY-".indexOf("-"));

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,8 +16,6 @@
 
 package org.javarosa.core.model.utils.test;
 
-import static java.time.DayOfWeek.SUNDAY;
-import static java.time.Month.JANUARY;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
 import static org.junit.Assert.assertThat;
@@ -25,11 +23,7 @@ import static org.junit.Assert.assertThat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.TextStyle;
 import java.util.Date;
-import java.util.Locale;
-import java.util.function.Consumer;
-import org.javarosa.core.model.utils.DateUtils;
 import org.junit.Test;
 
 public class DateUtilsTests {
@@ -47,38 +41,4 @@ public class DateUtilsTests {
         assertThat(LocalDate.parse(nowXmlFormatterDate), is(nowDateTime.toLocalDate()));
     }
 
-    @Test
-    public void format_is_localized() {
-        class LangJanSun {
-            private LangJanSun(Locale locale) {
-                this.locale = locale;
-            }
-
-            private Locale locale;
-        }
-
-        LangJanSun langJanSuns[] = new LangJanSun[]{
-            new LangJanSun(Locale.ENGLISH),
-            new LangJanSun(Locale.forLanguageTag("es-ES")),
-            new LangJanSun(Locale.FRENCH)
-        };
-
-        // Use a Sunday in January for our test
-        LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
-        Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
-
-        for (LangJanSun ljs : langJanSuns) {
-            withLocale(ljs.locale, locale -> {
-                assertThat(DateUtils.format(date, "%b"), is(JANUARY.getDisplayName(TextStyle.SHORT, locale)));
-                assertThat(DateUtils.format(date, "%a"), is(SUNDAY.getDisplayName(TextStyle.SHORT, locale)));
-            });
-        }
-    }
-
-    public void withLocale(Locale locale, Consumer<Locale> block) {
-        Locale backupLocale = Locale.getDefault();
-        Locale.setDefault(locale);
-        block.accept(locale);
-        Locale.setDefault(backupLocale);
-    }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,13 +16,9 @@
 
 package org.javarosa.core.model.utils.test;
 
-import static java.util.TimeZone.getTimeZone;
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.core.model.utils.DateUtils.FORMAT_ISO8601;
 import static org.javarosa.core.model.utils.DateUtils.format;
-import static org.javarosa.core.model.utils.DateUtils.formatDateTime;
 import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
-import static org.javarosa.core.model.utils.DateUtils.parseDateTime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -32,7 +28,6 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import java.util.stream.Stream;
 import org.javarosa.core.model.utils.DateUtils.DateFields;
 import org.junit.After;
 import org.junit.Before;
@@ -67,29 +62,6 @@ public class DateUtilsTests {
         Date nowDate = Date.from(nowDateTime.toInstant(OffsetDateTime.now().getOffset()));
         String nowXmlFormatterDate = getXMLStringValue(nowDate);
         assertThat(LocalDate.parse(nowXmlFormatterDate), is(nowDateTime.toLocalDate()));
-    }
-
-    @Test
-    public void sanity_check_iso_format_and_parse_back() {
-        Stream.of(
-            TimeZone.getDefault(),
-            getTimeZone("UTC"),
-            getTimeZone("GMT+12"),
-            getTimeZone("GMT-13"),
-            getTimeZone("GMT+0230")
-        ).forEach(timeZone -> withTimeZone(timeZone, () ->
-            Stream.of(
-                new Date(1300139579000L),
-                new Date(0)
-            ).forEach(input ->
-                assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)))));
-    }
-
-    private void withTimeZone(TimeZone timeZone, Runnable block) {
-        TimeZone backupZone = TimeZone.getDefault();
-        TimeZone.setDefault(timeZone);
-        block.run();
-        TimeZone.setDefault(backupZone);
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -17,7 +17,6 @@
 package org.javarosa.core.model.utils.test;
 
 import static org.hamcrest.Matchers.is;
-import static org.javarosa.core.model.utils.DateUtils.format;
 import static org.javarosa.core.model.utils.DateUtils.getXMLStringValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -28,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.DateUtils.DateFields;
 import org.junit.After;
 import org.junit.Before;
@@ -65,7 +65,7 @@ public class DateUtilsTests {
     }
 
     @Test
-    public void testFormatting() {
+    public void format_is_localized() {
         class LangJanSun {
             private LangJanSun(String language, String january, String sunday) {
                 this.language = language;
@@ -87,11 +87,11 @@ public class DateUtilsTests {
         for (LangJanSun ljs : langJanSuns) {
             Locale.setDefault(Locale.forLanguageTag(ljs.language));
 
-            String month = format(DateFields.of(2018, 1, 1, 10, 20, 30, 400), "%b");
+            String month = DateUtils.format(DateFields.of(2018, 1, 1, 10, 20, 30, 400), "%b");
             assertEquals(ljs.january, month);
 
             // 2018-04-01 was sunday
-            String day = format(DateFields.of(2018, 4, 1, 10, 20, 30, 400), "%a");
+            String day = DateUtils.format(DateFields.of(2018, 4, 1, 10, 20, 30, 400), "%a");
             assertEquals(ljs.sunday, day);
         }
     }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 import org.javarosa.core.model.utils.DateUtils;
-import org.javarosa.core.model.utils.DateUtils.DateFields;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,11 +86,14 @@ public class DateUtilsTests {
         for (LangJanSun ljs : langJanSuns) {
             Locale.setDefault(Locale.forLanguageTag(ljs.language));
 
-            String month = DateUtils.format(DateFields.of(2018, 1, 1, 10, 20, 30, 400), "%b");
+            // Use a Sunday in January for our test
+            LocalDateTime localDateTime = LocalDateTime.parse("2018-01-07T10:20:30.400");
+            Date date = Date.from(localDateTime.toInstant(OffsetDateTime.now().getOffset()));
+
+            String month = DateUtils.format(date, "%b");
             assertEquals(ljs.january, month);
 
-            // 2018-04-01 was sunday
-            String day = DateUtils.format(DateFields.of(2018, 4, 1, 10, 20, 30, 400), "%a");
+            String day = DateUtils.format(date, "%a");
             assertEquals(ljs.sunday, day);
         }
     }

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsTests.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.core.model.utils.test;
 
+import static java.util.TimeZone.getTimeZone;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.utils.DateUtils.FORMAT_ISO8601;
 import static org.javarosa.core.model.utils.DateUtils.format;
@@ -70,37 +71,25 @@ public class DateUtilsTests {
 
     @Test
     public void sanity_check_iso_format_and_parse_back() {
+        Stream.of(
+            TimeZone.getDefault(),
+            getTimeZone("UTC"),
+            getTimeZone("GMT+12"),
+            getTimeZone("GMT-13"),
+            getTimeZone("GMT+0230")
+        ).forEach(timeZone -> withTimeZone(timeZone, () ->
+            Stream.of(
+                new Date(1300139579000L),
+                new Date(0)
+            ).forEach(input ->
+                assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)))));
+    }
 
-        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
-            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
-
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-
-        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
-            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
-
-        TimeZone offsetTwoHours = TimeZone.getTimeZone("GMT+02");
-
-        TimeZone.setDefault(offsetTwoHours);
-
-        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
-            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
-
-        TimeZone offTwoHalf = TimeZone.getTimeZone("GMT+0230");
-
-        TimeZone.setDefault(offTwoHalf);
-
-        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
-            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
-
-        TimeZone offMinTwoHalf = TimeZone.getTimeZone("GMT-0230");
-
-        TimeZone.setDefault(offMinTwoHalf);
-
-        Stream.of(new Date(1300139579000L), new Date(0)).forEach(input ->
-            assertThat(parseDateTime(formatDateTime(input, FORMAT_ISO8601)), is(input)));
-
-
+    private void withTimeZone(TimeZone timeZone, Runnable block) {
+        TimeZone backupZone = TimeZone.getDefault();
+        TimeZone.setDefault(timeZone);
+        block.run();
+        TimeZone.setDefault(backupZone);
     }
 
     @Test

--- a/src/test/java/org/javarosa/test/utils/SystemHelper.java
+++ b/src/test/java/org/javarosa/test/utils/SystemHelper.java
@@ -18,14 +18,23 @@ package org.javarosa.test.utils;
 
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class SystemHelper {
     public static void withTimeZone(TimeZone timeZone, Runnable block) {
+        withTimeZone(timeZone, __ -> block.run());
+    }
+
+    public static void withTimeZone(TimeZone timeZone, Consumer<TimeZone> block) {
         TimeZone backupZone = TimeZone.getDefault();
         TimeZone.setDefault(timeZone);
-        block.run();
+        block.accept(timeZone);
         TimeZone.setDefault(backupZone);
+    }
+
+    public static void withLocale(Locale locale, Runnable block) {
+        withLocale(locale, __ -> block.run());
     }
 
     public static void withLocale(Locale locale, Consumer<Locale> block) {
@@ -33,5 +42,13 @@ public class SystemHelper {
         Locale.setDefault(locale);
         block.accept(locale);
         Locale.setDefault(backupLocale);
+    }
+
+    public static void withLocaleAndTimeZone(Locale locale, TimeZone timeZone, Runnable block) {
+        withLocaleAndTimeZone(locale, timeZone, (__, ___) -> block.run());
+    }
+
+    public static void withLocaleAndTimeZone(Locale locale, TimeZone timeZone, BiConsumer<Locale, TimeZone> block) {
+        withLocale(locale, l -> withTimeZone(timeZone, () -> block.accept(l, timeZone)));
     }
 }

--- a/src/test/java/org/javarosa/test/utils/SystemHelper.java
+++ b/src/test/java/org/javarosa/test/utils/SystemHelper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.test.utils;
+
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.function.Consumer;
+
+public class SystemHelper {
+    public static void withTimeZone(TimeZone timeZone, Runnable block) {
+        TimeZone backupZone = TimeZone.getDefault();
+        TimeZone.setDefault(timeZone);
+        block.run();
+        TimeZone.setDefault(backupZone);
+    }
+
+    public static void withLocale(Locale locale, Consumer<Locale> block) {
+        Locale backupLocale = Locale.getDefault();
+        Locale.setDefault(locale);
+        block.accept(locale);
+        Locale.setDefault(backupLocale);
+    }
+}


### PR DESCRIPTION
Closes #534

This PR has become more than simply fixing the DateUtilsTest class into a review of the whole test suite to ensure we always deal with timezones and locales in a way that's consistent, safe and easier to understand.

#### What has been done to verify that this works as intended?
- Run automated tests
- Use [external](https://www.epochconverter.com/timezones?q=1580378400000&tz=Pacific%2FHonolulu) tools to double-check that the `java.time` values used to replace long timestamps actually represent the same instant.

#### Why is this the best possible solution? Were any other approaches considered?
- Using `java.time` as much as possible is the safest way to move forward even if the implementation codebase will use Jodatime while we support Android API levels that don't include it.

  This is the standard way to deal with dates in Java starting from Java8 and it's very well documented with lots of examples.

  Also, using a `java.time` serves as a safe and solid baseline that provides an extra sanity check over our code and tests.

- Using human readable date and time definitions in our tests makes them easier to understand. When something goes wrong, it will be easier to detect problems if we can read the values involved, as opposed to using timestamps.

- Although Using the `@Before` and `@After` hooks to prevent side-effects due to setting default locales and time zones in test methods is super safe, using the methods provided by `SystemHelper` (new in this PR) make more explicit where this is actually required.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This PR doesn't change the implementation codebase, so no behavior change expected whatsoever.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No