### PR TITLE
Issue 540 expansion of refs in nested repeats

### DIFF
--- a/dag.md
+++ b/dag.md
@@ -105,7 +105,9 @@ A new repeat instance can be created under two circumstances:
 - When a user is asked to create a new repeat, and they answer yes. This is driven by `FormEntryController.newRepeat(...)`.
 - When the form has to satisfy a certain number of repeat instances determined by a `jr:count` expression e.g., when jumping to the controller jumps to the index of such a group. This is driven by `FormEntryModel.createModelIfNecessary`.
 
-In both cases, `FormDef.createNewRepeat(...)` is eventually called, and a chain of triggerable evaluations is triggered on the new node that's added to the main instance. 
+In both cases, `FormDef.createNewRepeat(...)` is eventually called, and a chain of triggerable evaluations is triggered on the new node that's added to the main instance.
+
+An important consequence of this implementation is that triggerables will only be applied to the repeat instance that is created. This could produce unexpected results when calculate expressions use count() or other functions that work on a nodeset based on the repeat siblings the new repeat instance belongs to. For more information and specific examples of this, check out the TriggerableDatTest class.  
 
 **Set of evaluated triggerables**: 
 - First phase (value change), those triggered by the repeat group's reference

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -332,8 +332,12 @@ public class TreeReference implements Externalizable, Serializable {
                 //on this expression, since those reset any existing resolutions which
                 //may have been done.
                 if (newRef.getPredicate(i) == null) {
-                    newRef.setMultiplicity(i, contextRef.getMultiplicity(i));
-                    newRef.addPredicate(i, contextRef.getPredicate(i));
+                    List<XPathExpression> predicate = contextRef.getPredicate(i);
+                    newRef.addPredicate(i, predicate);
+                }
+                if (i + refLevel <= newRef.size()) {
+                    int multiplicity = contextRef.getMultiplicity(i);
+                    newRef.setMultiplicity(i, multiplicity);
                 }
             } else {
                 break;

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -912,11 +912,20 @@ public class TriggerableDagTest {
         scenario.createNewRepeat("/data/outer[1]/inner");
         scenario.createNewRepeat("/data/outer[1]/inner");
 
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(1))); // Should be 3
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(1))); // Should be 3
-        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(1))); // Should be 3
-        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(1))); // Should be 2
-        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(1))); // Should be 2
+        // The following assertions have incrementally greater count values because
+        // we currently evaluate triggerables bound to the new repeat group only. This
+        // means that the actual count value only takes into account the existing repeat
+        // groups when creating the new instance.
+        //
+        // To have the expected count of 3 for outer[0] and 2 for outer[1], we would have
+        // to change the sequence of evaluations when a new repeat group is created to
+        // evaluate the triggerables on all siblings (not just on the instance that has
+        // been created). This is currently driven by TriggerableDag.createRepeatGroup()
+        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
     }
 
     /**

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
@@ -57,7 +57,10 @@ public class TreeReferenceContextualizeTest {
             {"Wildcards #2", getRef("../baz"), getRef("/foo/*/bar"), getRef("/foo/*/baz")},
             {"Wildcards #3", getRef("*/baz"), getRef("/foo/*/bar"), getRef("/foo/*/bar/*/baz")},
             {"Wildcards #4", getRef("*/bar"), getRef("/foo"), getRef("/foo/*/bar")},
-            {"Parent refs in nested repeats", getRef("../../inner"), getRef("/data/outer[0]/inner[1]/count[0]"), getRef("/data/outer[0]/inner[1]")} // Should be /data/outer[0]/inner
+            {"Predicates #1", getRef("bar"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar")},
+            {"Predicates #2", getRef("bar[@foo = 'baz']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar[@foo = 'baz']")},
+            {"Predicates #3", getRef("bar[@foo = 'baz']"), getRef("/foo"), getRef("/foo/bar[@foo = 'baz']")},
+            {"Predicates #4", getRef("/foo[@foo = 'foo']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'foo']")}
         });
     }
 

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
@@ -60,7 +60,8 @@ public class TreeReferenceContextualizeTest {
             {"Predicates #1", getRef("bar"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar")},
             {"Predicates #2", getRef("bar[@foo = 'baz']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar[@foo = 'baz']")},
             {"Predicates #3", getRef("bar[@foo = 'baz']"), getRef("/foo"), getRef("/foo/bar[@foo = 'baz']")},
-            {"Predicates #4", getRef("/foo[@foo = 'foo']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'foo']")}
+            {"Predicates #4", getRef("/foo[@foo = 'foo']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'foo']")},
+            {"Parent refs in nested repeats", getRef("../../inner"), getRef("/data/outer[0]/inner[1]/count[0]"), getRef("/data/outer[0]/inner")}
         });
     }
 


### PR DESCRIPTION
Closes #540

This PR is built on top of #543 and the first commit is b4959970

#### What has been done to verify that this works as intended?
Added automated tests
Run the whole test suite

#### Why is this the best possible solution? Were any other approaches considered?
An alternative solution that was speculated on would be to change function evaluation to overwrite any multiplicity value at the last step in references that have to be used with functions that operate on nodesets rather than single nodes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users should be able to use relative parent references inside nested repeats and obtain the correct nodesets in return for example to correctly count nested repeat groups correctly from within those groups.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.