### PR TITLE
Improve TreeReference.contextualize() comments

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -62,7 +62,7 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
  *
  * <p>TODO: Split out the bind-able session data from this class and leave only the mandatory values to speed up
  * new DOM-like models</p>
- 
+
  * @author Clayton Sims
  */
 
@@ -893,7 +893,7 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
             step.setInstanceName(elem.getInstanceName());
             if(elem.getInstanceName() != null) {
                 // it is a named instance; it should not inherit runtime context...
-                step.setContext(TreeReference.CONTEXT_INSTANCE);
+                step.setContextType(TreeReference.CONTEXT_INSTANCE);
             }
 
             ref = ref.parent(step);

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -199,7 +199,7 @@ public class TreeReference implements Externalizable, Serializable {
 
         //copy instances
         newRef.setInstanceName(instanceName);
-        newRef.setContext(this.contextType);
+        newRef.setContextType(this.contextType);
         return newRef;
     }
 
@@ -312,7 +312,7 @@ public class TreeReference implements Externalizable, Serializable {
 
         TreeReference newRef = anchor(contextRef);
         // unclear...
-        newRef.setContext(contextRef.getContext());
+        newRef.setContextType(contextRef.getContextType());
 
         //apply multiplicities and fill in wildcards as necessary based on the context ref
         for (int i = 0; i < contextRef.size() && i < newRef.size(); i++) {
@@ -642,12 +642,29 @@ public class TreeReference implements Externalizable, Serializable {
     }
 
     //TODO: This should be in construction
-    public void setContext(int context) {
-        this.contextType = context;
+
+    /**
+     * @deprecated use #setContextType(int) instead
+     */
+    @Deprecated
+    public void setContext(int contextType) {
+        setContextType(contextType);
     }
 
+    public void setContextType(int contextType) {
+        this.contextType = contextType;
+    }
+
+    /**
+     * @deprecated use #getContextType() instead
+     */
+    @Deprecated
     public int getContext() {
-        return this.contextType;
+        return this.getContextType();
+    }
+
+    public int getContextType() {
+        return contextType;
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -323,12 +323,10 @@ public class TreeReference implements Externalizable, Serializable {
 
             if (contextRef.getName(i).equals(newRef.getName(i))) {
                 if (newRef.getPredicate(i) == null) {
-                    List<XPathExpression> predicate = contextRef.getPredicate(i);
-                    newRef.addPredicate(i, predicate);
+                    newRef.addPredicate(i, contextRef.getPredicate(i));
                 }
                 if (i + refLevel <= newRef.size()) {
-                    int multiplicity = contextRef.getMultiplicity(i);
-                    newRef.setMultiplicity(i, multiplicity);
+                    newRef.setMultiplicity(i, contextRef.getMultiplicity(i));
                 }
             } else {
                 break;

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -306,14 +306,9 @@ public class TreeReference implements Externalizable, Serializable {
     }
 
     public TreeReference contextualize(TreeReference contextRef) {
-        //TODO: Technically we should possibly be modifying context stuff here
-        //instead of in the xpath stuff;
         if (!contextRef.isAbsolute()) {
             return null;
         }
-
-        // I think contextualizing of absolute nodes still needs to be done.
-        // They may contain predicates that need to be contextualized.
 
         TreeReference newRef = anchor(contextRef);
         // unclear...
@@ -321,16 +316,12 @@ public class TreeReference implements Externalizable, Serializable {
 
         //apply multiplicities and fill in wildcards as necessary based on the context ref
         for (int i = 0; i < contextRef.size() && i < newRef.size(); i++) {
-
-            //If the the contextRef can provide a definition for a wildcard, do so
+            //If the the contextRef can provide a definition for a wildcard (not currently supported by JR), do so
             if (TreeReference.NAME_WILDCARD.equals(newRef.getName(i)) && !TreeReference.NAME_WILDCARD.equals(contextRef.getName(i))) {
                 newRef.data.set(i, newRef.data.get(i).setName(contextRef.getName(i)));
             }
 
             if (contextRef.getName(i).equals(newRef.getName(i))) {
-                //We can't actually merge nodes if the newRef has predicates or filters
-                //on this expression, since those reset any existing resolutions which
-                //may have been done.
                 if (newRef.getPredicate(i) == null) {
                     List<XPathExpression> predicate = contextRef.getPredicate(i);
                     newRef.addPredicate(i, predicate);

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -311,8 +311,6 @@ public class TreeReference implements Externalizable, Serializable {
         }
 
         TreeReference newRef = anchor(contextRef);
-        // unclear...
-        newRef.setContextType(contextRef.getContextType());
 
         //apply multiplicities and fill in wildcards as necessary based on the context ref
         for (int i = 0; i < contextRef.size() && i < newRef.size(); i++) {

--- a/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -119,10 +119,10 @@ public class XPathPathExpr extends XPathExpression {
                             //we've got a non-standard instance in play, watch out
                             if (strLit.s == null) {
                                 // absolute reference to the main instance
-                                ref.setContext(TreeReference.CONTEXT_ABSOLUTE);
+                                ref.setContextType(TreeReference.CONTEXT_ABSOLUTE);
                                 ref.setInstanceName(null);
                             } else {
-                                ref.setContext(TreeReference.CONTEXT_INSTANCE);
+                                ref.setContextType(TreeReference.CONTEXT_INSTANCE);
                                 ref.setInstanceName(strLit.s);
                             }
                             break;
@@ -142,7 +142,7 @@ public class XPathPathExpr extends XPathExpression {
                              * in the XPathPathExprCurrentTest test class
                              */
                             parentsAllowed = true;
-                            ref.setContext(TreeReference.CONTEXT_ORIGINAL);
+                            ref.setContextType(TreeReference.CONTEXT_ORIGINAL);
                             break;
                         default:
                             //We only support expression root contexts for instance refs, everything else is an illegal filter

--- a/src/main/java/org/javarosa/xpath/expr/XPathPathExprEval.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPathExprEval.java
@@ -82,7 +82,7 @@ public class XPathPathExprEval {
 
     private TreeReference getContextualizedTreeReference(TreeReference genericRef, EvaluationContext ec) {
         // We don't necessarily know the model we want to be working with until we've contextualized the node
-        TreeReference contextRef = genericRef.getContext() == TreeReference.CONTEXT_ORIGINAL ?
+        TreeReference contextRef = genericRef.getContextType() == TreeReference.CONTEXT_ORIGINAL ?
             ec.getOriginalContext() : ec.getContextRef();
         return genericRef.contextualize(contextRef);
     }

--- a/src/test/java/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFuncExprRandomizeTest.java
@@ -216,7 +216,7 @@ public class XPathFuncExprRandomizeTest {
     private static TreeReference absoluteRef(String path) {
         TreeReference tr = new TreeReference();
         tr.setRefLevel(REF_ABSOLUTE);
-        tr.setContext(CONTEXT_ABSOLUTE);
+        tr.setContextType(CONTEXT_ABSOLUTE);
         tr.setInstanceName(null);
         Arrays.stream(path.split("/"))
             .filter(s -> !s.isEmpty())


### PR DESCRIPTION
This PR syncs comments in `TreeReference.contextualize` and some implementation details with our current understanding of the inner workings of JavaRosa.

#### What has been done to verify that this works as intended?
Run the automated tests

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There shouldn't be any behavior change.

JR client developers will note that `TreeReference.getContext()` and `TreeReference.setContext(int)` have been deprecated and will have to migrate to documented alternatives.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.