### PR TITLE
Add test to highlight recomputation bug

### DIFF
--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -929,6 +929,65 @@ public class TriggerableDagTest {
     }
 
     /**
+     * This test documents some bugs:
+     *  * calling the count function with an absolute reference to a repeat should return the count of repeat instances
+     *  but instead it always returns 1
+     *  * a count inside of a repeat instance is not recomputed as new instances are added
+     *  * calculations that don't involve user input are not recomputed on form validation
+     */
+    @Test
+    public void validation_only_triggers_calculations_involving_user_visible_fields() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("user-input", "1"),
+                        t("repeat jr:template=\"\"",
+                            t("count"),
+                            t("multiplied-count"),
+                            t("some-field")
+                        )
+                    )),
+                    bind("/data/user-input").type("int"),
+                    bind("/data/repeat/count").type("int").calculate("count(../../repeat)"), // both .. and /data/repeat always give a count of 1
+                    bind("/data/repeat/multiplied-count").type("int").calculate("/data/user-input * count(../../repeat)")
+                )
+            ),
+            body(
+                input("/data/user-input"),
+                repeat("/data/repeat",
+                    input("/data/repeat/some-field"))
+            )));
+
+        scenario.createNewRepeat("/data/repeat");
+        scenario.createNewRepeat("/data/repeat");
+        scenario.createNewRepeat("/data/repeat");
+
+        // All of these counts should be 3
+        assertThat(scenario.answerOf("/data/repeat[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/repeat[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/count"), is(intAnswer(3)));
+
+        // The initial value of user-input is 1 so we expect the same values as the raw count
+        assertThat(scenario.answerOf("/data/repeat[0]/multiplied-count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/repeat[1]/multiplied-count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/multiplied-count"), is(intAnswer(3)));
+
+        scenario.getValidationOutcome();
+
+        // None of these have been recalculated
+        assertThat(scenario.answerOf("/data/repeat[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/repeat[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/count"), is(intAnswer(3)));
+
+        // All of these have been recalculated
+        assertThat(scenario.answerOf("/data/repeat[0]/multiplied-count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/repeat[1]/multiplied-count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/repeat[2]/multiplied-count"), is(intAnswer(3)));
+    }
+
+    /**
      * Non-relevance is inherited from ancestor nodes, as per the W3C XForms specs:
      * - https://www.w3.org/TR/xforms11/#model-prop-relevant
      * - https://www.w3.org/community/xformsusers/wiki/XForms_2.0#The_relevant_Property


### PR DESCRIPTION
This is a test-only change meant to document some new-to-me behavior. I was always under the impression that the final validation pass performed by e.g. Collect triggered all computations. That is not the case. I haven't done a deep dive yet but I believe that because the validation runs through user-visible fields, calculate-only fields will not be recomputed.

@ggalmazor does this match your expectations? Do you agree that this is a bug?

I also expected that if `/data/repeat` were a repeat, that I could do `count(/data/repeat)` to get the count of instances of that repeat. That expression always returns 1 as though the reference were to a specific repeat instance. I think that's a bug.

Given a node `/data/repeat/foo` in that same repeat, `count(..)` returns 1. I think that might be the right thing though I'm wondering whether `count` should always use a generic reference for the last step in the reference as we've previously discussed.