### PR TITLE
Handle relative paths with predicates

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -200,8 +200,8 @@ public class XPathPathExpr extends XPathExpression {
             if (step.predicates.length > 0) {
                 List<XPathExpression> v = new ArrayList<XPathExpression>(step.predicates.length);
                 Collections.addAll(v, step.predicates);
-                //int level = ref.getRefLevel() > 0 ? i - ref.getRefLevel() : i; // refLevel represents parenting steps
-                ref.addPredicate(i, v);
+                int level = ref.getRefLevel() > 0 ? i - ref.getRefLevel() : i; // refLevel represents parenting steps
+                ref.addPredicate(level, v);
             }
         }
         return ref;

--- a/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -200,6 +200,7 @@ public class XPathPathExpr extends XPathExpression {
             if (step.predicates.length > 0) {
                 List<XPathExpression> v = new ArrayList<XPathExpression>(step.predicates.length);
                 Collections.addAll(v, step.predicates);
+                //int level = ref.getRefLevel() > 0 ? i - ref.getRefLevel() : i; // refLevel represents parenting steps
                 ref.addPredicate(i, v);
             }
         }

--- a/src/test/java/org/javarosa/regression/IndefiniteRepeatTest.java
+++ b/src/test/java/org/javarosa/regression/IndefiniteRepeatTest.java
@@ -1,0 +1,109 @@
+package org.javarosa.regression;
+
+import org.javarosa.core.test.Scenario;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.repeat;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+public class IndefiniteRepeatTest {
+    @Test
+    public void indefiniteRepeatJrCountExpression_inSingleRepeat_addsRepeatsUntilConditionMet() throws IOException {
+        Scenario scenario = Scenario.init("indefinite repeat", html(
+            head(
+                title("Indefinite repeat"),
+                model(
+                    mainInstance(t("data id=\"indefinite-repeat\"",
+                        t("count"),
+                        t("target_count"),
+                        t("repeat",
+                            t("add_more")
+                        )
+                    )),
+                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
+                    bind("/data/target_count").type("int").calculate("if(/data/count = 0 or /data/repeat[position()=/data/count]/add_more = 'yes', /data/count + 1, /data/count)"),
+                    bind("/data/repeat/add_more").type("string")
+                )),
+            body(
+                repeat("/data/repeat", "/data/target_count",
+                    input("/data/repeat/add_more")
+                )
+            )
+        ));
+
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("no");
+        scenario.next();
+        assertThat(scenario.atTheEndOfForm(), is(true));
+    }
+
+    @Test
+    public void indefiniteRepeatJrCountExpression_inNestedRepeat_addsRepeatsUntilConditionMet() throws IOException {
+        Scenario scenario = Scenario.init("nested indefinite repeat", html(
+            head(
+                title("Indefinite repeat in nested repeat"),
+                model(
+                    mainInstance(t("data id=\"indefinite-nested-repeat\"",
+                        t("outer_repeat",
+                            t("inner_count"),
+                            t("target_count"),
+                            t("inner_repeat",
+                                t("add_more")
+                            )
+                        ))
+                    ),
+                    bind("/data/outer_repeat/inner_count").type("int").calculate("count(/data/outer_repeat/inner_repeat)"),
+                    bind("/data/outer_repeat/target_count").type("int").calculate("if(/data/outer_repeat/inner_count = 0" +
+                        "or /data/outer_repeat/inner_repeat[position() = /data/outer_repeat/inner_count]/add_more = 'yes', " +
+                        "/data/outer_repeat/inner_count + 1, /data/outer_repeat/inner_count)")
+                )),
+            body(
+                repeat("/data/outer_repeat",
+                    repeat("/data/outer_repeat/inner_repeat", "target_count",
+                        input("/data/outer_repeat/inner_repeat/add_more")
+                    )
+                )
+            )));
+
+        scenario.next();
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("no");
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("no");
+        scenario.next();
+        scenario.next();
+        assertThat(scenario.atTheEndOfForm(), is(true));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprRelativeRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprRelativeRefTest.java
@@ -1,0 +1,20 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class XPathPathExprRelativeRefTest {
+    @Test
+    public void predicateInRelativeRef_isAppliedToCorrectLevel() throws XPathSyntaxException {
+        XPathExpression predicate = XPathParseTool.parseXPath("position() = ../count");
+        XPathPathExpr parentRefWithPredicate = (XPathPathExpr) XPathParseTool.parseXPath("../repeat[position() = ../count]/choice");
+        assertThat(parentRefWithPredicate.getReference().getPredicate(0).get(0), is(predicate));
+
+        XPathPathExpr grandParentRefWithPredicate = (XPathPathExpr) XPathParseTool.parseXPath("../../repeat[position() = ../count]/choice");
+        assertThat(grandParentRefWithPredicate.getReference().getPredicate(0).get(0), is(predicate));
+    }
+}


### PR DESCRIPTION
Closes #540

The solution to #540 in #546 was not complete. In particular, the form in the issue still fails because relative paths with predicates fail to parse.

I added a narrow failing test to illustrate the issue, fixed the bug, and then also added an integration/regression test using actual forms with the indefinite repeat pattern [in the documentation](https://docs.opendatakit.org/form-logic/#repeating-as-long-as-a-condition-is-met). There's a lot going on in that example and it's the kind of thing that could be broken by changes in `jr:count`, relative references, predicates and more. Only the nested case exercises the bug fixed here but I added the single repeat case for completeness.

We've had this kind of problem a few times now where the solution to a problem comes with narrow tests and somehow we don't go back to verify the original form. QA helps with this but probably reviewers should also make sure that a test with a form is in place.

#### What has been done to verify that this works as intended?
Added the tests and verified the original form from the issue.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only approach I could come up with. See af53cd9 for an explanation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is intended only as a bug fix. It modifies the `getReference()` method which is used to parse any XPath expression in a form definition. However, there's only a change in behavior for `ref.getRefLevel() > 0` which means only if there's a relative reference. So the risk would be to relative references with predicates. Those didn't work at all before so I think that the worst that could happen is that they're not fully fixed.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.