### PR TITLE
On repeat creation, don't double-evaluate expressions

### DIFF
--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -211,7 +211,7 @@ public class TriggerableDag {
         publishSummary("Created (phase 1)", createRef, qtSet1);
 
         // initialize conditions for the node (and sub-nodes)
-        Set<QuickTriggerable> qtSet2 = initializeTriggerables(mainInstance, evalContext, createRef, new HashSet<>(0));
+        Set<QuickTriggerable> qtSet2 = initializeTriggerables(mainInstance, evalContext, createRef, qtSet1);
         publishSummary("Created (phase 2)", createRef, qtSet2);
 
         Set<QuickTriggerable> alreadyEvaluated = new HashSet<>(qtSet1);
@@ -240,7 +240,7 @@ public class TriggerableDag {
         publishSummary("Copied itemset answer (phase 1)", targetRef, qtSet1);
 
         // initialize conditions for the node (and sub-nodes)
-        Set<QuickTriggerable> qtSet2 = initializeTriggerables(mainInstance, evalContext, copyRef, new HashSet<>(0));
+        Set<QuickTriggerable> qtSet2 = initializeTriggerables(mainInstance, evalContext, copyRef, qtSet1);
         publishSummary("Copied itemset answer (phase 2)", targetRef, qtSet2);
         // not 100% sure this will work since destRef is ambiguous as the last
         // step, but i think it's supposed to work

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -110,14 +110,13 @@ public class TriggerableDag {
         this.accessor = accessor;
     }
 
-    private Set<QuickTriggerable> doEvaluateTriggerables(FormInstance mainInstance, EvaluationContext evalContext, Set<QuickTriggerable> triggerables, TreeReference anchorRef, Set<QuickTriggerable> alreadyEvaluated) {
+    private Set<QuickTriggerable> doEvaluateTriggerables(FormInstance mainInstance, EvaluationContext evalContext, Set<QuickTriggerable> toTrigger, TreeReference anchorRef, Set<QuickTriggerable> alreadyEvaluated) {
         Set<QuickTriggerable> fired = new HashSet<>();
 
         // Evaluate the provided set of triggerables in the order they appear
         // in the sorted DAG to ensure the correct sequence of evaluations
         for (QuickTriggerable qt : triggerablesDAG)
-            if (triggerables.contains(qt) && !alreadyEvaluated.contains(qt)) {
-
+            if (toTrigger.contains(qt) && !alreadyEvaluated.contains(qt)) {
                 evaluateTriggerable(mainInstance, evalContext, qt, anchorRef);
 
                 fired.add(qt);
@@ -492,23 +491,16 @@ public class TriggerableDag {
      * further be triggered due to their update, and then dispatching all of the
      * evaluations.
      */
-    private Set<QuickTriggerable> evaluateTriggerables(FormInstance mainInstance, EvaluationContext evalContext, Set<QuickTriggerable> tv, TreeReference anchorRef, Set<QuickTriggerable> alreadyEvaluated) {
-        // add all cascaded triggerables to queue
-
-        // Iterate through all of the currently known triggerables to be
-        // triggered
-        Set<QuickTriggerable> refSet = new HashSet<>(tv);
-        for (; !refSet.isEmpty(); ) {
+    private Set<QuickTriggerable> evaluateTriggerables(FormInstance mainInstance, EvaluationContext evalContext, Set<QuickTriggerable> toTrigger, TreeReference anchorRef, Set<QuickTriggerable> alreadyEvaluated) {
+        Set<QuickTriggerable> refSet = new HashSet<>(toTrigger);
+        while (!refSet.isEmpty()) {
             Set<QuickTriggerable> newSet = new HashSet<>();
             for (QuickTriggerable qt : refSet) {
-                // leverage the saved DAG edges.
-                // This may over-fill the set of triggerables.
-                // but should be faster than recomputing the edges.
-                // with value-change optimizations, this should be
-                // much faster.
+                // Leverage the saved DAG edges. This may over-fill the set of triggerables but should be faster than
+                // recomputing the edges. With value-change optimizations, this should be much faster.
                 for (QuickTriggerable qu : qt.getImmediateCascades()) {
-                    if (!tv.contains(qu)) {
-                        tv.add(qu);
+                    if (!toTrigger.contains(qu)) {
+                        toTrigger.add(qu);
                         newSet.add(qu);
                     }
                 }
@@ -516,7 +508,7 @@ public class TriggerableDag {
             refSet = newSet;
         }
 
-        return doEvaluateTriggerables(mainInstance, evalContext, tv, anchorRef, alreadyEvaluated);
+        return doEvaluateTriggerables(mainInstance, evalContext, toTrigger, anchorRef, alreadyEvaluated);
     }
 
     /**
@@ -558,10 +550,7 @@ public class TriggerableDag {
     }
 
     private Set<QuickTriggerable> triggerTriggerables(FormInstance mainInstance, EvaluationContext evalContext, TreeReference ref, Set<QuickTriggerable> alreadyEvaluated) {
-
-        // turn unambiguous ref into a generic ref
-        // to identify what nodes should be triggered by this
-        // reference changing
+        // Turn unambiguous ref into a generic ref to identify what nodes should be triggered by this reference changing
         TreeReference genericRef = ref.genericize();
 
         // get triggerables which are activated by the generic reference


### PR DESCRIPTION
When reviewing https://github.com/opendatakit/javarosa/pull/537, I noticed that some expressions were evaluated twice on repeat creation. This PR prevents that. 

Additionally, no tests failed when `triggerTriggerables` was removed and only the smoke test failed when `initializeTriggerables` was removed. This PR adds coverage to demonstrate that both are required.

#### What has been done to verify that this works as intended?
Added and ran automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is narrow and effective. I didn't consider alternatives.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only expected user impact is a performance improvement on repeat addition but either there would have to be lots of expressions in the repeat or many repeat instances for it to be noticeable. There's a risk to all calculations that need to happen on repeat add. Clearly we didn't have much coverage in this area and if we can think of other meaningful tests to add we should do so.

#### Do we need any specific form for testing your changes? If so, please attach one.
See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.