### PR TITLE
Improve test suite

### DIFF
--- a/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -118,7 +118,7 @@ public class XPathLazyNodeset extends XPathNodeset {
         return super.toArgList();
     }
 
-    protected List<TreeReference> getReferences() {
+    public List<TreeReference> getReferences() {
         performEvaluation();
         return super.getReferences();
     }

--- a/src/main/java/org/javarosa/xpath/XPathNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathNodeset.java
@@ -109,7 +109,7 @@ public class XPathNodeset {
         this.nodes = nodes;
     }
 
-    protected List<TreeReference> getReferences() {
+    public List<TreeReference> getReferences() {
         return this.nodes;
     }
 

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1101,8 +1101,6 @@ public class TriggerableDagTest {
         // Verify that regardless of the constraint defined in /data/a, the
         // form appears to be valid
         assertThat(scenario.getFormDef(), is(valid()));
-
-
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -378,10 +378,9 @@ public class TriggerableDagTest {
         ));
         scenario.next();
         scenario.answer(2);
-        // Notice how the calculate at number1_x2 gets evaluated even though it's in a non-relevant group
-        // and number1_x2_x2 doesn't get evaluated. The difference could be that the second field depends
-        // on a field that is inside a non-relevant group.
         assertThat(scenario.answerOf("/data/group/number1_x2"), is(intAnswer(4)));
+        // The expected value is null because the calculate expression uses a non-relevant field.
+        // Values of non-relevant fields are always null.
         assertThat(scenario.answerOf("/data/group/number1_x2_x2"), is(nullValue()));
         scenario.next();
         scenario.answer("1"); // Label: "yes"

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
@@ -57,6 +57,7 @@ public class TreeReferenceContextualizeTest {
             {"Wildcards #2", getRef("../baz"), getRef("/foo/*/bar"), getRef("/foo/*/baz")},
             {"Wildcards #3", getRef("*/baz"), getRef("/foo/*/bar"), getRef("/foo/*/bar/*/baz")},
             {"Wildcards #4", getRef("*/bar"), getRef("/foo"), getRef("/foo/*/bar")},
+            {"Parent refs in nested repeats", getRef("../../inner"), getRef("/data/outer[0]/inner[1]/count[0]"), getRef("/data/outer[0]/inner[1]")} // Should be /data/outer[0]/inner
         });
     }
 
@@ -70,5 +71,4 @@ public class TreeReferenceContextualizeTest {
                 : is(expectedResult)
         );
     }
-
 }

--- a/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
+++ b/src/test/java/org/javarosa/core/test/AnswerDataMatchers.java
@@ -3,6 +3,7 @@ package org.javarosa.core.test;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.StringData;
@@ -99,6 +100,25 @@ public class AnswerDataMatchers {
             @Override
             protected boolean matchesSafely(T item) {
                 return item.getDisplayText().matches(expectedAnswerText);
+            }
+        };
+    }
+
+    public static Matcher<BooleanData> booleanAnswer(boolean expectedAnswer) {
+        return new TypeSafeMatcher<BooleanData>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("answer with value " + expectedAnswer);
+            }
+
+            @Override
+            protected void describeMismatchSafely(BooleanData item, Description mismatchDescription) {
+                mismatchDescription.appendText("was answer " + item.getDisplayText() + "(").appendValue(item.getValue()).appendText(")");
+            }
+
+            @Override
+            protected boolean matchesSafely(BooleanData item) {
+                return item.getValue().equals(expectedAnswer);
             }
         };
     }

--- a/src/test/java/org/javarosa/core/test/FormDefMatchers.java
+++ b/src/test/java/org/javarosa/core/test/FormDefMatchers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.core.test;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.javarosa.core.model.FormDef;
+
+public class FormDefMatchers {
+
+    public static TypeSafeMatcher<FormDef> valid() {
+        return new TypeSafeMatcher<FormDef>() {
+            @Override
+            protected boolean matchesSafely(FormDef item) {
+                return item.validate(true) == null;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("valid");
+            }
+
+            @Override
+            protected void describeMismatchSafely(FormDef item, Description mismatchDescription) {
+                mismatchDescription.appendValue(item).appendText(" has at least one invalid field");
+            }
+        };
+    }
+}

--- a/src/test/java/org/javarosa/core/test/QuestionDefMatchers.java
+++ b/src/test/java/org/javarosa/core/test/QuestionDefMatchers.java
@@ -41,7 +41,7 @@ public class QuestionDefMatchers {
         };
     }
 
-    public static TypeSafeMatcher<TreeElement> irrelevant() {
+    public static TypeSafeMatcher<TreeElement> nonRelevant() {
         return new TypeSafeMatcher<TreeElement>() {
             @Override
             protected boolean matchesSafely(TreeElement item) {

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -770,8 +770,9 @@ public class Scenario {
         if (!reference.isAmbiguous())
             throw new RuntimeException("Provided xPath must be ambiguous");
 
-        return ec
-            .expandReference(reference)
+        List<TreeReference> treeReferences = ec
+            .expandReference(reference);
+        return treeReferences
             .size();
     }
 

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -56,6 +56,7 @@ import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
@@ -431,6 +432,21 @@ public class Scenario {
         return answer(value);
     }
 
+    /**
+     * Answers with a boolean value the question at the form index
+     * corresponding to the provided reference.
+     * <p>
+     * This method has side-effects:
+     * - It will create all the required middle and end repeat group instances
+     * - It changes the current form index
+     */
+    public AnswerResult answer(String xPath, boolean value) {
+        createMissingRepeats(xPath);
+        TreeReference ref = getRef(xPath);
+        silentJump(getIndexOf(ref));
+        return answer(value);
+    }
+
     // endregion
 
     // region Answer the question at the form index
@@ -464,8 +480,18 @@ public class Scenario {
         return answer(new StringData(String.valueOf(value)));
     }
 
+    /**
+     * Answers the question at the form index
+     */
     public AnswerResult answer(LocalDate value) {
         return answer(new DateData(Date.valueOf(value)));
+    }
+
+    /**
+     * Answers the question at the form index
+     */
+    public AnswerResult answer(boolean value) {
+        return answer(new BooleanData(value));
     }
 
     private AnswerResult answer(IAnswerData data) {

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -175,6 +175,10 @@ public class Scenario {
         }
     }
 
+    public TreeReference getExpandedRef(String xpath) {
+        return expandSingle(getRef(xpath));
+    }
+
     /**
      * Prepares the form to answer a new blank instance
      */
@@ -665,6 +669,10 @@ public class Scenario {
 
     public boolean atTheEndOfForm() {
         return model.getFormIndex().isEndOfFormIndex();
+    }
+
+    public TreeReference refAtIndex() {
+        return formEntryController.getModel().getFormIndex().getReference();
     }
 
     public boolean atQuestion() {

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -134,6 +134,10 @@ public class Scenario {
 
     // region Miscelaneous
 
+    public FormDef getFormDef() {
+        return formDef;
+    }
+
     /**
      * Returns a TreeReference from the provided xpath string.
      * <p>
@@ -238,7 +242,7 @@ public class Scenario {
      * references to fully qualified references that wouldn't match existing
      * form indexes otherwise.
      */
-    private TreeReference expandSingle(TreeReference reference) {
+    public TreeReference expandSingle(TreeReference reference) {
         List<TreeReference> expandedRefs = ec.expandReference(reference);
         if (expandedRefs.size() != 1)
             throw new RuntimeException("Provided xPath expands to " + expandedRefs.size() + " references. Expecting exactly one expanded reference.");

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -191,10 +191,6 @@ public class Scenario {
         }
     }
 
-    public TreeReference getExpandedRef(String xpath) {
-        return expandSingle(getRef(xpath));
-    }
-
     /**
      * Prepares the form to answer a new blank instance
      */

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -55,6 +55,7 @@ import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.ValidateOutcome;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
@@ -137,6 +138,14 @@ public class Scenario {
 
     public FormDef getFormDef() {
         return formDef;
+    }
+
+    public FormIndex indexOf(String xPath) {
+        return getIndexOf(expandSingle(getRef(xPath)));
+    }
+
+    public ValidateOutcome getValidationOutcome() {
+        return formDef.validate(true);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -261,6 +261,29 @@ public class Scenario {
         return expandedRefs.get(0);
     }
 
+    public void trace(String msg) {
+        log.info("===============================================================================");
+        log.info("       " + msg);
+        log.info("===============================================================================");
+    }
+
+    public enum AnswerResult {
+        OK(0), REQUIRED_BUT_EMPTY(1), CONSTRAINT_VIOLATED(2);
+
+        private final int jrCode;
+
+        AnswerResult(int jrCode) {
+            this.jrCode = jrCode;
+        }
+
+        public static AnswerResult from(int jrCode) {
+            return Stream.of(values())
+                .filter(v -> v.jrCode == jrCode)
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+        }
+    }
+
     private boolean refExists(TreeReference reference) {
         return ec.expandReference(reference).size() == 1;
     }
@@ -335,29 +358,6 @@ public class Scenario {
         } while (index.isInForm());
         silentJump(backupIndex);
         return null;
-    }
-
-    public void trace(String msg) {
-        log.info("===============================================================================");
-        log.info("       " + msg);
-        log.info("===============================================================================");
-    }
-
-    public enum AnswerResult {
-        OK(0), REQUIRED_BUT_EMPTY(1), CONSTRAINT_VIOLATED(2);
-
-        private final int jrCode;
-
-        AnswerResult(int jrCode) {
-            this.jrCode = jrCode;
-        }
-
-        public static AnswerResult from(int jrCode) {
-            return Stream.of(values())
-                .filter(v -> v.jrCode == jrCode)
-                .findFirst()
-                .orElseThrow(RuntimeException::new);
-        }
     }
 
     // endregion
@@ -630,6 +630,13 @@ public class Scenario {
         return jumpResultCode;
     }
 
+    /**
+     * Jump the provided amount of times to the next event.
+     * <p>
+     * Side effects:
+     * - This method updates the form index.
+     * - This method leaves log traces
+     */
     public void next(int amount) {
         while (amount-- > 0)
             next();
@@ -646,11 +653,11 @@ public class Scenario {
         jump(BEGINNING_OF_FORM);
     }
 
-    public int silentNext() {
+    private int silentNext() {
         return formEntryController.stepToNextEvent();
     }
 
-    public int silentPrev() {
+    private int silentPrev() {
         return formEntryController.stepToPreviousEvent();
     }
 

--- a/src/test/java/org/javarosa/core/util/XFormsElement.java
+++ b/src/test/java/org/javarosa/core/util/XFormsElement.java
@@ -64,10 +64,10 @@ public interface XFormsElement {
 
     static XFormsElement html(XFormsElement... children) {
         return t("h:html " +
-                "xmlns=\"http://www.w3.org/2002/xforms\" " +
-                "xmlns:h=\"http://www.w3.org/1999/xhtml\" " +
-                "xmlns:jr=\"http://openrosa.org/javarosa\"",
-            children
+                        "xmlns=\"http://www.w3.org/2002/xforms\" " +
+                        "xmlns:h=\"http://www.w3.org/1999/xhtml\" " +
+                        "xmlns:jr=\"http://openrosa.org/javarosa\"",
+                children
         );
     }
 
@@ -108,6 +108,10 @@ public interface XFormsElement {
         return t("repeat nodeset=\"" + ref + "\"", children);
     }
 
+    static XFormsElement repeat(String ref, String countRef, XFormsElement... children) {
+        return t("repeat nodeset=\"" + ref + "\" jr:count=\"" + countRef + "\"", children);
+    }
+
     static XFormsElement label(String innerHtml) {
         return new StringLiteralXFormsElement("label", emptyMap(), innerHtml);
     }
@@ -118,8 +122,8 @@ public interface XFormsElement {
 
     static XFormsElement item(String value, String label) {
         return t("item",
-            t("label", label),
-            t("value", value)
+                t("label", label),
+                t("value", value)
         );
     }
 

--- a/src/test/java/org/javarosa/smoketests/ChildVaccionationTest.java
+++ b/src/test/java/org/javarosa/smoketests/ChildVaccionationTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2020 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.smoketests;
+
+
+import static org.javarosa.core.test.Scenario.getRef;
+import static org.javarosa.smoketests.ChildVaccionationTest.Sex.FEMALE;
+import static org.javarosa.smoketests.ChildVaccionationTest.Sex.MALE;
+import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.DIPHTERIA;
+import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.DIPHTERIA_AND_MEASLES;
+import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.DIPHTERIA_FIRST;
+import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.DIPHTERIA_FIRST_AND_MEASLES;
+import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.MEASLES;
+import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.NONE;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.Scenario;
+import org.junit.Test;
+
+public class ChildVaccionationTest {
+
+    public static final TreeReference NEXT_CHILD_REF = getRef("/data/household/child_repeat/nextChild");
+    public static final TreeReference NEXT_CHILD_NO_MOTHER_REF = getRef("/data/household/child_repeat/nextChild_no_mother");
+    public static final TreeReference FINAL_FLAT_REF = getRef("/data/household/finalflat");
+    public static final TreeReference VACCINATION_PENTA1_REF = getRef("/data/household/child_repeat/penta1");
+    public static final TreeReference VACCINATION_PENTA3_REF = getRef("/data/household/child_repeat/penta3");
+    public static final TreeReference VACCINATION_MEASLES_REF = getRef("/data/household/child_repeat/mcv1");
+    public static final TreeReference NOT_ELIG_NOTE_REF = getRef("/data/household/child_repeat/not_elig_note");
+    public static final LocalDate TODAY = LocalDate.now();
+    public static final TreeReference CHILD_REPEAT_REF = getRef("/data/household/child_repeat");
+
+    @Test
+    public void smoke_test() {
+        Scenario scenario = Scenario.init("child_vaccination_VOL_tool_v12.xml");
+
+        scenario.next();
+        scenario.answer("multi");
+        scenario.next();
+        scenario.next();
+        scenario.answer("1.234 5.678");
+        scenario.next();
+        scenario.answer("Some building");
+        scenario.next();
+        scenario.answer("Some address, some location");
+
+        // Start filling in households
+
+        AtomicInteger householdSeq = new AtomicInteger(1);
+        List<List<Consumer<Integer>>> households = HealthRecord.all().stream().flatMap(healthRecord -> buildHouseholds(scenario, healthRecord).stream()).collect(Collectors.toList());
+        for (int i = 0; i < households.size(); i++) {
+            answerHousehold(scenario, householdSeq.getAndIncrement(), households.get(i));
+            if (i + 1 < households.size()) {
+                scenario.next();
+                scenario.answer("no");
+                scenario.next();
+            }
+        }
+
+        scenario.trace("END HOUSEHOLDS");
+        scenario.next();
+        scenario.answer("yes");
+
+        // Go to the end of the form
+        scenario.next();
+        scenario.next();
+    }
+
+    private List<List<Consumer<Integer>>> buildHouseholds(Scenario scenario, HealthRecord healthRecord) {
+        return Arrays.asList(
+            buildChildrenWithLocalDates(scenario, 23, healthRecord),
+            buildChildrenWithIntegers(scenario, 23, healthRecord),
+            buildChildrenWithLocalDates(scenario, 6, healthRecord),
+            buildChildrenWithIntegers(scenario, 6, healthRecord),
+            buildChildrenWithLocalDates(scenario, 3, healthRecord),
+            buildChildrenWithIntegers(scenario, 3, healthRecord)
+        );
+    }
+
+    private List<Consumer<Integer>> buildChildrenWithIntegers(Scenario scenario, int ageInMonths, HealthRecord healthRecord) {
+        return Arrays.asList(
+            answerChild(scenario, healthRecord, ageInMonths, NONE, MALE),
+            answerChild(scenario, healthRecord, ageInMonths, DIPHTERIA_FIRST, FEMALE),
+            answerChild(scenario, healthRecord, ageInMonths, DIPHTERIA, MALE),
+            answerChild(scenario, healthRecord, ageInMonths, MEASLES, FEMALE),
+            answerChild(scenario, healthRecord, ageInMonths, DIPHTERIA_FIRST_AND_MEASLES, MALE),
+            answerChild(scenario, healthRecord, ageInMonths, DIPHTERIA_AND_MEASLES, FEMALE)
+        );
+    }
+
+    private List<Consumer<Integer>> buildChildrenWithLocalDates(Scenario scenario, int ageInMonths, HealthRecord healthRecord) {
+        LocalDate dob = TODAY.minusMonths(ageInMonths);
+        return Arrays.asList(
+            answerChild(scenario, healthRecord, dob, NONE, FEMALE),
+            answerChild(scenario, healthRecord, dob, DIPHTERIA_FIRST, MALE),
+            answerChild(scenario, healthRecord, dob, DIPHTERIA, FEMALE),
+            answerChild(scenario, healthRecord, dob, MEASLES, MALE),
+            answerChild(scenario, healthRecord, dob, DIPHTERIA_FIRST_AND_MEASLES, FEMALE),
+            answerChild(scenario, healthRecord, dob, DIPHTERIA_AND_MEASLES, MALE)
+        );
+    }
+
+    private void answerHousehold(Scenario scenario, int number, List<Consumer<Integer>> children) {
+        scenario.trace("HOUSEHOLD " + number);
+        scenario.next();
+        scenario.next();
+        scenario.answer(number);
+        // Does someone answer the door?
+        scenario.next();
+        scenario.answer("yes");
+        // Is there an adult
+        scenario.next();
+        scenario.answer("yes");
+        // Do children under 2 live in the house?
+        scenario.next();
+        scenario.answer("yes");
+        // What's the mother's or caregiver's name
+        scenario.next();
+        scenario.answer("Foo");
+        // Is the mother or caregiver present?
+        scenario.next();
+        scenario.answer("yes");
+        // Give consent
+        scenario.next();
+        scenario.answer("yes");
+        // How many children under 2?
+        scenario.next();
+        scenario.answer(children.size());
+
+        answerChildren(scenario, children);
+    }
+
+
+    enum Vaccines {
+        NONE(false, false, false),
+        DIPHTERIA_FIRST(true, false, false),
+        DIPHTERIA(true, true, false),
+        MEASLES(false, false, true),
+        DIPHTERIA_FIRST_AND_MEASLES(true, false, true),
+        DIPHTERIA_AND_MEASLES(true, true, true);
+
+        static List<TreeReference> END_OF_VISIT_REFS = Arrays.asList(NEXT_CHILD_REF, FINAL_FLAT_REF, CHILD_REPEAT_REF);
+
+        private final boolean diphteriaFirst;
+        private final boolean diphteriaThird;
+        private final boolean measles;
+
+        Vaccines(boolean diphteriaFirst, boolean diphteriaThird, boolean measles) {
+            this.diphteriaFirst = diphteriaFirst;
+            this.diphteriaThird = diphteriaThird;
+            this.measles = measles;
+        }
+
+        void visit(Scenario scenario) {
+            // Answer questions until there's no more vaccination related questions
+            while (!(END_OF_VISIT_REFS.contains(scenario.nextRef().genericize()))) {
+                scenario.next();
+                if (scenario.refAtIndex().genericize().equals(VACCINATION_PENTA1_REF))
+                    scenario.answer(diphteriaFirst ? "yes" : "no");
+                else if (scenario.refAtIndex().genericize().equals(VACCINATION_PENTA3_REF))
+                    scenario.answer(diphteriaThird ? "yes" : "no");
+                else if (scenario.refAtIndex().genericize().equals(VACCINATION_MEASLES_REF))
+                    scenario.answer(measles ? "yes" : "no");
+            }
+        }
+    }
+
+    enum HealthRecord {
+        HEALTH_HANDBOOK,
+        VACCINATION_CARD,
+        HEALTH_CLINIC;
+
+        public static List<HealthRecord> all() {
+            return Arrays.asList(values());
+        }
+
+        void visit(Scenario scenario) {
+            if (this == HEALTH_HANDBOOK) {
+                scenario.next();
+                scenario.answer("yes");
+            } else if (this == VACCINATION_CARD) {
+                scenario.next();
+                scenario.answer("no");
+                scenario.next();
+                scenario.answer("yes");
+            } else if (this == HEALTH_CLINIC) {
+                scenario.next();
+                scenario.answer("no");
+                scenario.next();
+                scenario.answer("no");
+                scenario.next();
+                scenario.answer("yes");
+            }
+        }
+    }
+
+    enum Sex {
+        FEMALE("female"), MALE("male");
+
+        private final String name;
+
+        Sex(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private void answerChildren(Scenario scenario, List<Consumer<Integer>> children) {
+        for (int i = 0; i < children.size(); i++)
+            children.get(i).accept(i + 1);
+        scenario.trace("END CHILDREN");
+    }
+
+    private Consumer<Integer> answerChild(Scenario scenario, HealthRecord healthRecord, LocalDate dob, Vaccines vaccines, Sex sex) {
+        return i -> {
+            int ageInMonths = dob.until(TODAY).getMonths();
+            String name = String.format("CHILD %d - Age %d months - %s", i, ageInMonths, sex.getName());
+            scenario.trace(name);
+            scenario.next();
+            scenario.next();
+            scenario.answer(name);
+            healthRecord.visit(scenario);
+            scenario.next();
+            scenario.answer(sex.getName());
+            answerDateOfBirth(scenario, dob);
+            if (scenario.nextRef().genericize().equals(NOT_ELIG_NOTE_REF))
+                scenario.next();
+            else if (scenario.nextRef().genericize().equals(VACCINATION_PENTA1_REF))
+                vaccines.visit(scenario);
+
+            if (Arrays.asList(NEXT_CHILD_REF, NEXT_CHILD_NO_MOTHER_REF).contains(scenario.nextRef().genericize()))
+                scenario.next();
+        };
+    }
+
+    private Consumer<Integer> answerChild(Scenario scenario, HealthRecord healthRecord, int ageInMonths, Vaccines vaccines, Sex sex) {
+        return i -> {
+            String name = String.format("CHILD %d - Age %d months - %s", i, ageInMonths, sex.getName());
+            scenario.trace(name);
+            scenario.next();
+            scenario.next();
+            scenario.answer(name);
+            healthRecord.visit(scenario);
+            scenario.next();
+            scenario.answer(sex.getName());
+            answerAgeInMonths(scenario, ageInMonths);
+            if (scenario.nextRef().genericize().equals(NOT_ELIG_NOTE_REF))
+                scenario.next();
+            else if (scenario.nextRef().genericize().equals(VACCINATION_PENTA1_REF))
+                vaccines.visit(scenario);
+
+            if (Arrays.asList(NEXT_CHILD_REF, NEXT_CHILD_NO_MOTHER_REF).contains(scenario.nextRef().genericize()))
+                scenario.next();
+        };
+    }
+
+    private void answerDateOfBirth(Scenario scenario, LocalDate dob) {
+        // Is DoB known?
+        scenario.next();
+        scenario.answer("yes");
+        // Year in DoB
+        scenario.next();
+        scenario.answer(dob.getYear());
+        // Month in DoB
+        scenario.next();
+        scenario.answer(dob.getMonthValue());
+        // Day in DoB
+        scenario.next();
+        scenario.answer(dob.getDayOfMonth());
+    }
+
+    private void answerAgeInMonths(Scenario scenario, int ageInMonths) {
+        // Is DoB known?
+        scenario.next();
+        scenario.answer("no");
+        // Age in months
+        scenario.next();
+        scenario.answer(ageInMonths);
+    }
+
+}

--- a/src/test/java/org/javarosa/smoketests/ChildVaccionationTest.java
+++ b/src/test/java/org/javarosa/smoketests/ChildVaccionationTest.java
@@ -17,6 +17,9 @@
 package org.javarosa.smoketests;
 
 
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.Scenario.getRef;
 import static org.javarosa.smoketests.ChildVaccionationTest.Sex.FEMALE;
 import static org.javarosa.smoketests.ChildVaccionationTest.Sex.MALE;
@@ -26,32 +29,39 @@ import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.DIPHTERIA_F
 import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.DIPHTERIA_FIRST_AND_MEASLES;
 import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.MEASLES;
 import static org.javarosa.smoketests.ChildVaccionationTest.Vaccines.NONE;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.test.Scenario;
 import org.junit.Test;
 
 public class ChildVaccionationTest {
 
-    public static final TreeReference NEXT_CHILD_REF = getRef("/data/household/child_repeat/nextChild");
-    public static final TreeReference NEXT_CHILD_NO_MOTHER_REF = getRef("/data/household/child_repeat/nextChild_no_mother");
-    public static final TreeReference FINAL_FLAT_REF = getRef("/data/household/finalflat");
+    public static final TreeReference DOB_DAY_MONTH_TYPE_1_REF = getRef("/data/household/child_repeat/dob_day_1");
+    public static final TreeReference DOB_DAY_MONTH_TYPE_2_REF = getRef("/data/household/child_repeat/dob_day_2");
+    public static final TreeReference DOB_DAY_MONTH_TYPE_3_REF = getRef("/data/household/child_repeat/dob_day_3");
+    public static final TreeReference DOB_DAY_MONTH_TYPE_4_REF = getRef("/data/household/child_repeat/dob_day_4");
+    public static final TreeReference DOB_AGE_IN_MONTHS_REF = getRef("/data/household/child_repeat/age_months");
     public static final TreeReference VACCINATION_PENTA1_REF = getRef("/data/household/child_repeat/penta1");
     public static final TreeReference VACCINATION_PENTA3_REF = getRef("/data/household/child_repeat/penta3");
     public static final TreeReference VACCINATION_MEASLES_REF = getRef("/data/household/child_repeat/mcv1");
-    public static final TreeReference NOT_ELIG_NOTE_REF = getRef("/data/household/child_repeat/not_elig_note");
-    public static final LocalDate TODAY = LocalDate.now();
     public static final TreeReference CHILD_REPEAT_REF = getRef("/data/household/child_repeat");
+    public static final TreeReference NOT_ELIG_NOTE_REF = getRef("/data/household/child_repeat/not_elig_note");
+    public static final TreeReference NEXT_CHILD_REF = getRef("/data/household/child_repeat/nextChild");
+    public static final TreeReference NEXT_CHILD_NO_MOTHER_REF = getRef("/data/household/child_repeat/nextChild_no_mother");
+    public static final TreeReference FINAL_FLAT_REF = getRef("/data/household/finalflat");
+    public static final LocalDate TODAY = LocalDate.now();
 
     @Test
     public void smoke_test() {
         Scenario scenario = Scenario.init("child_vaccination_VOL_tool_v12.xml");
+
+        // region Answer questions about the building
 
         scenario.next();
         scenario.answer("multi");
@@ -63,29 +73,73 @@ public class ChildVaccionationTest {
         scenario.next();
         scenario.answer("Some address, some location");
 
-        // Start filling in households
+        // endregion
 
-        AtomicInteger householdSeq = new AtomicInteger(1);
-        List<List<Consumer<Integer>>> households = HealthRecord.all().stream().flatMap(healthRecord -> buildHouseholds(scenario, healthRecord).stream()).collect(Collectors.toList());
+        // region Answer all household repeats
+
+        // Create all possible permutations of children combining
+        // all health record types, meaningful ages, ways to define age,
+        // and vaccination sets, which amounts to 18 households and 108 children
+        List<List<Consumer<Integer>>> households = HealthRecord.all().stream()
+            .flatMap(healthRecord -> buildHouseholdChildren(scenario, healthRecord).stream())
+            .collect(toList());
+
         for (int i = 0; i < households.size(); i++) {
-            answerHousehold(scenario, householdSeq.getAndIncrement(), households.get(i));
+            List<Consumer<Integer>> children = households.get(i);
+            answerHousehold(scenario, i, children);
+            assertThat(scenario.refAtIndex().genericize(), anyOf(
+                // Either we stopped after filling the age with a decomposed date
+                is(DOB_DAY_MONTH_TYPE_1_REF),
+                is(DOB_DAY_MONTH_TYPE_2_REF),
+                is(DOB_DAY_MONTH_TYPE_3_REF),
+                is(DOB_DAY_MONTH_TYPE_4_REF),
+                // Or we stopped after filling the age in months
+                is(DOB_AGE_IN_MONTHS_REF),
+                // Or we stopped after answering any of the vaccination questions
+                is(VACCINATION_PENTA1_REF),
+                is(VACCINATION_PENTA3_REF),
+                is(VACCINATION_MEASLES_REF),
+                // Or we answered all questions
+                is(NEXT_CHILD_REF)
+            ));
             if (i + 1 < households.size()) {
                 scenario.next();
                 scenario.answer("no");
                 scenario.next();
+            } else {
+                scenario.next();
+                scenario.answer("yes");
             }
         }
 
         scenario.trace("END HOUSEHOLDS");
-        scenario.next();
-        scenario.answer("yes");
 
-        // Go to the end of the form
+        // endregion
+
+        // region Go to the end of the form
+
         scenario.next();
         scenario.next();
+
+        // endregion
     }
 
-    private List<List<Consumer<Integer>>> buildHouseholds(Scenario scenario, HealthRecord healthRecord) {
+    /**
+     * Builds every possible combination of:
+     * <ul>
+     *     <li>Meaningful ages: 23, 6 and 3 months</li>
+     *     <li>Supported ways of defining the age: a decomposed date of birth or
+     *     a number of months</li>
+     *     <li>Vaccination records: No vaccines, first and third diphteria shot, measles shot</li>
+     * </ul>
+     * <p>
+     * These combinations ensure that all critical paths for the provided health
+     * record type are taken while filling out a child group.
+     * <p>
+     * Since the form's limit to the number of children per household is 10, this method will return
+     * a list entry per every 6 children (the possible permutations of vaccine sets).
+     */
+    private List<List<Consumer<Integer>>> buildHouseholdChildren(Scenario scenario, HealthRecord healthRecord) {
         return Arrays.asList(
             buildChildrenWithLocalDates(scenario, 23, healthRecord),
             buildChildrenWithIntegers(scenario, 23, healthRecord),
@@ -120,6 +174,8 @@ public class ChildVaccionationTest {
     }
 
     private void answerHousehold(Scenario scenario, int number, List<Consumer<Integer>> children) {
+        // region Answer info about the household
+
         scenario.trace("HOUSEHOLD " + number);
         scenario.next();
         scenario.next();
@@ -142,11 +198,17 @@ public class ChildVaccionationTest {
         // Give consent
         scenario.next();
         scenario.answer("yes");
+
+        // endregion
+
         // How many children under 2?
         scenario.next();
         scenario.answer(children.size());
 
-        answerChildren(scenario, children);
+        for (int i = 0; i < children.size(); i++)
+            children.get(i).accept(i);
+
+        scenario.trace("END CHILDREN");
     }
 
 
@@ -227,12 +289,6 @@ public class ChildVaccionationTest {
         }
     }
 
-    private void answerChildren(Scenario scenario, List<Consumer<Integer>> children) {
-        for (int i = 0; i < children.size(); i++)
-            children.get(i).accept(i + 1);
-        scenario.trace("END CHILDREN");
-    }
-
     private Consumer<Integer> answerChild(Scenario scenario, HealthRecord healthRecord, LocalDate dob, Vaccines vaccines, Sex sex) {
         return i -> {
             int ageInMonths = dob.until(TODAY).getMonths();
@@ -252,6 +308,8 @@ public class ChildVaccionationTest {
 
             if (Arrays.asList(NEXT_CHILD_REF, NEXT_CHILD_NO_MOTHER_REF).contains(scenario.nextRef().genericize()))
                 scenario.next();
+            else if (!scenario.nextRef().genericize().equals(FINAL_FLAT_REF))
+                fail("Unexpected next ref " + scenario.nextRef().toString(true, true) + " at index");
         };
     }
 
@@ -266,13 +324,13 @@ public class ChildVaccionationTest {
             scenario.next();
             scenario.answer(sex.getName());
             answerAgeInMonths(scenario, ageInMonths);
-            if (scenario.nextRef().genericize().equals(NOT_ELIG_NOTE_REF))
-                scenario.next();
-            else if (scenario.nextRef().genericize().equals(VACCINATION_PENTA1_REF))
+            if (scenario.nextRef().genericize().equals(VACCINATION_PENTA1_REF))
                 vaccines.visit(scenario);
 
             if (Arrays.asList(NEXT_CHILD_REF, NEXT_CHILD_NO_MOTHER_REF).contains(scenario.nextRef().genericize()))
                 scenario.next();
+            else if (!scenario.nextRef().genericize().equals(FINAL_FLAT_REF))
+                fail("Unexpected next ref " + scenario.nextRef().toString(true, true) + " at index");
         };
     }
 

--- a/src/test/java/org/javarosa/smoketests/ChildVaccionationTest.java
+++ b/src/test/java/org/javarosa/smoketests/ChildVaccionationTest.java
@@ -54,7 +54,9 @@ public class ChildVaccionationTest {
     public static final TreeReference NOT_ELIG_NOTE_REF = getRef("/data/household/child_repeat/not_elig_note");
     public static final TreeReference NEXT_CHILD_REF = getRef("/data/household/child_repeat/nextChild");
     public static final TreeReference NEXT_CHILD_NO_MOTHER_REF = getRef("/data/household/child_repeat/nextChild_no_mother");
+    public static final TreeReference NEW_HOUSEHOLD_REPEAT_JUNCTION_REF = getRef("/data/household");
     public static final TreeReference FINAL_FLAT_REF = getRef("/data/household/finalflat");
+    public static final TreeReference FINISHED_FORM_REF = getRef("/data/household/finished2");
     public static final LocalDate TODAY = LocalDate.now();
 
     @Test
@@ -86,7 +88,13 @@ public class ChildVaccionationTest {
 
         for (int i = 0; i < households.size(); i++) {
             List<Consumer<Integer>> children = households.get(i);
+            assertThat(scenario.nextRef().genericize(), is(NEW_HOUSEHOLD_REPEAT_JUNCTION_REF));
             answerHousehold(scenario, i, children);
+            // We just want to make sure that we are in a valid position without
+            // going into more detail. Due to the conditional nature of this
+            // form, it would be too complex to describe that in a test with all
+            // the precission in a test like this one that will follow all possible
+            // branches.
             assertThat(scenario.refAtIndex().genericize(), anyOf(
                 // Either we stopped after filling the age with a decomposed date
                 is(DOB_DAY_MONTH_TYPE_1_REF),
@@ -102,12 +110,12 @@ public class ChildVaccionationTest {
                 // Or we answered all questions
                 is(NEXT_CHILD_REF)
             ));
+            scenario.next();
+            assertThat(scenario.refAtIndex().genericize(), is(FINAL_FLAT_REF));
             if (i + 1 < households.size()) {
-                scenario.next();
                 scenario.answer("no");
                 scenario.next();
             } else {
-                scenario.next();
                 scenario.answer("yes");
             }
         }
@@ -119,6 +127,7 @@ public class ChildVaccionationTest {
         // region Go to the end of the form
 
         scenario.next();
+        assertThat(scenario.refAtIndex().genericize(), is(FINISHED_FORM_REF));
         scenario.next();
 
         // endregion

--- a/src/test/java/org/javarosa/smoketests/WhoVATest.java
+++ b/src/test/java/org/javarosa/smoketests/WhoVATest.java
@@ -75,7 +75,6 @@ public class WhoVATest {
         assertThat(scenario.getAnswerNode("/data/consented/illhistory/illdur/Id10120_0"), is(nonRelevant()));
     }
 
-    // TODO Add a comment pointing out which questions belong to the longest path or, at least, where it's exercised in this script.
     @Test
     public void smoke_test_route_fever_and_lumps() {
         Scenario scenario = Scenario.init(r("whova_form.xml"));
@@ -99,6 +98,7 @@ public class WhoVATest {
         scenario.next();
         scenario.answer(LocalDate.parse("1998-01-01"));
         // (Id10022) Is the date of death known? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10022
+        // This question triggers one of the longest evaluation chain of triggerables including 5 calculations
         scenario.next();
         scenario.answer("yes");
         // (Id10021) When was the deceased born? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10021

--- a/src/test/java/org/javarosa/smoketests/WhoVATest.java
+++ b/src/test/java/org/javarosa/smoketests/WhoVATest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.test.QuestionDefMatchers.irrelevant;
+import static org.javarosa.core.test.Scenario.getRef;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertThat;
 
@@ -74,6 +75,7 @@ public class WhoVATest {
         assertThat(scenario.getAnswerNode("/data/consented/illhistory/illdur/Id10120_0"), is(irrelevant()));
     }
 
+    // TODO Add a comment pointing out which questions belong to the longest path or, at least, where it's exercised in this script.
     @Test
     public void smoke_test_route_fever_and_lumps() {
         Scenario scenario = Scenario.init(r("whova_form.xml"));
@@ -81,14 +83,14 @@ public class WhoVATest {
         // region Give consent to unblock the rest of the form
         // (Id10013) [Did the respondent give consent?] ref:/data/respondent_backgr/Id10013
         scenario.next(14);
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/respondent_backgr/Id10013")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/respondent_backgr/Id10013")));
         scenario.answer("yes");
         // endregion
 
         // region Info on deceased
         // (Id10019) What was the sex of the deceased? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10019
         scenario.next(6);
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/deceased_CRVS/info_on_deceased/Id10019")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/deceased_CRVS/info_on_deceased/Id10019")));
         scenario.answer("female");
         // (Id10020) Is the date of birth known? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10020
         scenario.next();
@@ -110,7 +112,7 @@ public class WhoVATest {
 
         // Skip a bunch of non yes/no questions
         scenario.next(11);
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/illdur/id10120_unit")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/illhistory/illdur/id10120_unit")));
 
         // Answer no to the rest of questions
         IntStream.range(0, 23).forEach(n -> {
@@ -123,7 +125,7 @@ public class WhoVATest {
         // region Signs and symptoms - fever
         // (Id10147) Did (s)he have a fever? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10147
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10147")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10147")));
         scenario.answer("yes");
         // (Id10148_units) How long did the fever last? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10148_units
         scenario.next();
@@ -140,7 +142,7 @@ public class WhoVATest {
         // (Id10151) What was the pattern of the fever? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10151
         scenario.next();
         scenario.answer("nightly");
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10151")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10151")));
         // endregion
 
         // region Answer "no" until we get to the lumps group
@@ -154,7 +156,7 @@ public class WhoVATest {
         // region Signs and symptoms - lumps
         // (Id10253) Did (s)he have any lumps? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10253
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10253")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10253")));
         scenario.answer("yes");
         // (Id10254) Did (s)he have any lumps or lesions in the mouth? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10254
         scenario.next();
@@ -168,7 +170,7 @@ public class WhoVATest {
         // (Id10257) Did (s)he have any lumps on the groin? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10257
         scenario.next();
         scenario.answer("yes");
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10257")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10257")));
         // endregion
 
         // region Answer "no" to almost the end of the form
@@ -181,7 +183,7 @@ public class WhoVATest {
 
         // region Answer the last question with comments
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/comment")));
+        assertThat(scenario.refAtIndex().genericize(), is(getRef("/data/consented/comment")));
         scenario.answer("No comments");
 
         scenario.next();

--- a/src/test/java/org/javarosa/smoketests/WhoVATest.java
+++ b/src/test/java/org/javarosa/smoketests/WhoVATest.java
@@ -18,11 +18,14 @@ package org.javarosa.smoketests;
 
 
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.test.QuestionDefMatchers.irrelevant;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertThat;
 
 import java.time.LocalDate;
+import java.util.stream.IntStream;
 import org.javarosa.core.test.Scenario;
 import org.junit.Test;
 
@@ -31,19 +34,15 @@ public class WhoVATest {
     public void regression_after_2_17_0_relevance_updates() {
         Scenario scenario = Scenario.init(r("whova_form.xml"));
 
-        scenario.next(13);
-
         // region Give consent to unblock the rest of the form
         // (Id10013) [Did the respondent give consent?] ref:/data/respondent_backgr/Id10013
-        scenario.next();
+        scenario.next(14);
         scenario.answer("yes");
         // endregion
 
-        scenario.next(5);
-
         // region Info on deceased
         // (Id10019) What was the sex of the deceased? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10019
-        scenario.next();
+        scenario.next(6);
         scenario.answer("female");
         // (Id10020) Is the date of birth known? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10020
         scenario.next();
@@ -57,6 +56,7 @@ public class WhoVATest {
         // (Id10021) When was the deceased born? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10021
         scenario.next();
         scenario.answer(LocalDate.parse("2018-01-01"));
+        // endregion
 
         /*
          * Regression happens here: we changed FormInstanceParser to add all descendants of a group as targets
@@ -72,6 +72,121 @@ public class WhoVATest {
          * expected relevance state.
          */
         assertThat(scenario.getAnswerNode("/data/consented/illhistory/illdur/Id10120_0"), is(irrelevant()));
+    }
+
+    @Test
+    public void smoke_test_route_fever_and_lumps() {
+        Scenario scenario = Scenario.init(r("whova_form.xml"));
+
+        // region Give consent to unblock the rest of the form
+        // (Id10013) [Did the respondent give consent?] ref:/data/respondent_backgr/Id10013
+        scenario.next(14);
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/respondent_backgr/Id10013")));
+        scenario.answer("yes");
+        // endregion
+
+        // region Info on deceased
+        // (Id10019) What was the sex of the deceased? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10019
+        scenario.next(6);
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/deceased_CRVS/info_on_deceased/Id10019")));
+        scenario.answer("female");
+        // (Id10020) Is the date of birth known? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10020
+        scenario.next();
+        scenario.answer("yes");
+        // (Id10021) When was the deceased born? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10021
+        scenario.next();
+        scenario.answer(LocalDate.parse("1998-01-01"));
+        // (Id10022) Is the date of death known? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10022
+        scenario.next();
+        scenario.answer("yes");
+        // (Id10021) When was the deceased born? ref:/data/consented/deceased_CRVS/info_on_deceased/Id10021
+        scenario.next();
+        scenario.answer(LocalDate.parse("2018-01-01"));
+
+        // Sanity check about age and isAdult field
+        assertThat(scenario.answerOf("/data/consented/deceased_CRVS/info_on_deceased/ageInDays"), is(intAnswer(7305)));
+        assertThat(scenario.answerOf("/data/consented/deceased_CRVS/info_on_deceased/isAdult"), is(stringAnswer("1")));
+        assertThat(scenario.answerOf("/data/consented/deceased_CRVS/info_on_deceased/isNeonatal"), is(stringAnswer("0")));
+
+        // Skip a bunch of non yes/no questions
+        scenario.next(11);
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/illdur/id10120_unit")));
+
+        // Answer no to the rest of questions
+        IntStream.range(0, 23).forEach(n -> {
+            scenario.next();
+            if (scenario.atQuestion())
+                scenario.answer("no");
+        });
+        // endregion
+
+        // region Signs and symptoms - fever
+        // (Id10147) Did (s)he have a fever? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10147
+        scenario.next();
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10147")));
+        scenario.answer("yes");
+        // (Id10148_units) How long did the fever last? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10148_units
+        scenario.next();
+        scenario.answer("days");
+        // (Id10148_b) [Enter how long the fever lasted in days]: ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10148_b
+        scenario.next();
+        scenario.answer(30);
+        // (Id10149) Did the fever continue until death? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10149
+        scenario.next();
+        scenario.answer("yes");
+        // (Id10150) How severe was the fever? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10150
+        scenario.next();
+        scenario.answer("severe");
+        // (Id10151) What was the pattern of the fever? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10151
+        scenario.next();
+        scenario.answer("nightly");
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10151")));
+        // endregion
+
+        // region Answer "no" until we get to the lumps group
+        IntStream.range(0, 36).forEach(n -> {
+            scenario.next();
+            if (scenario.atQuestion())
+                scenario.answer("no");
+        });
+        // endregion
+
+        // region Signs and symptoms - lumps
+        // (Id10253) Did (s)he have any lumps? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10253
+        scenario.next();
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10253")));
+        scenario.answer("yes");
+        // (Id10254) Did (s)he have any lumps or lesions in the mouth? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10254
+        scenario.next();
+        scenario.answer("yes");
+        // (Id10255) Did (s)he have any lumps on the neck? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10255
+        scenario.next();
+        scenario.answer("yes");
+        // (Id10256) Did (s)he have any lumps on the armpit? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10256
+        scenario.next();
+        scenario.answer("yes");
+        // (Id10257) Did (s)he have any lumps on the groin? ref:/data/consented/illhistory/signs_symptoms_final_illness/Id10257
+        scenario.next();
+        scenario.answer("yes");
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/illhistory/signs_symptoms_final_illness/Id10257")));
+        // endregion
+
+        // region Answer "no" to almost the end of the form
+        IntStream.range(0, 59).forEach(n -> {
+            scenario.next();
+            if (scenario.atQuestion())
+                scenario.answer("no");
+        });
+        // endregion
+
+        // region Answer the last question with comments
+        scenario.next();
+        assertThat(scenario.refAtIndex(), is(scenario.getExpandedRef("/data/consented/comment")));
+        scenario.answer("No comments");
+
+        scenario.next();
+        assertThat(scenario.atTheEndOfForm(), is(true));
+        // endregion
     }
 
 }

--- a/src/test/java/org/javarosa/smoketests/WhoVATest.java
+++ b/src/test/java/org/javarosa/smoketests/WhoVATest.java
@@ -20,7 +20,7 @@ package org.javarosa.smoketests;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
-import static org.javarosa.core.test.QuestionDefMatchers.irrelevant;
+import static org.javarosa.core.test.QuestionDefMatchers.nonRelevant;
 import static org.javarosa.core.test.Scenario.getRef;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertThat;
@@ -72,7 +72,7 @@ public class WhoVATest {
          * not equipotent, ensuring that the one declared in the field will be evaluated last, producing the
          * expected relevance state.
          */
-        assertThat(scenario.getAnswerNode("/data/consented/illhistory/illdur/Id10120_0"), is(irrelevant()));
+        assertThat(scenario.getAnswerNode("/data/consented/illhistory/illdur/Id10120_0"), is(nonRelevant()));
     }
 
     // TODO Add a comment pointing out which questions belong to the longest path or, at least, where it's exercised in this script.

--- a/src/test/resources/child_vaccination_VOL_tool_v12.xml
+++ b/src/test/resources/child_vaccination_VOL_tool_v12.xml
@@ -1,0 +1,1201 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>child_vaccination_VOL_tool_v12</h:title>
+        <model>
+            <instance>
+                <data id="VOL_CVT_0627" version="1">
+                    <today/>
+                    <start/>
+                    <end/>
+                    <deviceid/>
+                    <phonenumber/>
+                    <building_type/>
+                    <home_type/>
+                    <home_type2/>
+                    <home_type3/>
+                    <not_single>
+                        <gps/>
+                        <accuracy/>
+                        <rounded_accuracy/>
+                        <gps2/>
+                    </not_single>
+                    <building_name/>
+                    <full_address1/>
+                    <flatcount/>
+                    <household_count/>
+                    <household jr:template="">
+                        <houseCount/>
+                        <nextHse/>
+                        <flatNumber/>
+                        <inHome/>
+                        <adultPresence/>
+                        <adultName/>
+                        <childPresent/>
+                        <familyName/>
+                        <motherName/>
+                        <NameA/>
+                        <motherPresent/>
+                        <consent/>
+                        <childNum/>
+                        <child_repeat_count/>
+                        <child_repeat jr:template="">
+                            <childName/>
+                            <NameB/>
+                            <health_card/>
+                            <vacc_record_note/>
+                            <no_card/>
+                            <ever_had_card/>
+                            <ever_been_clinic/>
+                            <sex/>
+                            <gender_ref/>
+                            <dobknown/>
+                            <dob_year/>
+                            <leap/>
+                            <dob_month/>
+                            <dob_day_1/>
+                            <dob_day_2/>
+                            <dob_day_3/>
+                            <dob_day_4/>
+                            <dob_day/>
+                            <dob_month_fix/>
+                            <dob_day_fix/>
+                            <dob/>
+                            <age_days/>
+                            <month_name/>
+                            <not_elig_note/>
+                            <dobnote2/>
+                            <age_months/>
+                            <under2/>
+                            <penta1/>
+                            <pt1/>
+                            <penta3/>
+                            <pt3/>
+                            <mcv1/>
+                            <mr1/>
+                            <count/>
+                            <addchild/>
+                            <nextChild_no_mother/>
+                            <nextChild/>
+                        </child_repeat>
+                        <no_cards/>
+                        <missVaccine/>
+                        <thankyou/>
+                        <single>
+                            <full_address_single/>
+                            <single_consent_not_withheld>
+                                <gps_single1/>
+                                <accuracy_single1/>
+                                <rounded_accuracy_single1/>
+                                <gps_single2/>
+                            </single_consent_not_withheld>
+                            <single_consent_withheld>
+                                <gps_single_no_consent1/>
+                                <accuracy_single_no_consent1/>
+                                <rounded_accuracy_single_no_consent1/>
+                                <gps_single_no_consent2/>
+                            </single_consent_withheld>
+                            <finished1/>
+                        </single>
+                        <finalflat/>
+                        <finishednote/>
+                        <finished2/>
+                    </household>
+                    <household>
+                        <houseCount/>
+                        <nextHse/>
+                        <flatNumber/>
+                        <inHome/>
+                        <adultPresence/>
+                        <adultName/>
+                        <childPresent/>
+                        <familyName/>
+                        <motherName/>
+                        <NameA/>
+                        <motherPresent/>
+                        <consent/>
+                        <childNum/>
+                        <child_repeat_count/>
+                        <child_repeat>
+                            <childName/>
+                            <NameB/>
+                            <health_card/>
+                            <vacc_record_note/>
+                            <no_card/>
+                            <ever_had_card/>
+                            <ever_been_clinic/>
+                            <sex/>
+                            <gender_ref/>
+                            <dobknown/>
+                            <dob_year/>
+                            <leap/>
+                            <dob_month/>
+                            <dob_day_1/>
+                            <dob_day_2/>
+                            <dob_day_3/>
+                            <dob_day_4/>
+                            <dob_day/>
+                            <dob_month_fix/>
+                            <dob_day_fix/>
+                            <dob/>
+                            <age_days/>
+                            <month_name/>
+                            <not_elig_note/>
+                            <dobnote2/>
+                            <age_months/>
+                            <under2/>
+                            <penta1/>
+                            <pt1/>
+                            <penta3/>
+                            <pt3/>
+                            <mcv1/>
+                            <mr1/>
+                            <count/>
+                            <addchild/>
+                            <nextChild_no_mother/>
+                            <nextChild/>
+                        </child_repeat>
+                        <no_cards/>
+                        <missVaccine/>
+                        <thankyou/>
+                        <single>
+                            <full_address_single/>
+                            <single_consent_not_withheld>
+                                <gps_single1/>
+                                <accuracy_single1/>
+                                <rounded_accuracy_single1/>
+                                <gps_single2/>
+                            </single_consent_not_withheld>
+                            <single_consent_withheld>
+                                <gps_single_no_consent1/>
+                                <accuracy_single_no_consent1/>
+                                <rounded_accuracy_single_no_consent1/>
+                                <gps_single_no_consent2/>
+                            </single_consent_withheld>
+                            <finished1/>
+                        </single>
+                        <finalflat/>
+                        <finishednote/>
+                        <finished2/>
+                    </household>
+                    <not_a_dwelling>
+                        <endnote2/>
+                    </not_a_dwelling>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind jr:preload="date" jr:preloadParams="today" nodeset="/data/today" type="date"/>
+            <bind jr:preload="timestamp" jr:preloadParams="start" nodeset="/data/start" type="dateTime"/>
+            <bind jr:preload="timestamp" jr:preloadParams="end" nodeset="/data/end" type="dateTime"/>
+            <bind jr:preload="property" jr:preloadParams="deviceid" nodeset="/data/deviceid" type="string"/>
+            <bind jr:preload="property" jr:preloadParams="phonenumber" nodeset="/data/phonenumber" type="string"/>
+            <bind nodeset="/data/building_type" required="true()" type="string"/>
+            <bind calculate="if( /data/building_type ='single','house',if( /data/building_type ='multi','flat/dwelling',&quot;&quot;))" nodeset="/data/home_type" type="string"/>
+            <bind calculate="if( /data/building_type ='single','home',if( /data/building_type ='multi','flat/dwelling',&quot;&quot;))" nodeset="/data/home_type2" type="string"/>
+            <bind calculate="if( /data/building_type ='single','House',if( /data/building_type ='multi','Flat',&quot;&quot;))" nodeset="/data/home_type3" type="string"/>
+            <bind nodeset="/data/not_single" relevant=" /data/building_type  != 'single'"/>
+            <bind nodeset="/data/not_single/gps" required="true()" type="geopoint"/>
+            <bind calculate="selected-at( /data/not_single/gps ,3)" nodeset="/data/not_single/accuracy" type="string"/>
+            <bind calculate="round( /data/not_single/accuracy ,2)" nodeset="/data/not_single/rounded_accuracy" type="string"/>
+            <bind nodeset="/data/not_single/gps2" relevant=" /data/not_single/rounded_accuracy &gt; 5 or  /data/not_single/rounded_accuracy  = 0" required="true()" type="geopoint"/>
+            <bind nodeset="/data/building_name" relevant=" /data/building_type ='multi'" type="string"/>
+            <bind nodeset="/data/full_address1" relevant=" /data/building_type ='multi'" type="string"/>
+            <bind calculate="count( /data/household )" nodeset="/data/flatcount" relevant=" /data/building_type ='multi'" type="string"/>
+            <bind nodeset="/data/household_count" readonly="true()" type="string"
+                  calculate="
+                    if(
+                        /data/building_type = 'single',
+                        1,
+                        if(
+                            /data/flatcount = 0 or indexed-repeat(/data/household/finalflat, /data/household, /data/flatcount) != 'yes',
+                            /data/flatcount + 1,
+                            /data/flatcount
+                        )
+                    )"
+            />
+            <bind nodeset="/data/household" relevant=" /data/building_type !='not_dwelling'"/>
+            <bind calculate="position(..)" nodeset="/data/household/houseCount" type="string"/>
+            <bind calculate=" ../houseCount +1" nodeset="/data/household/nextHse" type="string"/>
+            <bind nodeset="/data/household/flatNumber" relevant=" /data/building_type ='multi'" type="string"/>
+            <bind nodeset="/data/household/inHome" required="true()" type="string"/>
+            <bind nodeset="/data/household/adultPresence" relevant=" ../inHome ='yes'" required="true()" type="string"/>
+            <bind nodeset="/data/household/adultName" relevant=" ../adultPresence ='no'" type="string"/>
+            <bind nodeset="/data/household/childPresent" relevant=" ../adultPresence ='yes'" required="true()" type="string"/>
+            <bind nodeset="/data/household/familyName" relevant=" ../childPresent ='no'" type="string"/>
+            <bind nodeset="/data/household/motherName" relevant=" ../childPresent ='yes'" type="string"/>
+            <bind calculate="if( ../motherName !='', ../motherName ,'the caregiver')" nodeset="/data/household/NameA" type="string"/>
+            <bind nodeset="/data/household/motherPresent" relevant=" ../childPresent ='yes'" required="true()" type="string"/>
+            <bind nodeset="/data/household/consent" relevant=" ../motherPresent ='yes'" required="true()" type="string"/>
+            <bind constraint=".&gt;=0 and .&lt;= 10" jr:constraintMsg="Please enter number between 0 and 10" nodeset="/data/household/childNum" relevant=" ../consent ='yes'" required="true()" type="int"/>
+            <bind calculate=" ../childNum " nodeset="/data/household/child_repeat_count" readonly="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat" relevant=" ../consent ='yes'"/>
+            <bind nodeset="/data/household/child_repeat/childName" type="string"/>
+            <bind calculate="if( ../childName !='', ../childName ,'the child')" nodeset="/data/household/child_repeat/NameB" type="string"/>
+            <bind nodeset="/data/household/child_repeat/health_card" required="true()" type="string"/>
+            <bind calculate="if( ../health_card ='yes',' or is the date of birth on the vaccination card','')" nodeset="/data/household/child_repeat/vacc_record_note" type="string"/>
+            <bind calculate="if( ../health_card ='no',1,0)" nodeset="/data/household/child_repeat/no_card" type="string"/>
+            <bind nodeset="/data/household/child_repeat/ever_had_card" relevant=" ../health_card ='no'" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/ever_been_clinic" relevant=" ../ever_had_card ='no'" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/sex" required="true()" type="string"/>
+            <bind calculate="if( ../sex ='male','he','she')" nodeset="/data/household/child_repeat/gender_ref" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dobknown" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dob_year" relevant=" ../dobknown ='yes'" required="true()" type="string"/>
+            <bind calculate="if( ../dob_year ='2016' or  ../dob_year ='2020' or  ../dob_year ='2024' or  ../dob_year ='2028' ,1,0)" nodeset="/data/household/child_repeat/leap" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dob_month" relevant=" ../dobknown ='yes'" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dob_day_1" relevant=" ../dobknown ='yes' and ( ../dob_month ='1' or  ../dob_month ='3' or  ../dob_month ='5' or  ../dob_month ='7' or  ../dob_month ='8' or  ../dob_month ='10' or  ../dob_month ='12')" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dob_day_2" relevant=" ../dobknown ='yes' and ( ../dob_month ='4' or  ../dob_month ='6' or  ../dob_month ='9' or  ../dob_month ='11')" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dob_day_3" relevant=" ../dobknown ='yes' and  ../dob_month ='2' and  ../leap =1" required="true()" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dob_day_4" relevant=" ../dobknown ='yes' and  ../dob_month ='2' and  ../leap =0" required="true()" type="string"/>
+            <bind calculate="if( ../dob_day_1 !='', ../dob_day_1 , if( ../dob_day_2 !='', ../dob_day_2 ,if( ../dob_day_3 !='', ../dob_day_3 , ../dob_day_4 )))" nodeset="/data/household/child_repeat/dob_day" relevant=" ../dobknown " type="string"/>
+            <bind calculate="if(number( ../dob_month )&lt;10,concat('0', ../dob_month ), ../dob_month )" nodeset="/data/household/child_repeat/dob_month_fix" relevant=" ../dobknown " type="string"/>
+            <bind calculate="if(number( ../dob_day )&lt;10,concat('0', ../dob_day ), ../dob_day )" nodeset="/data/household/child_repeat/dob_day_fix" relevant=" ../dobknown " type="string"/>
+            <bind calculate="if( ../dob_year !='' and  ../dob_month_fix !='' and  ../dob_day_fix !='',date(concat( ../dob_year ,'-', ../dob_month_fix ,'-', ../dob_day_fix )),'')" nodeset="/data/household/child_repeat/dob" relevant=" ../dobknown " type="string"/>
+            <bind calculate="today() -  ../dob " nodeset="/data/household/child_repeat/age_days" relevant=" ../dobknown " type="string"/>
+            <bind calculate="if( ../dob_month =1,'January',if( ../dob_month =2,'February',if( ../dob_month =3,'March',if( ../dob_month =4,'April',if( ../dob_month =5,'May',if( ../dob_month =6,'June',if( ../dob_month =7,'July',if( ../dob_month =8,'August',if( ../dob_month =9,'September',if( ../dob_month =10,'October',if( ../dob_month =11,'November','December')))))))))))" nodeset="/data/household/child_repeat/month_name" type="string"/>
+            <bind nodeset="/data/household/child_repeat/not_elig_note" readonly="true()" relevant=" ../dobknown ='yes' and  ../age_days  &gt; 730" type="string"/>
+            <bind nodeset="/data/household/child_repeat/dobnote2" readonly="true()" relevant=" ../dobknown ='yes' and  ../age_days  &lt; 0" type="string"/>
+            <bind constraint=".&gt;= 0 and .&lt;= 23" jr:constraintMsg="Age in months must be between 0 - 23 months" nodeset="/data/household/child_repeat/age_months" relevant=" ../dobknown ='no'" required="true()" type="int"/>
+            <bind calculate="if( ../age_days &gt;0 and  ../age_days  &lt;=730,1,0)" nodeset="/data/household/child_repeat/under2" type="string"/>
+            <bind nodeset="/data/household/child_repeat/penta1" relevant="( ../age_months  &gt; 1 or ((today() -  ../dob  ) &gt;= 42 and  ../under2 =1)) and  ../health_card ='yes'" required="true()" type="string"/>
+            <bind calculate="if( ../penta1 ='no',1,0)" nodeset="/data/household/child_repeat/pt1" type="string"/>
+            <bind nodeset="/data/household/child_repeat/penta3" relevant="( ../age_months  &gt;= 4 or (( today() -  ../dob  ) &gt;= 98 and  ../under2 =1)) and  ../penta1 ='yes'" required="true()" type="string"/>
+            <bind calculate="if( ../penta3 ='no',1,0)" nodeset="/data/household/child_repeat/pt3" type="string"/>
+            <bind nodeset="/data/household/child_repeat/mcv1" relevant="( ../age_months  &gt;= 9 or ((today() -  ../dob  ) &gt;= 273 and  ../under2 =1)) and  ../health_card ='yes'" required="true()" type="string"/>
+            <bind calculate="if( ../mcv1 ='no',1,0)" nodeset="/data/household/child_repeat/mr1" type="string"/>
+            <bind calculate="position(..)" nodeset="/data/household/child_repeat/count" type="string"/>
+            <bind calculate=" ../count  + 1" nodeset="/data/household/child_repeat/addchild" type="string"/>
+            <bind nodeset="/data/household/child_repeat/nextChild_no_mother" readonly="true()" relevant=" ../health_card ='no' and  ../count  &lt;  ../../childNum " type="string"/>
+            <bind nodeset="/data/household/child_repeat/nextChild" readonly="true()" relevant=" ../health_card ='yes' and  ../count  &lt;  ../../childNum " type="string"/>
+            <bind calculate="sum( /data/household/child_repeat/no_card )" nodeset="/data/household/no_cards" type="string"/>
+            <bind calculate="sum( /data/household/child_repeat/pt1 ) + sum( /data/household/child_repeat/pt3 )+sum( /data/household/child_repeat/mr1 )" nodeset="/data/household/missVaccine" type="string"/>
+            <bind calculate="if( ../inHome ='no','',if( ../childPresent ='no' and  /data/building_type ='multi','Thank the person for their time and explain we are only looking for flats/dwellings where children under 2 years of age permanently live.',if( ../childPresent ='no' and  /data/building_type ='single','Thank the person for their time and explain we are only looking for houses where children under 2 years of age permanently live.','Thank the person for their time.')))" nodeset="/data/household/thankyou" type="string"/>
+            <bind nodeset="/data/household/single" relevant=" /data/building_type  = 'single'"/>
+            <bind nodeset="/data/household/single/full_address_single" type="string"/>
+            <bind nodeset="/data/household/single/single_consent_not_withheld" relevant=" ../../inHome ='no' or ( ../../inHome ='yes' and  ../../adultPresence ='no') or ( ../../inHome ='yes' and  ../../adultPresence ='yes' and  ../../childPresent ='no') or ( ../../inHome ='yes' and  ../../adultPresence ='yes' and  ../../childPresent ='yes' and  ../../motherPresent ='no') or ( ../../inHome ='yes' and  ../../adultPresence ='yes' and  ../../childPresent ='yes' and  ../../motherPresent ='yes' and  ../../consent ='yes')"/>
+            <bind nodeset="/data/household/single/single_consent_not_withheld/gps_single1" required="true()" type="geopoint"/>
+            <bind calculate="selected-at( ../gps_single1 ,3)" nodeset="/data/household/single/single_consent_not_withheld/accuracy_single1" type="string"/>
+            <bind calculate="round( ../accuracy_single1 ,2)" nodeset="/data/household/single/single_consent_not_withheld/rounded_accuracy_single1" type="string"/>
+            <bind nodeset="/data/household/single/single_consent_not_withheld/gps_single2" relevant=" ../rounded_accuracy_single1 &gt; 5 or  ../rounded_accuracy_single1  = 0" required="true()" type="geopoint"/>
+            <bind nodeset="/data/household/single/single_consent_withheld" relevant=" ../../inHome ='yes' and  ../../adultPresence ='yes' and  ../../childPresent ='yes' and  ../../motherPresent ='yes' and  ../../consent ='no'"/>
+            <bind nodeset="/data/household/single/single_consent_withheld/gps_single_no_consent1" type="geopoint"/>
+            <bind calculate="selected-at( ../gps_single_no_consent1 ,3)" nodeset="/data/household/single/single_consent_withheld/accuracy_single_no_consent1" type="string"/>
+            <bind calculate="round( ../accuracy_single_no_consent1 ,2)" nodeset="/data/household/single/single_consent_withheld/rounded_accuracy_single_no_consent1" type="string"/>
+            <bind nodeset="/data/household/single/single_consent_withheld/gps_single_no_consent2" relevant=" ../rounded_accuracy_single_no_consent1 &gt; 5 or  ../rounded_accuracy_single_no_consent1  = 0" type="geopoint"/>
+            <bind nodeset="/data/household/single/finished1" readonly="true()" type="string"/>
+            <bind nodeset="/data/household/finalflat" relevant=" /data/building_type  = 'multi'" required="true()" type="string"/>
+            <bind calculate="if( ../finalflat ='no','You have finished the questionnaire for this flat/dwelling. Go on to the next flat/dwelling.','You have finished the questionnaire for this multi-family dwelling. Go to the next building.')" nodeset="/data/household/finishednote" type="string"/>
+            <bind nodeset="/data/household/finished2" readonly="true()" relevant=" /data/building_type  = 'multi'" type="string"/>
+            <bind nodeset="/data/not_a_dwelling" relevant=" /data/building_type ='not_dwelling'"/>
+            <bind nodeset="/data/not_a_dwelling/endnote2" readonly="true()" type="string"/>
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/building_type">
+            <label>What type of building is this?</label>
+            <item>
+                <label>Not a dwelling (examples: store, abandoned building, factory, etc.)</label>
+                <value>not_dwelling</value>
+            </item>
+            <item>
+                <label>Single family dwelling (house)</label>
+                <value>single</value>
+            </item>
+            <item>
+                <label>Multi-family dwelling (flat, apartment)</label>
+                <value>multi</value>
+            </item>
+        </select1>
+        <group ref="/data/not_single">
+            <input appearance="placement-map" ref="/data/not_single/gps">
+                <label>Record GPS coordinates of this building</label>
+                <hint>Ensure clear sky for better accuracies</hint>
+            </input>
+            <input appearance="placement-map" ref="/data/not_single/gps2">
+                <label>GPS recording is<output value=" /data/not_single/rounded_accuracy "/>m. Accuracy should be greater than 0m and less than 5m - Please recapture the GPS coordinates.
+                </label>
+                <hint>Ensure clear sky for better accuracies</hint>
+            </input>
+        </group>
+        <input ref="/data/building_name">
+            <label>Record the building name</label>
+            <hint>All interviewers entering the same building should record the SAME building name.</hint>
+        </input>
+        <input ref="/data/full_address1">
+            <label>Record the full address of the building</label>
+            <hint>All interviewers entering the same building should record the same address. Record Road, Street, Estate, and/or Court, Block Number</hint>
+        </input>
+        <group ref="/data/household">
+            <label>
+                <output value=" /data/home_type3 "/>
+            </label>
+            <repeat jr:count=" /data/household_count " nodeset="/data/household">
+                <input ref="/data/household/flatNumber">
+                    <label>House, apartment or dwelling number</label>
+                </input>
+                <select1 ref="/data/household/inHome">
+                    <label>Knock on the door. Is there a response?</label>
+                    <item>
+                        <label>Yes</label>
+                        <value>yes</value>
+                    </item>
+                    <item>
+                        <label>No</label>
+                        <value>no</value>
+                    </item>
+                </select1>
+                <select1 ref="/data/household/adultPresence">
+                    <label>Is there an adult in the<output value=" /data/home_type2 "/>?
+                    </label>
+                    <hint>Greetings. I am [Name] from Red Cross. We are working to improve health services in this area.
+                        (If a child answers the door, ask to speak to an adult. If there is no adult in the<output value=" /data/home_type "/>, it will need to be revisited.)
+                    </hint>
+                    <item>
+                        <label>Yes</label>
+                        <value>yes</value>
+                    </item>
+                    <item>
+                        <label>No</label>
+                        <value>no</value>
+                    </item>
+                </select1>
+                <input ref="/data/household/adultName">
+                    <label>Record the name of the adult for revisit purposes.</label>
+                    <hint>We may come back later to talk with an adult. What is the name of the head of household.</hint>
+                </input>
+                <select1 ref="/data/household/childPresent">
+                    <label>We are helping to improve health care in this area, and vaccinations of children in particular. Are there any children under the age of 2 years who permanently live in this<output value=" /data/home_type "/>?
+                    </label>
+                    <item>
+                        <label>Yes</label>
+                        <value>yes</value>
+                    </item>
+                    <item>
+                        <label>No</label>
+                        <value>no</value>
+                    </item>
+                </select1>
+                <input ref="/data/household/familyName">
+                    <label>Can you please tell me what is the name of the family who lives at this<output value=" /data/home_type "/>?
+                    </label>
+                    <hint>There are no children under the age of 2 years who permanently live in this<output value=" /data/home_type "/>.
+                    </hint>
+                </input>
+                <input ref="/data/household/motherName">
+                    <label>What is the name of the mother or caregiver of the child(ren) under 2 years of age?</label>
+                </input>
+                <select1 ref="/data/household/motherPresent">
+                    <label>Is
+                        <output value=" ../NameA "/>
+                        available?
+                    </label>
+                    <hint>If yes, request to speak to the mother or caregiver.</hint>
+                    <item>
+                        <label>Yes</label>
+                        <value>yes</value>
+                    </item>
+                    <item>
+                        <label>No</label>
+                        <value>no</value>
+                    </item>
+                </select1>
+                <select1 ref="/data/household/consent">
+                    <label>I'd like to ask you a few questions about each of the children under the age of 2 years who permanently live in the<output value=" /data/home_type "/>. Is that OK?
+                    </label>
+                    <hint>Introduce yourself to the mother or caregiver, giving your name and stating you are a Red Cross Volunteer and explaining why you are there</hint>
+                    <item>
+                        <label>Yes</label>
+                        <value>yes</value>
+                    </item>
+                    <item>
+                        <label>No</label>
+                        <value>no</value>
+                    </item>
+                </select1>
+                <input ref="/data/household/childNum">
+                    <label>How many children under the age of 2 years live permanently in this<output value=" /data/home_type "/>?
+                    </label>
+                </input>
+                <group ref="/data/household/child_repeat">
+                    <label>Child</label>
+                    <repeat jr:count=" ../child_repeat_count " nodeset="/data/household/child_repeat">
+                        <input ref="/data/household/child_repeat/childName">
+                            <label>What is the name of your child?</label>
+                        </input>
+                        <select1 ref="/data/household/child_repeat/health_card">
+                            <label>Does
+                                <output value=" ../NameB "/>
+                                have a mother and child health handbook or any vaccination record available?
+                            </label>
+                            <hint>If yes, ask the caregiver to get the health record book for the child</hint>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/ever_had_card">
+                            <label>Has
+                                <output value=" ../NameB "/>
+                                ever had a health or vaccination card?
+                            </label>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                            <item>
+                                <label>Not sure, can't remember</label>
+                                <value>dont_know</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/ever_been_clinic">
+                            <label>Has
+                                <output value=" ../NameB "/>
+                                ever been to a health clinic for any reason?
+                            </label>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                            <item>
+                                <label>Not sure, can't remember</label>
+                                <value>dont_know</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/sex">
+                            <label>Is
+                                <output value=" ../NameB "/>
+                                a boy or a girl?
+                            </label>
+                            <item>
+                                <label>Boy</label>
+                                <value>male</value>
+                            </item>
+                            <item>
+                                <label>Girl</label>
+                                <value>female</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dobknown">
+                            <label>Do you know<output value=" ../NameB "/>'s date of birth<output value=" ../vacc_record_note "/>?
+                            </label>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dob_year">
+                            <label>Record<output value=" ../NameB "/>'s year of birth
+                            </label>
+                            <item>
+                                <label>2017</label>
+                                <value>2017</value>
+                            </item>
+                            <item>
+                                <label>2018</label>
+                                <value>2018</value>
+                            </item>
+                            <item>
+                                <label>2019</label>
+                                <value>2019</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dob_month">
+                            <label>Record<output value=" ../NameB "/>'s month of birth
+                            </label>
+                            <item>
+                                <label>01 - January</label>
+                                <value>1</value>
+                            </item>
+                            <item>
+                                <label>02 - February</label>
+                                <value>2</value>
+                            </item>
+                            <item>
+                                <label>03 - March</label>
+                                <value>3</value>
+                            </item>
+                            <item>
+                                <label>04 - April</label>
+                                <value>4</value>
+                            </item>
+                            <item>
+                                <label>05 - May</label>
+                                <value>5</value>
+                            </item>
+                            <item>
+                                <label>06 - June</label>
+                                <value>6</value>
+                            </item>
+                            <item>
+                                <label>07 - July</label>
+                                <value>7</value>
+                            </item>
+                            <item>
+                                <label>08 - August</label>
+                                <value>8</value>
+                            </item>
+                            <item>
+                                <label>09 - September</label>
+                                <value>9</value>
+                            </item>
+                            <item>
+                                <label>10 - October</label>
+                                <value>10</value>
+                            </item>
+                            <item>
+                                <label>11 - November</label>
+                                <value>11</value>
+                            </item>
+                            <item>
+                                <label>12 - December</label>
+                                <value>12</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dob_day_1">
+                            <label>Record<output value=" ../NameB "/>'s day of birth
+                            </label>
+                            <item>
+                                <label>1</label>
+                                <value>1</value>
+                            </item>
+                            <item>
+                                <label>2</label>
+                                <value>2</value>
+                            </item>
+                            <item>
+                                <label>3</label>
+                                <value>3</value>
+                            </item>
+                            <item>
+                                <label>4</label>
+                                <value>4</value>
+                            </item>
+                            <item>
+                                <label>5</label>
+                                <value>5</value>
+                            </item>
+                            <item>
+                                <label>6</label>
+                                <value>6</value>
+                            </item>
+                            <item>
+                                <label>7</label>
+                                <value>7</value>
+                            </item>
+                            <item>
+                                <label>8</label>
+                                <value>8</value>
+                            </item>
+                            <item>
+                                <label>9</label>
+                                <value>9</value>
+                            </item>
+                            <item>
+                                <label>10</label>
+                                <value>10</value>
+                            </item>
+                            <item>
+                                <label>11</label>
+                                <value>11</value>
+                            </item>
+                            <item>
+                                <label>12</label>
+                                <value>12</value>
+                            </item>
+                            <item>
+                                <label>13</label>
+                                <value>13</value>
+                            </item>
+                            <item>
+                                <label>14</label>
+                                <value>14</value>
+                            </item>
+                            <item>
+                                <label>15</label>
+                                <value>15</value>
+                            </item>
+                            <item>
+                                <label>16</label>
+                                <value>16</value>
+                            </item>
+                            <item>
+                                <label>17</label>
+                                <value>17</value>
+                            </item>
+                            <item>
+                                <label>18</label>
+                                <value>18</value>
+                            </item>
+                            <item>
+                                <label>19</label>
+                                <value>19</value>
+                            </item>
+                            <item>
+                                <label>20</label>
+                                <value>20</value>
+                            </item>
+                            <item>
+                                <label>21</label>
+                                <value>21</value>
+                            </item>
+                            <item>
+                                <label>22</label>
+                                <value>22</value>
+                            </item>
+                            <item>
+                                <label>23</label>
+                                <value>23</value>
+                            </item>
+                            <item>
+                                <label>24</label>
+                                <value>24</value>
+                            </item>
+                            <item>
+                                <label>25</label>
+                                <value>25</value>
+                            </item>
+                            <item>
+                                <label>26</label>
+                                <value>26</value>
+                            </item>
+                            <item>
+                                <label>27</label>
+                                <value>27</value>
+                            </item>
+                            <item>
+                                <label>28</label>
+                                <value>28</value>
+                            </item>
+                            <item>
+                                <label>29</label>
+                                <value>29</value>
+                            </item>
+                            <item>
+                                <label>30</label>
+                                <value>30</value>
+                            </item>
+                            <item>
+                                <label>31</label>
+                                <value>31</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dob_day_2">
+                            <label>Record<output value=" ../NameB "/>'s day of birth
+                            </label>
+                            <item>
+                                <label>1</label>
+                                <value>1</value>
+                            </item>
+                            <item>
+                                <label>2</label>
+                                <value>2</value>
+                            </item>
+                            <item>
+                                <label>3</label>
+                                <value>3</value>
+                            </item>
+                            <item>
+                                <label>4</label>
+                                <value>4</value>
+                            </item>
+                            <item>
+                                <label>5</label>
+                                <value>5</value>
+                            </item>
+                            <item>
+                                <label>6</label>
+                                <value>6</value>
+                            </item>
+                            <item>
+                                <label>7</label>
+                                <value>7</value>
+                            </item>
+                            <item>
+                                <label>8</label>
+                                <value>8</value>
+                            </item>
+                            <item>
+                                <label>9</label>
+                                <value>9</value>
+                            </item>
+                            <item>
+                                <label>10</label>
+                                <value>10</value>
+                            </item>
+                            <item>
+                                <label>11</label>
+                                <value>11</value>
+                            </item>
+                            <item>
+                                <label>12</label>
+                                <value>12</value>
+                            </item>
+                            <item>
+                                <label>13</label>
+                                <value>13</value>
+                            </item>
+                            <item>
+                                <label>14</label>
+                                <value>14</value>
+                            </item>
+                            <item>
+                                <label>15</label>
+                                <value>15</value>
+                            </item>
+                            <item>
+                                <label>16</label>
+                                <value>16</value>
+                            </item>
+                            <item>
+                                <label>17</label>
+                                <value>17</value>
+                            </item>
+                            <item>
+                                <label>18</label>
+                                <value>18</value>
+                            </item>
+                            <item>
+                                <label>19</label>
+                                <value>19</value>
+                            </item>
+                            <item>
+                                <label>20</label>
+                                <value>20</value>
+                            </item>
+                            <item>
+                                <label>21</label>
+                                <value>21</value>
+                            </item>
+                            <item>
+                                <label>22</label>
+                                <value>22</value>
+                            </item>
+                            <item>
+                                <label>23</label>
+                                <value>23</value>
+                            </item>
+                            <item>
+                                <label>24</label>
+                                <value>24</value>
+                            </item>
+                            <item>
+                                <label>25</label>
+                                <value>25</value>
+                            </item>
+                            <item>
+                                <label>26</label>
+                                <value>26</value>
+                            </item>
+                            <item>
+                                <label>27</label>
+                                <value>27</value>
+                            </item>
+                            <item>
+                                <label>28</label>
+                                <value>28</value>
+                            </item>
+                            <item>
+                                <label>29</label>
+                                <value>29</value>
+                            </item>
+                            <item>
+                                <label>30</label>
+                                <value>30</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dob_day_3">
+                            <label>Record<output value=" ../NameB "/>'s day of birth
+                            </label>
+                            <item>
+                                <label>1</label>
+                                <value>1</value>
+                            </item>
+                            <item>
+                                <label>2</label>
+                                <value>2</value>
+                            </item>
+                            <item>
+                                <label>3</label>
+                                <value>3</value>
+                            </item>
+                            <item>
+                                <label>4</label>
+                                <value>4</value>
+                            </item>
+                            <item>
+                                <label>5</label>
+                                <value>5</value>
+                            </item>
+                            <item>
+                                <label>6</label>
+                                <value>6</value>
+                            </item>
+                            <item>
+                                <label>7</label>
+                                <value>7</value>
+                            </item>
+                            <item>
+                                <label>8</label>
+                                <value>8</value>
+                            </item>
+                            <item>
+                                <label>9</label>
+                                <value>9</value>
+                            </item>
+                            <item>
+                                <label>10</label>
+                                <value>10</value>
+                            </item>
+                            <item>
+                                <label>11</label>
+                                <value>11</value>
+                            </item>
+                            <item>
+                                <label>12</label>
+                                <value>12</value>
+                            </item>
+                            <item>
+                                <label>13</label>
+                                <value>13</value>
+                            </item>
+                            <item>
+                                <label>14</label>
+                                <value>14</value>
+                            </item>
+                            <item>
+                                <label>15</label>
+                                <value>15</value>
+                            </item>
+                            <item>
+                                <label>16</label>
+                                <value>16</value>
+                            </item>
+                            <item>
+                                <label>17</label>
+                                <value>17</value>
+                            </item>
+                            <item>
+                                <label>18</label>
+                                <value>18</value>
+                            </item>
+                            <item>
+                                <label>19</label>
+                                <value>19</value>
+                            </item>
+                            <item>
+                                <label>20</label>
+                                <value>20</value>
+                            </item>
+                            <item>
+                                <label>21</label>
+                                <value>21</value>
+                            </item>
+                            <item>
+                                <label>22</label>
+                                <value>22</value>
+                            </item>
+                            <item>
+                                <label>23</label>
+                                <value>23</value>
+                            </item>
+                            <item>
+                                <label>24</label>
+                                <value>24</value>
+                            </item>
+                            <item>
+                                <label>25</label>
+                                <value>25</value>
+                            </item>
+                            <item>
+                                <label>26</label>
+                                <value>26</value>
+                            </item>
+                            <item>
+                                <label>27</label>
+                                <value>27</value>
+                            </item>
+                            <item>
+                                <label>28</label>
+                                <value>28</value>
+                            </item>
+                            <item>
+                                <label>29</label>
+                                <value>29</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/dob_day_4">
+                            <label>Record<output value=" ../NameB "/>'s day of birth
+                            </label>
+                            <item>
+                                <label>1</label>
+                                <value>1</value>
+                            </item>
+                            <item>
+                                <label>2</label>
+                                <value>2</value>
+                            </item>
+                            <item>
+                                <label>3</label>
+                                <value>3</value>
+                            </item>
+                            <item>
+                                <label>4</label>
+                                <value>4</value>
+                            </item>
+                            <item>
+                                <label>5</label>
+                                <value>5</value>
+                            </item>
+                            <item>
+                                <label>6</label>
+                                <value>6</value>
+                            </item>
+                            <item>
+                                <label>7</label>
+                                <value>7</value>
+                            </item>
+                            <item>
+                                <label>8</label>
+                                <value>8</value>
+                            </item>
+                            <item>
+                                <label>9</label>
+                                <value>9</value>
+                            </item>
+                            <item>
+                                <label>10</label>
+                                <value>10</value>
+                            </item>
+                            <item>
+                                <label>11</label>
+                                <value>11</value>
+                            </item>
+                            <item>
+                                <label>12</label>
+                                <value>12</value>
+                            </item>
+                            <item>
+                                <label>13</label>
+                                <value>13</value>
+                            </item>
+                            <item>
+                                <label>14</label>
+                                <value>14</value>
+                            </item>
+                            <item>
+                                <label>15</label>
+                                <value>15</value>
+                            </item>
+                            <item>
+                                <label>16</label>
+                                <value>16</value>
+                            </item>
+                            <item>
+                                <label>17</label>
+                                <value>17</value>
+                            </item>
+                            <item>
+                                <label>18</label>
+                                <value>18</value>
+                            </item>
+                            <item>
+                                <label>19</label>
+                                <value>19</value>
+                            </item>
+                            <item>
+                                <label>20</label>
+                                <value>20</value>
+                            </item>
+                            <item>
+                                <label>21</label>
+                                <value>21</value>
+                            </item>
+                            <item>
+                                <label>22</label>
+                                <value>22</value>
+                            </item>
+                            <item>
+                                <label>23</label>
+                                <value>23</value>
+                            </item>
+                            <item>
+                                <label>24</label>
+                                <value>24</value>
+                            </item>
+                            <item>
+                                <label>25</label>
+                                <value>25</value>
+                            </item>
+                            <item>
+                                <label>26</label>
+                                <value>26</value>
+                            </item>
+                            <item>
+                                <label>27</label>
+                                <value>27</value>
+                            </item>
+                            <item>
+                                <label>28</label>
+                                <value>28</value>
+                            </item>
+                        </select1>
+                        <input ref="/data/household/child_repeat/not_elig_note">
+                            <label>We are only looking for children under 2 years of age (730 days).
+                                Date of birth for
+                                <output value=" ../NameB "/>
+                                is
+                                <output value=" ../dob_day_fix "/>
+                                <output value=" ../month_name "/>
+                                <output value=" ../dob_year "/>
+                                and
+                                <output value=" ../gender_ref "/>
+                                is
+                                <output value=" ../age_days "/>
+                                days old.
+
+                                If this is not correct, swipe back and fix the date of birth.
+                            </label>
+                        </input>
+                        <input ref="/data/household/child_repeat/dobnote2">
+                            <label>Date of birth for
+                                <output value=" ../NameB "/>
+                                is
+                                <output value=" ../dob_day_fix "/>
+                                <output value=" ../month_name "/>
+                                <output value=" ../dob_year "/>
+                                and is a date in the future.
+
+                                Please swipe back and correct.
+                            </label>
+                        </input>
+                        <input ref="/data/household/child_repeat/age_months">
+                            <label>Record the age of
+                                <output value=" ../NameB "/>
+                                in months.
+                            </label>
+                            <hint>If the age is only known in weeks, round up to the nearest month</hint>
+                        </input>
+                        <select1 ref="/data/household/child_repeat/penta1">
+                            <label>Record if the 1st dose of the vaccine beginning with 'Diphtheria' or 'Penta' was received</label>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/penta3">
+                            <label>Record if the 3rd dose of the vaccine beginning with 'Diphtheria' or 'Penta' was received</label>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <select1 ref="/data/household/child_repeat/mcv1">
+                            <label>Record if measles rubella (MR) vaccine was received</label>
+                            <item>
+                                <label>Yes</label>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label>No</label>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <input ref="/data/household/child_repeat/nextChild_no_mother">
+                            <label>Move on to child number
+                                <output value=" ../addchild "/>
+                            </label>
+                        </input>
+                        <input ref="/data/household/child_repeat/nextChild">
+                            <label>Move on to child number
+                                <output value=" ../addchild "/>
+                            </label>
+                        </input>
+                    </repeat>
+                </group>
+                <group ref="/data/household/single">
+                    <input ref="/data/household/single/full_address_single">
+                        <label>Record the full address of the house</label>
+                    </input>
+                    <group ref="/data/household/single/single_consent_not_withheld">
+                        <input appearance="placement-map" ref="/data/household/single/single_consent_not_withheld/gps_single1">
+                            <label>Record GPS coordinates of this building</label>
+                            <hint>Ensure clear sky for better accuracies</hint>
+                        </input>
+                        <input appearance="placement-map" ref="/data/household/single/single_consent_not_withheld/gps_single2">
+                            <label>GPS recording is<output value=" ../rounded_accuracy_single1 "/>m. Accuracy should be greater than 0m and less than 5m - Please recapture the GPS coordinates.
+                            </label>
+                            <hint>Ensure clear sky for better accuracies</hint>
+                        </input>
+                    </group>
+                    <group ref="/data/household/single/single_consent_withheld">
+                        <input appearance="placement-map" ref="/data/household/single/single_consent_withheld/gps_single_no_consent1">
+                            <label>Record GPS coordinates of this building</label>
+                            <hint>Ensure clear sky for better accuracies</hint>
+                        </input>
+                        <input appearance="placement-map" ref="/data/household/single/single_consent_withheld/gps_single_no_consent2">
+                            <label>GPS recording is<output value=" ../rounded_accuracy_single_no_consent1 "/>m. Accuracy should be greater than 0m and less than 5m - Please recapture the GPS coordinates.
+                            </label>
+                            <hint>Ensure clear sky for better accuracies</hint>
+                        </input>
+                    </group>
+                    <input ref="/data/household/single/finished1">
+                        <label>You have finished the questionnaire for this single family dwelling. Go to the next building.</label>
+                        <hint>
+                            <output value=" ../../thankyou "/>
+                        </hint>
+                    </input>
+                </group>
+                <select1 ref="/data/household/finalflat">
+                    <label>Is this the final flat/dwelling?</label>
+                    <item>
+                        <label>Yes</label>
+                        <value>yes</value>
+                    </item>
+                    <item>
+                        <label>No</label>
+                        <value>no</value>
+                    </item>
+                </select1>
+                <input ref="/data/household/finished2">
+                    <label>
+                        <output value=" ../finishednote "/>
+                    </label>
+                    <hint>
+                        <output value=" ../thankyou "/>
+                    </hint>
+                </input>
+            </repeat>
+        </group>
+        <group ref="/data/not_a_dwelling">
+            <input ref="/data/not_a_dwelling/endnote2">
+                <label>You have finished the questionnaire for this non dwelling. Go to the next building.</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>

--- a/src/test/resources/logback-test.xml.example
+++ b/src/test/resources/logback-test.xml.example
@@ -1,11 +1,25 @@
 <configuration>
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
-  </appender>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
 
-  <root level="debug">
-    <appender-ref ref="STDOUT" />
-  </root>
+    <appender name="STDOUT_SCENARIO" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[FORM TRACE] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.javarosa.core.test.Scenario" level="debug" additivity="false">
+        <appender-ref ref="STDOUT_SCENARIO"/>
+    </logger>
+
+    <logger name="guru.nidi.graphviz" level="ERROR" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
 </configuration>


### PR DESCRIPTION
This PR only improves the test suite without changing the implementation codebase.

Noteworthy tests for future discussion:
- There are new tests to describe how relevance and constraint conditions work and the strange interaction between relevance and computations
- There are tests to describe the behavior discussed in #119, #135, and #540 
- There are a couple of smoke tests.
  - The test with the WHO VA form is more directed and has more assertions. This is a form without repeat groups but a complex network of relevance conditions
  - The test with the child vaccination form is more dynamic and has assertions only at a couple of places. This is a form with simple logic but nested repeats featuring infinite (outer) repeat groups.

#### What has been done to verify that this works as intended?
Run the automated tests

#### Why is this the best possible solution? Were any other approaches considered?
Doesn't apply

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This PR shouldn't affect users in any way.

#### Do we need any specific form for testing your changes? If so, please attach one.
Nope.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Nope.